### PR TITLE
kuma-dp: if `--config-dir` argument is not set, automatically create a temp dir

### DIFF
--- a/app/kuma-dp/cmd/run_test.go
+++ b/app/kuma-dp/cmd/run_test.go
@@ -4,6 +4,7 @@ package cmd
 
 import (
 	"bytes"
+	"fmt"
 	"io/ioutil"
 	"os"
 	"path/filepath"
@@ -22,6 +23,8 @@ import (
 	. "github.com/onsi/gomega"
 
 	"github.com/Kong/kuma/pkg/core"
+
+	"github.com/Kong/kuma/pkg/test"
 )
 
 var _ = Describe("run", func() {
@@ -56,17 +59,17 @@ var _ = Describe("run", func() {
 		}
 	})
 
-	var configDir string
+	var tmpDir string
 
 	BeforeEach(func() {
 		var err error
-		configDir, err = ioutil.TempDir("", "")
+		tmpDir, err = ioutil.TempDir("", "")
 		Expect(err).ToNot(HaveOccurred())
 	})
 	AfterEach(func() {
-		if configDir != "" {
+		if tmpDir != "" {
 			// when
-			err := os.RemoveAll(configDir)
+			err := os.RemoveAll(tmpDir)
 			// then
 			Expect(err).ToNot(HaveOccurred())
 		}
@@ -85,19 +88,30 @@ var _ = Describe("run", func() {
 		}
 	})
 
+	var port int
+	BeforeEach(func() {
+		var err error
+		port, err = test.GetFreePort()
+		Expect(err).NotTo(HaveOccurred())
+	})
+
 	type testCase struct {
-		envVars map[string]string
-		args    []string
+		envVars      map[string]string
+		args         []string
+		expectedFile string
 	}
 	DescribeTable("should be possible to start dataplane (Envoy) using `kuma-dp run`",
-		func(given testCase) {
+		func(givenFunc func() testCase) {
+			given := givenFunc()
+
 			// setup
-			pidFile := filepath.Join(configDir, "envoy-mock.pid")
+			pidFile := filepath.Join(tmpDir, "envoy-mock.pid")
+			cmdlineFile := filepath.Join(tmpDir, "envoy-mock.cmdline")
 
 			// and
 			env := given.envVars
-			env["KUMA_DATAPLANE_RUNTIME_CONFIG_DIR"] = configDir
 			env["ENVOY_MOCK_PID_FILE"] = pidFile
+			env["ENVOY_MOCK_CMDLINE_FILE"] = cmdlineFile
 			for key, value := range env {
 				Expect(os.Setenv(key, value)).To(Succeed())
 			}
@@ -130,6 +144,22 @@ var _ = Describe("run", func() {
 			// and
 			Expect(pid).ToNot(BeZero())
 
+			By("verifying the arguments Envoy was launched with")
+			// when
+			cmdline, err := ioutil.ReadFile(cmdlineFile)
+			// then
+			Expect(err).ToNot(HaveOccurred())
+			// and
+			actualArgs := strings.Split(string(cmdline), "\n")
+			Expect(actualArgs[0]).To(Equal("-c"))
+			actualConfigFile := actualArgs[1]
+			Expect(actualConfigFile).To(BeARegularFile())
+
+			// then
+			if given.expectedFile != "" {
+				Expect(actualArgs[1]).To(Equal(given.expectedFile))
+			}
+
 			// when
 			By("signalling the dataplane manager to stop")
 			close(stopCh)
@@ -147,24 +177,68 @@ var _ = Describe("run", func() {
 				// we expect Envoy process to get killed by now
 				return err != nil
 			}, "5s", "100ms").Should(BeTrue())
+
+			By("verifying that temporary configuration dir gets removed")
+			if given.expectedFile == "" {
+				Expect(actualConfigFile).NotTo(BeAnExistingFile())
+			}
+
+			By("verifying that explicit configuration dir is not removed")
+			if given.expectedFile != "" {
+				Expect(given.expectedFile).To(BeAnExistingFile())
+			}
 		},
-		Entry("can be launched with env vars", testCase{
-			envVars: map[string]string{
-				"KUMA_CONTROL_PLANE_BOOTSTRAP_SERVER_URL": "http://localhost:1234",
-				"KUMA_DATAPLANE_NAME":                     "example",
-				"KUMA_DATAPLANE_ADMIN_PORT":               "2345",
-				"KUMA_DATAPLANE_RUNTIME_BINARY_PATH":      filepath.Join("testdata", "envoy-mock.sleep.sh"),
-			},
-			args: []string{},
+		Entry("can be launched with env vars", func() testCase {
+			return testCase{
+				envVars: map[string]string{
+					"KUMA_CONTROL_PLANE_BOOTSTRAP_SERVER_URL": "http://localhost:1234",
+					"KUMA_DATAPLANE_NAME":                     "example",
+					"KUMA_DATAPLANE_ADMIN_PORT":               fmt.Sprintf("%d", port),
+					"KUMA_DATAPLANE_RUNTIME_BINARY_PATH":      filepath.Join("testdata", "envoy-mock.sleep.sh"),
+					// Notice: KUMA_DATAPLANE_RUNTIME_CONFIG_DIR is not set in order to let `kuma-dp` to create a temporary directory
+				},
+				args:         []string{},
+				expectedFile: "",
+			}
 		}),
-		Entry("can be launched with args", testCase{
-			envVars: map[string]string{},
-			args: []string{
-				"--cp-address", "http://localhost:1234",
-				"--name", "example",
-				"--admin-port", "2345",
-				"--binary-path", filepath.Join("testdata", "envoy-mock.sleep.sh"),
-			},
+		Entry("can be launched with env vars and given config dir", func() testCase {
+			return testCase{
+				envVars: map[string]string{
+					"KUMA_CONTROL_PLANE_BOOTSTRAP_SERVER_URL": "http://localhost:1234",
+					"KUMA_DATAPLANE_NAME":                     "example",
+					"KUMA_DATAPLANE_ADMIN_PORT":               fmt.Sprintf("%d", port),
+					"KUMA_DATAPLANE_RUNTIME_BINARY_PATH":      filepath.Join("testdata", "envoy-mock.sleep.sh"),
+					"KUMA_DATAPLANE_RUNTIME_CONFIG_DIR":       tmpDir,
+				},
+				args:         []string{},
+				expectedFile: filepath.Join(tmpDir, "bootstrap.yaml"),
+			}
+		}),
+		Entry("can be launched with args", func() testCase {
+			return testCase{
+				envVars: map[string]string{},
+				args: []string{
+					"--cp-address", "http://localhost:1234",
+					"--name", "example",
+					"--admin-port", fmt.Sprintf("%d", port),
+					"--binary-path", filepath.Join("testdata", "envoy-mock.sleep.sh"),
+					// Notice: --config-dir is not set in order to let `kuma-dp` to create a temporary directory
+				},
+				expectedFile: "",
+			}
+		}),
+		Entry("can be launched with args and given config dir", func() testCase {
+			return testCase{
+				envVars: map[string]string{},
+				args: []string{
+					"--cp-address", "http://localhost:1234",
+					"--name", "example",
+					"--admin-port", fmt.Sprintf("%d", port),
+					"--binary-path", filepath.Join("testdata", "envoy-mock.sleep.sh"),
+					"--config-dir", tmpDir,
+				},
+				expectedFile: filepath.Join(tmpDir, "bootstrap.yaml"),
+			}
 		}),
 	)
 })

--- a/app/kuma-dp/cmd/testdata/envoy-mock.sleep.sh
+++ b/app/kuma-dp/cmd/testdata/envoy-mock.sleep.sh
@@ -2,4 +2,9 @@
 
 echo $$ >${ENVOY_MOCK_PID_FILE}
 
+touch ${ENVOY_MOCK_CMDLINE_FILE}
+for arg in "$@"; do
+    echo $arg >> ${ENVOY_MOCK_CMDLINE_FILE}
+done
+
 sleep 86400

--- a/pkg/config/app/kuma-dp/config.go
+++ b/pkg/config/app/kuma-dp/config.go
@@ -23,7 +23,7 @@ func DefaultConfig() Config {
 		},
 		DataplaneRuntime: DataplaneRuntime{
 			BinaryPath: "envoy",
-			ConfigDir:  "/tmp/kuma.io/envoy",
+			ConfigDir:  "", // if left empty, a temporary directory will be generated automatically
 		},
 	}
 }
@@ -111,9 +111,6 @@ var _ config.Config = &DataplaneRuntime{}
 func (d *DataplaneRuntime) Validate() (errs error) {
 	if d.BinaryPath == "" {
 		errs = multierr.Append(errs, errors.Errorf(".BinaryPath must be non-empty"))
-	}
-	if d.ConfigDir == "" {
-		errs = multierr.Append(errs, errors.Errorf(".ConfigDir must be non-empty"))
 	}
 	return
 }

--- a/pkg/config/app/kuma-dp/config_test.go
+++ b/pkg/config/app/kuma-dp/config_test.go
@@ -103,6 +103,6 @@ var _ = Describe("Config", func() {
 		err := config.Load(filepath.Join("testdata", "invalid-config.input.yaml"), &cfg)
 
 		// then
-		Expect(err).To(MatchError(`Invalid configuration: .ControlPlane is not valid: .BootstrapServer is not valid: .URL must be a valid absolute URI; .Dataplane is not valid: .Mesh must be non-empty; .Name must be non-empty; .AdminPort must be in the range [0, 65535]; .DataplaneRuntime is not valid: .BinaryPath must be non-empty; .ConfigDir must be non-empty`))
+		Expect(err).To(MatchError(`Invalid configuration: .ControlPlane is not valid: .BootstrapServer is not valid: .URL must be a valid absolute URI; .Dataplane is not valid: .Mesh must be non-empty; .Name must be non-empty; .AdminPort must be in the range [0, 65535]; .DataplaneRuntime is not valid: .BinaryPath must be non-empty`))
 	})
 })

--- a/pkg/config/app/kuma-dp/testdata/default-config.golden.yaml
+++ b/pkg/config/app/kuma-dp/testdata/default-config.golden.yaml
@@ -2,4 +2,3 @@ dataplane:
   mesh: default
 dataplaneRuntime:
   binaryPath: envoy
-  configDir: /tmp/kuma.io/envoy

--- a/pkg/config/app/kuma-dp/testdata/invalid-config.input.yaml
+++ b/pkg/config/app/kuma-dp/testdata/invalid-config.input.yaml
@@ -7,4 +7,3 @@ dataplane:
   adminPort: 82345
 dataplaneRuntime:
   binaryPath:
-  configDir:


### PR DESCRIPTION
### Summary

Previously, `kuma-dp` had `--config-dir` option set to `/tmp/kuma.io/envoy` by default.

If 2 `kuma-dp` instances were started on the same machine, both of them would persist generated config file at `/tmp/kuma.io/envoy/bootstrap.yaml`, overwriting each other.

### Full changelog

* the new default value for `--config-dir` is empty
* in that case `kuma-dp` will create a temporary dir, use it to store generated Envoy config, and remove that directory on exit
