### PR TITLE
kuma-dp: turn off Envoy Admin interface by default

### DIFF
--- a/app/kuma-injector/pkg/injector/injector.go
+++ b/app/kuma-injector/pkg/injector/injector.go
@@ -100,6 +100,10 @@ func (i *KumaInjector) NewSidecarContainer(pod *kube_core.Pod) kube_core.Contain
 				// that is why we have to use a runtime reference to POD_NAME instead
 				Value: "$(POD_NAME).$(POD_NAMESPACE)", // variable references get expanded by Kubernetes
 			},
+			{
+				Name:  "KUMA_DATAPLANE_ADMIN_PORT",
+				Value: fmt.Sprintf("%d", i.cfg.SidecarContainer.AdminPort),
+			},
 		},
 		SecurityContext: &kube_core.SecurityContext{
 			RunAsUser:  &i.cfg.SidecarContainer.UID,

--- a/app/kuma-injector/pkg/injector/testdata/inject.01.golden.yaml
+++ b/app/kuma-injector/pkg/injector/testdata/inject.01.golden.yaml
@@ -44,6 +44,8 @@ spec:
       value: default
     - name: KUMA_DATAPLANE_NAME
       value: $(POD_NAME).$(POD_NAMESPACE)
+    - name: KUMA_DATAPLANE_ADMIN_PORT
+      value: "9901"
     image: kuma/kuma-sidecar:latest
     imagePullPolicy: IfNotPresent
     livenessProbe:

--- a/app/kuma-injector/pkg/injector/testdata/inject.02.golden.yaml
+++ b/app/kuma-injector/pkg/injector/testdata/inject.02.golden.yaml
@@ -45,6 +45,8 @@ spec:
       value: default
     - name: KUMA_DATAPLANE_NAME
       value: $(POD_NAME).$(POD_NAMESPACE)
+    - name: KUMA_DATAPLANE_ADMIN_PORT
+      value: "9901"
     image: kuma/kuma-sidecar:latest
     imagePullPolicy: IfNotPresent
     livenessProbe:

--- a/app/kuma-injector/pkg/injector/testdata/inject.03.golden.yaml
+++ b/app/kuma-injector/pkg/injector/testdata/inject.03.golden.yaml
@@ -104,6 +104,8 @@ spec:
       value: default
     - name: KUMA_DATAPLANE_NAME
       value: $(POD_NAME).$(POD_NAMESPACE)
+    - name: KUMA_DATAPLANE_ADMIN_PORT
+      value: "9901"
     image: kuma/kuma-sidecar:latest
     imagePullPolicy: IfNotPresent
     livenessProbe:

--- a/app/kuma-injector/pkg/injector/testdata/inject.04.golden.yaml
+++ b/app/kuma-injector/pkg/injector/testdata/inject.04.golden.yaml
@@ -44,6 +44,8 @@ spec:
       value: pilot
     - name: KUMA_DATAPLANE_NAME
       value: $(POD_NAME).$(POD_NAMESPACE)
+    - name: KUMA_DATAPLANE_ADMIN_PORT
+      value: "9901"
     image: kuma/kuma-sidecar:latest
     imagePullPolicy: IfNotPresent
     livenessProbe:

--- a/pkg/config/app/kuma-cp/kuma-cp.defaults.yaml
+++ b/pkg/config/app/kuma-cp/kuma-cp.defaults.yaml
@@ -28,7 +28,7 @@ bootstrapServer:
   # Parameters of bootstrap configuration
   params:
     # Port of Envoy Admin
-    adminPort: 9901 # ENV: KUMA_BOOTSTRAP_SERVER_PARAMS_ADMIN_PORT
+    adminPort: 0 # ENV: KUMA_BOOTSTRAP_SERVER_PARAMS_ADMIN_PORT
     # Host of XDS Server
     xdsHost: localhost # ENV: KUMA_BOOTSTRAP_SERVER_PARAMS_XDS_HOST
     # Port of XDS Server

--- a/pkg/config/app/kuma-dp/config.go
+++ b/pkg/config/app/kuma-dp/config.go
@@ -19,7 +19,7 @@ func DefaultConfig() Config {
 		Dataplane: Dataplane{
 			Mesh:      "default",
 			Name:      "", // Dataplane name must be set explicitly
-			AdminPort: 9901,
+			AdminPort: 0,  // by default, turn off Admin interface of Envoy
 		},
 		DataplaneRuntime: DataplaneRuntime{
 			BinaryPath: "envoy",

--- a/pkg/config/app/kuma-dp/testdata/default-config.golden.yaml
+++ b/pkg/config/app/kuma-dp/testdata/default-config.golden.yaml
@@ -1,6 +1,5 @@
 dataplane:
   mesh: default
-  adminPort: 9901
 dataplaneRuntime:
   binaryPath: envoy
   configDir: /tmp/kuma.io/envoy

--- a/pkg/config/xds/config.go
+++ b/pkg/config/xds/config.go
@@ -96,7 +96,7 @@ func (b *BootstrapParamsConfig) Validate() error {
 
 func DefaultBootstrapParamsConfig() *BootstrapParamsConfig {
 	return &BootstrapParamsConfig{
-		AdminPort: 9901,
+		AdminPort: 0, // by default, turn off Admin interface of Envoy
 		XdsHost:   "localhost",
 		XdsPort:   5678,
 	}

--- a/pkg/xds/bootstrap/template.go
+++ b/pkg/xds/bootstrap/template.go
@@ -13,6 +13,7 @@ node:
   id: {{.Id}}
   cluster: {{.Service}}
 
+{{if .AdminPort }}
 admin:
   access_log_path: /dev/null
   address:
@@ -20,6 +21,7 @@ admin:
       protocol: TCP
       address: 127.0.0.1
       port_value: {{ .AdminPort }}
+{{ end }}
 
 dynamic_resources:
   lds_config: {ads: {}}

--- a/pkg/xds/bootstrap/testdata/bootstrap.golden.yaml
+++ b/pkg/xds/bootstrap/testdata/bootstrap.golden.yaml
@@ -1,9 +1,3 @@
-admin:
-  accessLogPath: /dev/null
-  address:
-    socketAddress:
-      address: 127.0.0.1
-      portValue: 9901
 dynamicResources:
   adsConfig:
     apiType: GRPC


### PR DESCRIPTION
changes:
* to avoid constantly running into `port already in use` problem, turn off Envoy Admin interface by default