### PR TITLE
kuma-dp: cli args

### DIFF
--- a/app/kuma-dp/cmd/run.go
+++ b/app/kuma-dp/cmd/run.go
@@ -19,14 +19,14 @@ var (
 )
 
 func newRunCmd() *cobra.Command {
+	cfg := kuma_dp.DefaultConfig()
 	cmd := &cobra.Command{
 		Use:   "run",
 		Short: "Launch Dataplane (Envoy)",
 		Long:  `Launch Dataplane (Envoy).`,
 		RunE: func(cmd *cobra.Command, _ []string) error {
-			cfg := kuma_dp.DefaultConfig()
-			err := config.Load("", &cfg) // only support configuration via environment variables
-			if err != nil {
+			// only support configuration via environment variables and args
+			if err := config.Load("", &cfg); err != nil {
 				runLog.Error(err, "unable to load configuration")
 				return err
 			}
@@ -54,5 +54,12 @@ func newRunCmd() *cobra.Command {
 			return nil
 		},
 	}
+
+	cmd.PersistentFlags().StringVar(&cfg.Dataplane.Name, "name", cfg.Dataplane.Name, "Name of the Dataplane")
+	cmd.PersistentFlags().Uint32Var(&cfg.Dataplane.AdminPort, "admin-port", cfg.Dataplane.AdminPort, "Port for Envoy Admin")
+	cmd.PersistentFlags().StringVar(&cfg.Dataplane.Mesh, "mesh", cfg.Dataplane.Mesh, "Mesh that Dataplane belongs to")
+	cmd.PersistentFlags().StringVar(&cfg.ControlPlane.BootstrapServer.URL, "cp-address", cfg.ControlPlane.BootstrapServer.URL, "Mesh that Dataplane belongs to")
+	cmd.PersistentFlags().StringVar(&cfg.DataplaneRuntime.BinaryPath, "binary-path", cfg.DataplaneRuntime.BinaryPath, "Binary path of Envoy executable")
+	cmd.PersistentFlags().StringVar(&cfg.DataplaneRuntime.ConfigDir, "config-dir", cfg.DataplaneRuntime.ConfigDir, "Directory in which Envoy config will be generated")
 	return cmd
 }

--- a/app/kuma-dp/cmd/run_test.go
+++ b/app/kuma-dp/cmd/run_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/gogo/protobuf/proto"
 
 	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/ginkgo/extensions/table"
 	. "github.com/onsi/gomega"
 
 	"github.com/Kong/kuma/pkg/core"
@@ -80,74 +81,90 @@ var _ = Describe("run", func() {
 		os.Clearenv()
 		for _, envVar := range backupEnvVars {
 			parts := strings.SplitN(envVar, "=", 2)
-			os.Setenv(parts[0], parts[1])
+			Expect(os.Setenv(parts[0], parts[1])).To(Succeed())
 		}
 	})
 
-	It("should be possible to start dataplane (Envoy) using `kuma-dp run`", func(done Done) {
-		// setup
-		pidFile := filepath.Join(configDir, "envoy-mock.pid")
+	type testCase struct {
+		envVars map[string]string
+		args    []string
+	}
+	DescribeTable("should be possible to start dataplane (Envoy) using `kuma-dp run`",
+		func(given testCase) {
+			// setup
+			pidFile := filepath.Join(configDir, "envoy-mock.pid")
 
-		// and
-		env := map[string]string{
-			"KUMA_CONTROL_PLANE_BOOTSTRAP_SERVER_URL": "http://localhost:1234",
-			"KUMA_DATAPLANE_NAME":                     "example",
-			"KUMA_DATAPLANE_ADMIN_PORT":               "2345",
-			"KUMA_DATAPLANE_RUNTIME_BINARY_PATH":      filepath.Join("testdata", "envoy-mock.sleep.sh"),
-			"KUMA_DATAPLANE_RUNTIME_CONFIG_DIR":       configDir,
-			"ENVOY_MOCK_PID_FILE":                     pidFile,
-		}
-		for key, value := range env {
-			os.Setenv(key, value)
-		}
-
-		// given
-		cmd := newRootCmd()
-		cmd.SetArgs([]string{"run"})
-		cmd.SetOut(&bytes.Buffer{})
-		cmd.SetErr(&bytes.Buffer{})
-
-		// when
-		By("starting the dataplane manager")
-		errCh := make(chan error)
-		go func() {
-			defer close(errCh)
-			errCh <- cmd.Execute()
-		}()
-
-		// then
-		var pid int64
-		By("waiting for dataplane (Envoy) to get started")
-		Eventually(func() bool {
-			data, err := ioutil.ReadFile(pidFile)
-			if err != nil {
-				return false
+			// and
+			env := given.envVars
+			env["KUMA_DATAPLANE_RUNTIME_CONFIG_DIR"] = configDir
+			env["ENVOY_MOCK_PID_FILE"] = pidFile
+			for key, value := range env {
+				Expect(os.Setenv(key, value)).To(Succeed())
 			}
-			pid, err = strconv.ParseInt(strings.TrimSpace(string(data)), 10, 32)
-			return err == nil
-		}, "5s", "100ms").Should(BeTrue())
-		// and
-		Expect(pid).ToNot(BeZero())
 
-		// when
-		By("signalling the dataplane manager to stop")
-		close(stopCh)
+			// given
+			cmd := newRootCmd()
+			cmd.SetArgs(append([]string{"run"}, given.args...))
+			cmd.SetOut(&bytes.Buffer{})
+			cmd.SetErr(&bytes.Buffer{})
 
-		// then
-		select {
-		case err := <-errCh:
-			Expect(err).ToNot(HaveOccurred())
-		}
+			// when
+			By("starting the dataplane manager")
+			errCh := make(chan error)
+			go func() {
+				defer close(errCh)
+				errCh <- cmd.Execute()
+			}()
 
-		By("waiting for dataplane (Envoy) to get stopped")
-		Eventually(func() bool {
-			// send sig 0 to check whether Envoy process still exists
-			err := syscall.Kill(int(pid), syscall.Signal(0))
-			// we expect Envoy process to get killed by now
-			return err != nil
-		}, "5s", "100ms").Should(BeTrue())
+			// then
+			var pid int64
+			By("waiting for dataplane (Envoy) to get started")
+			Eventually(func() bool {
+				data, err := ioutil.ReadFile(pidFile)
+				if err != nil {
+					return false
+				}
+				pid, err = strconv.ParseInt(strings.TrimSpace(string(data)), 10, 32)
+				return err == nil
+			}, "5s", "100ms").Should(BeTrue())
+			// and
+			Expect(pid).ToNot(BeZero())
 
-		// complete
-		close(done)
-	}, 10)
+			// when
+			By("signalling the dataplane manager to stop")
+			close(stopCh)
+
+			// then
+			select {
+			case err := <-errCh:
+				Expect(err).ToNot(HaveOccurred())
+			}
+
+			By("waiting for dataplane (Envoy) to get stopped")
+			Eventually(func() bool {
+				// send sig 0 to check whether Envoy process still exists
+				err := syscall.Kill(int(pid), syscall.Signal(0))
+				// we expect Envoy process to get killed by now
+				return err != nil
+			}, "5s", "100ms").Should(BeTrue())
+		},
+		Entry("can be launched with env vars", testCase{
+			envVars: map[string]string{
+				"KUMA_CONTROL_PLANE_BOOTSTRAP_SERVER_URL": "http://localhost:1234",
+				"KUMA_DATAPLANE_NAME":                     "example",
+				"KUMA_DATAPLANE_ADMIN_PORT":               "2345",
+				"KUMA_DATAPLANE_RUNTIME_BINARY_PATH":      filepath.Join("testdata", "envoy-mock.sleep.sh"),
+			},
+			args: []string{},
+		}),
+		Entry("can be launched with args", testCase{
+			envVars: map[string]string{},
+			args: []string{
+				"--cp-address", "http://localhost:1234",
+				"--name", "example",
+				"--admin-port", "2345",
+				"--binary-path", filepath.Join("testdata", "envoy-mock.sleep.sh"),
+			},
+		}),
+	)
 })


### PR DESCRIPTION
The simplest solution would be to fill Config struct before passing to Load, but we want args to take precedence over env vars, therefore this need to be done after loading env vars.

Maybe we need to revisit https://github.com/spf13/viper at some point, but I remember I had issues with it.