### PR TITLE
kuma-dp: disable Envoy hot restart in order to support multiple Envoy instances on the same Linux machine

### DIFF
--- a/app/kuma-dp/pkg/dataplane/envoy/envoy_test.go
+++ b/app/kuma-dp/pkg/dataplane/envoy/envoy_test.go
@@ -115,7 +115,7 @@ var _ = Describe("Envoy", func() {
 			// then
 			Expect(err).ToNot(HaveOccurred())
 			// and
-			Expect(strings.TrimSpace(buf.String())).To(Equal(fmt.Sprintf("-c %s", expectedConfigFile)))
+			Expect(strings.TrimSpace(buf.String())).To(Equal(fmt.Sprintf("-c %s --disable-hot-restart", expectedConfigFile)))
 
 			By("verifying the contents Envoy config file")
 			// when


### PR DESCRIPTION
### Issues resolved

Fixes #254
