### PR TITLE
fix(kuma-cp) rename embded to builtin in sample yamls

### DIFF
--- a/app/kumactl/cmd/apply/testdata/apply-mesh-template.yaml
+++ b/app/kumactl/cmd/apply/testdata/apply-mesh-template.yaml
@@ -2,4 +2,4 @@ name: {{name}}
 type: {{type}}
 mtls:
   ca:
-    embedded:
+    builtin:

--- a/app/kumactl/cmd/apply/testdata/apply-mesh.yaml
+++ b/app/kumactl/cmd/apply/testdata/apply-mesh.yaml
@@ -2,4 +2,4 @@ name: sample
 type: Mesh
 mtls:
   ca:
-    embedded:
+    builtin:

--- a/dev/examples/k8s/meshes/pilot.yaml
+++ b/dev/examples/k8s/meshes/pilot.yaml
@@ -6,7 +6,4 @@ metadata:
 spec:
   mtls:
     ca:
-      embedded: {}
-  tracing:
-    zipkin:
-      address: zipkin:9411
+      builtin: {}

--- a/pkg/plugins/resources/k8s/native/config/samples/mesh_v1alpha1_mesh.yaml
+++ b/pkg/plugins/resources/k8s/native/config/samples/mesh_v1alpha1_mesh.yaml
@@ -5,7 +5,4 @@ metadata:
 spec:
   mtls:
     ca:
-      embedded: {}
-  tracing:
-    zipkin:
-      address: zipkin:9411
+      builtin: {}


### PR DESCRIPTION
### Summary

Rename embedded to builtin in sample YAMLs. At some point we've changed the name from embedded to builtin, but apparently we missed some example YAMLs.

### Full changelog

* Fix example YAMLs

### Issues resolved

Fix #262
