### PR TITLE
kumactl install: use Docker images of the same version as kumactl itself

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -75,7 +75,7 @@ jobs:
         name: "Run code generators (go generate, protoc, ...) and code checks (go fmt, go vet, ...)"
         command: |
           export PATH=$HOME/go/bin:$PATH
-          make check
+          make check BUILD_INFO_VERSION=latest
     - run:
         name: "Build all binaries"
         command: |
@@ -113,7 +113,7 @@ jobs:
         name: "Run code generators (go generate, protoc, ...) and code checks (go fmt, go vet, ...)"
         command: |
           export PATH=$HOME/go/bin:$PATH
-          make check
+          make check BUILD_INFO_VERSION=latest
     - run:
         name: "Build all binaries"
         command: |
@@ -173,7 +173,7 @@ jobs:
           apt update && apt install -y clang-format-10
     - run:
         name: "Run code generators (go generate, protoc, ...) and code checks (go fmt, go vet, ...)"
-        command: make check
+        command: make check BUILD_INFO_VERSION=latest
 
   api/check:
     <<: *go-defaults

--- a/Makefile
+++ b/Makefile
@@ -88,10 +88,10 @@ BINTRAY_REGISTRY ?= kong-docker-konvoy-docker.bintray.io
 BINTRAY_USERNAME ?=
 BINTRAY_API_KEY ?=
 
-KUMA_CP_DOCKER_IMAGE ?= kuma/kuma-cp:latest
-KUMA_DP_DOCKER_IMAGE ?= kuma/kuma-dp:latest
-KUMACTL_DOCKER_IMAGE ?= kuma/kumactl:latest
-KUMA_INJECTOR_DOCKER_IMAGE ?= kuma/kuma-injector:latest
+KUMA_CP_DOCKER_IMAGE ?= kuma/kuma-cp:$(BUILD_INFO_VERSION)
+KUMA_DP_DOCKER_IMAGE ?= kuma/kuma-dp:$(BUILD_INFO_VERSION)
+KUMACTL_DOCKER_IMAGE ?= kuma/kumactl:$(BUILD_INFO_VERSION)
+KUMA_INJECTOR_DOCKER_IMAGE ?= kuma/kuma-injector:$(BUILD_INFO_VERSION)
 
 PROTOC_VERSION := 3.6.1
 PROTOC_PGV_VERSION := v0.1.0
@@ -495,7 +495,7 @@ build/example/minikube: ## Minikube: build demo setup
 	eval $$(minikube docker-env) && $(MAKE) images
 
 deploy/example/minikube: image/kumactl ## Minikube: deploy demo setup
-	docker run --rm kuma/kumactl kumactl install control-plane | kubectl apply -f -
+	docker run --rm $(KUMACTL_DOCKER_IMAGE) kumactl install control-plane | kubectl apply -f -
 	kubectl wait --timeout=60s --for=condition=Available -n kuma-system deployment/kuma-injector
 	kubectl wait --timeout=60s --for=condition=Ready -n kuma-system pods -l app=kuma-injector
 	kubectl apply -f examples/minikube/kuma-demo/

--- a/app/kumactl/cmd/install/install_control_plane.go
+++ b/app/kumactl/cmd/install/install_control_plane.go
@@ -15,6 +15,7 @@ import (
 	"github.com/Kong/kuma/app/kumactl/pkg/install/k8s"
 	controlplane "github.com/Kong/kuma/app/kumactl/pkg/install/k8s/control-plane"
 	"github.com/Kong/kuma/pkg/tls"
+	kuma_version "github.com/Kong/kuma/pkg/version"
 )
 
 var (
@@ -42,7 +43,7 @@ func newInstallControlPlaneCmd(pctx *kumactl_cmd.RootContext) *cobra.Command {
 	}{
 		Namespace:               "kuma-system",
 		ImagePullPolicy:         "IfNotPresent",
-		ControlPlaneVersion:     "latest",
+		ControlPlaneVersion:     kuma_version.Build.Version,
 		ControlPlaneImage:       "kuma/kuma-cp",
 		ControlPlaneServiceName: "kuma-control-plane",
 		InjectorImage:           "kuma/kuma-injector",

--- a/app/kumactl/cmd/install/install_control_plane_test.go
+++ b/app/kumactl/cmd/install/install_control_plane_test.go
@@ -14,12 +14,12 @@ import (
 
 	"github.com/Kong/kuma/app/kumactl/pkg/install/data"
 	"github.com/Kong/kuma/pkg/tls"
+	kuma_version "github.com/Kong/kuma/pkg/version"
 )
 
 var _ = Describe("kumactl install control-plane", func() {
 
 	var backupNewSelfSignedCert func(string, ...string) (tls.KeyPair, error)
-
 	BeforeEach(func() {
 		backupNewSelfSignedCert = install.NewSelfSignedCert
 	})
@@ -33,6 +33,23 @@ var _ = Describe("kumactl install control-plane", func() {
 				CertPEM: []byte("CERT"),
 				KeyPEM:  []byte("KEY"),
 			}, nil
+		}
+	})
+
+	var backupBuildInfo kuma_version.BuildInfo
+	BeforeEach(func() {
+		backupBuildInfo = kuma_version.Build
+	})
+	AfterEach(func() {
+		kuma_version.Build = backupBuildInfo
+	})
+
+	BeforeEach(func() {
+		kuma_version.Build = kuma_version.BuildInfo{
+			Version:   "0.0.1",
+			GitTag:    "v0.0.1",
+			GitCommit: "91ce236824a9d875601679aa80c63783fb0e8725",
+			BuildDate: "2019-08-07T11:26:06Z",
 		}
 	})
 

--- a/app/kumactl/cmd/install/testdata/install-control-plane.defaults.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-control-plane.defaults.golden.yaml
@@ -2178,7 +2178,7 @@ spec:
     spec:
       containers:
       - name: kuma-injector
-        image: kuma/kuma-injector:latest
+        image: kuma/kuma-injector:0.0.1
         imagePullPolicy: IfNotPresent
         env:
         - name: KUMA_INJECTOR_WEBHOOK_SERVER_PORT
@@ -2190,7 +2190,7 @@ spec:
         - name: KUMA_INJECTOR_CONTROL_PLANE_API_SERVER_URL
           value: http://kuma-control-plane.kuma-system:5681
         - name: KUMA_INJECTOR_SIDECAR_CONTAINER_IMAGE
-          value: kuma/kuma-dp:latest
+          value: kuma/kuma-dp:0.0.1
         - name: KUMA_INJECTOR_INIT_CONTAINER_IMAGE
           value: docker.io/istio/proxy_init:1.1.2
         args:
@@ -2244,7 +2244,7 @@ spec:
       serviceAccountName: kuma-control-plane
       containers:
       - name: control-plane
-        image: kuma/kuma-cp:latest
+        image: kuma/kuma-cp:0.0.1
         imagePullPolicy: IfNotPresent
         env:
         - name: KUMA_ENVIRONMENT


### PR DESCRIPTION
changes:
* be default, `kumactl install` should use the same version of Docker images as `kumactl` itself