### PR TITLE
pkg/xds/generator: fix dropped errors in tests

### DIFF
--- a/pkg/xds/generator/inbound_proxy_generator_test.go
+++ b/pkg/xds/generator/inbound_proxy_generator_test.go
@@ -95,6 +95,7 @@ var _ = Describe("InboundProxyGenerator", func() {
 			// then
 			resp := generator.ResourceList(rs).ToDeltaDiscoveryResponse()
 			actual, err := util_proto.ToYAML(resp)
+			Expect(err).ToNot(HaveOccurred())
 
 			expected, err := ioutil.ReadFile(filepath.Join("testdata", "inbound-proxy", given.envoyConfigFile))
 			Expect(err).ToNot(HaveOccurred())

--- a/pkg/xds/generator/outbound_proxy_generator_test.go
+++ b/pkg/xds/generator/outbound_proxy_generator_test.go
@@ -83,6 +83,7 @@ var _ = Describe("OutboundProxyGenerator", func() {
 			// then
 			resp := generator.ResourceList(rs).ToDeltaDiscoveryResponse()
 			actual, err := util_proto.ToYAML(resp)
+			Expect(err).ToNot(HaveOccurred())
 
 			expected, err := ioutil.ReadFile(filepath.Join("testdata", "outbound-proxy", given.expected))
 			Expect(err).ToNot(HaveOccurred())

--- a/pkg/xds/generator/proxy_template_profile_source_test.go
+++ b/pkg/xds/generator/proxy_template_profile_source_test.go
@@ -101,6 +101,7 @@ var _ = Describe("ProxyTemplateProfileSource", func() {
 			// then
 			resp := generator.ResourceList(rs).ToDeltaDiscoveryResponse()
 			actual, err := util_proto.ToYAML(resp)
+			Expect(err).ToNot(HaveOccurred())
 
 			expected, err := ioutil.ReadFile(filepath.Join("testdata", "profile-source", given.envoyConfigFile))
 			Expect(err).ToNot(HaveOccurred())

--- a/pkg/xds/generator/proxy_template_test.go
+++ b/pkg/xds/generator/proxy_template_test.go
@@ -201,6 +201,7 @@ var _ = Describe("TemplateProxyGenerator", func() {
 				// then
 				resp := generator.ResourceList(rs).ToDeltaDiscoveryResponse()
 				actual, err := util_proto.ToYAML(resp)
+				Expect(err).ToNot(HaveOccurred())
 
 				expected, err := ioutil.ReadFile(filepath.Join("testdata", "template-proxy", given.envoyConfigFile))
 				Expect(err).ToNot(HaveOccurred())


### PR DESCRIPTION
This PR fixes dropped errors in `pkg/xds/generator` tests. These errors would have broken the subsequent test statements, but their origins would have been obscured.