### PR TITLE
control-plane: xds - replace localhost with ip address

### DIFF
--- a/pkg/config/app/kuma-cp/kuma-cp.defaults.yaml
+++ b/pkg/config/app/kuma-cp/kuma-cp.defaults.yaml
@@ -30,7 +30,7 @@ bootstrapServer:
     # Port of Envoy Admin
     adminPort: 0 # ENV: KUMA_BOOTSTRAP_SERVER_PARAMS_ADMIN_PORT
     # Host of XDS Server
-    xdsHost: localhost # ENV: KUMA_BOOTSTRAP_SERVER_PARAMS_XDS_HOST
+    xdsHost: 127.0.0.1 # ENV: KUMA_BOOTSTRAP_SERVER_PARAMS_XDS_HOST
     # Port of XDS Server
     xdsPort: 5678 # ENV: KUMA_BOOTSTRAP_SERVER_PARAMS_XDS_PORT
 
@@ -69,4 +69,4 @@ defaults:
 # Reports configuration
 reports:
   # If true then usage stats will be reported
-  enabled: true
+  enabled: true # ENV: KUMA_REPORTS_ENABLED

--- a/pkg/config/xds/config.go
+++ b/pkg/config/xds/config.go
@@ -97,7 +97,7 @@ func (b *BootstrapParamsConfig) Validate() error {
 func DefaultBootstrapParamsConfig() *BootstrapParamsConfig {
 	return &BootstrapParamsConfig{
 		AdminPort: 0, // by default, turn off Admin interface of Envoy
-		XdsHost:   "localhost",
+		XdsHost:   "127.0.0.1",
 		XdsPort:   5678,
 	}
 }

--- a/pkg/xds/bootstrap/testdata/bootstrap.golden.yaml
+++ b/pkg/xds/bootstrap/testdata/bootstrap.golden.yaml
@@ -22,7 +22,7 @@ staticResources:
               - endpoint:
                   address:
                     socketAddress:
-                      address: localhost
+                      address: 127.0.0.1
                       portValue: 5678
       name: ads_cluster
       type: STRICT_DNS

--- a/pkg/xds/bootstrap/testdata/bootstrap.overridden.golden.yaml
+++ b/pkg/xds/bootstrap/testdata/bootstrap.overridden.golden.yaml
@@ -28,7 +28,7 @@ staticResources:
               - endpoint:
                   address:
                     socketAddress:
-                      address: localhost
+                      address: 127.0.0.1
                       portValue: 5678
       name: ads_cluster
       type: STRICT_DNS


### PR DESCRIPTION
### Summary

Replace xDS default localhost with IP address so it will work on centos by default.