### PR TITLE
feat(kumacp) traffic logging matching

### DIFF
--- a/api/mesh/v1alpha1/dataplane_helpers.go
+++ b/api/mesh/v1alpha1/dataplane_helpers.go
@@ -160,6 +160,11 @@ func (d *Dataplane_Networking_Inbound) MatchTags(selector TagSelector) bool {
 	return selector.Matches(d.Tags)
 }
 
+func (d *Dataplane_Networking_Outbound) MatchTags(selector TagSelector) bool {
+	service := selector[ServiceTag]
+	return service == MatchAllTag || service == d.Service
+}
+
 const MatchAllTag = "*"
 
 type TagSelector map[string]string

--- a/api/mesh/v1alpha1/dataplane_helpers_test.go
+++ b/api/mesh/v1alpha1/dataplane_helpers_test.go
@@ -306,6 +306,49 @@ var _ = Describe("Dataplane_Networking", func() {
 	})
 })
 
+var _ = Describe("Dataplane_Networking_Outbound", func() {
+	type testCase struct {
+		serviceTag string
+		selector TagSelector
+		expectedMatch bool
+	}
+	DescribeTable("MatchTags()", func(given testCase) {
+			//given
+			outbound := Dataplane_Networking_Outbound{
+				Interface: "sdf",
+				Service: given.serviceTag,
+			}
+
+			// when
+			matched := outbound.MatchTags(given.selector)
+
+			// then
+			Expect(matched).To(Equal(given.expectedMatch))
+		},
+		Entry("it should match *", testCase{
+			serviceTag: "backend",
+			selector: map[string]string{
+				"service": "*",
+			},
+			expectedMatch: true,
+		}),
+		Entry("it should match service", testCase{
+			serviceTag: "backend",
+			selector: map[string]string{
+				"service": "backend",
+			},
+			expectedMatch: true,
+		}),
+		Entry("it shouldn't match tag other than service", testCase{
+			serviceTag: "backend",
+			selector: map[string]string{
+				"version": "1.0",
+			},
+			expectedMatch: false,
+		}),
+	)
+})
+
 var _ = Describe("Dataplane", func() {
 	d := Dataplane{
 		Networking: &Dataplane_Networking{

--- a/api/mesh/v1alpha1/mesh.pb.go
+++ b/api/mesh/v1alpha1/mesh.pb.go
@@ -488,10 +488,14 @@ func (m *Tracing_Zipkin) GetAddress() string {
 }
 
 type Logging struct {
-	AccessLogs           *Logging_AccessLogs `protobuf:"bytes,1,opt,name=accessLogs,proto3" json:"accessLogs,omitempty"`
-	XXX_NoUnkeyedLiteral struct{}            `json:"-"`
-	XXX_unrecognized     []byte              `json:"-"`
-	XXX_sizecache        int32               `json:"-"`
+	AccessLogs *Logging_AccessLogs `protobuf:"bytes,1,opt,name=accessLogs,proto3" json:"accessLogs,omitempty"`
+	// Name of the default backend
+	DefaultBackend string `protobuf:"bytes,2,opt,name=defaultBackend,proto3" json:"defaultBackend,omitempty"`
+	// List of available logging backends
+	Backends             []*LoggingBackend `protobuf:"bytes,3,rep,name=backends,proto3" json:"backends,omitempty"`
+	XXX_NoUnkeyedLiteral struct{}          `json:"-"`
+	XXX_unrecognized     []byte            `json:"-"`
+	XXX_sizecache        int32             `json:"-"`
 }
 
 func (m *Logging) Reset()         { *m = Logging{} }
@@ -530,6 +534,20 @@ var xxx_messageInfo_Logging proto.InternalMessageInfo
 func (m *Logging) GetAccessLogs() *Logging_AccessLogs {
 	if m != nil {
 		return m.AccessLogs
+	}
+	return nil
+}
+
+func (m *Logging) GetDefaultBackend() string {
+	if m != nil {
+		return m.DefaultBackend
+	}
+	return ""
+}
+
+func (m *Logging) GetBackends() []*LoggingBackend {
+	if m != nil {
+		return m.Backends
 	}
 	return nil
 }
@@ -589,6 +607,198 @@ func (m *Logging_AccessLogs) GetFilePath() string {
 	return ""
 }
 
+// LoggingBackend defines logging backend available to mesh. Backends can be used in TrafficLog rules.
+type LoggingBackend struct {
+	// Name of the backend, can be then used in Mesh.logging.defaultBackend or in
+	// TrafficLogging
+	Name string `protobuf:"bytes,1,opt,name=name,proto3" json:"name,omitempty"`
+	// Format of access logs. Placehodlers available on
+	// https://www.envoyproxy.io/docs/envoy/latest/configuration/observability/access_log
+	Format string `protobuf:"bytes,2,opt,name=format,proto3" json:"format,omitempty"`
+	// Types that are valid to be assigned to Type:
+	//	*LoggingBackend_File_
+	Type                 isLoggingBackend_Type `protobuf_oneof:"type"`
+	XXX_NoUnkeyedLiteral struct{}              `json:"-"`
+	XXX_unrecognized     []byte                `json:"-"`
+	XXX_sizecache        int32                 `json:"-"`
+}
+
+func (m *LoggingBackend) Reset()         { *m = LoggingBackend{} }
+func (m *LoggingBackend) String() string { return proto.CompactTextString(m) }
+func (*LoggingBackend) ProtoMessage()    {}
+func (*LoggingBackend) Descriptor() ([]byte, []int) {
+	return fileDescriptor_ae9b3cd8c92bbf6a, []int{4}
+}
+func (m *LoggingBackend) XXX_Unmarshal(b []byte) error {
+	return m.Unmarshal(b)
+}
+func (m *LoggingBackend) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
+	if deterministic {
+		return xxx_messageInfo_LoggingBackend.Marshal(b, m, deterministic)
+	} else {
+		b = b[:cap(b)]
+		n, err := m.MarshalTo(b)
+		if err != nil {
+			return nil, err
+		}
+		return b[:n], nil
+	}
+}
+func (m *LoggingBackend) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_LoggingBackend.Merge(m, src)
+}
+func (m *LoggingBackend) XXX_Size() int {
+	return m.Size()
+}
+func (m *LoggingBackend) XXX_DiscardUnknown() {
+	xxx_messageInfo_LoggingBackend.DiscardUnknown(m)
+}
+
+var xxx_messageInfo_LoggingBackend proto.InternalMessageInfo
+
+type isLoggingBackend_Type interface {
+	isLoggingBackend_Type()
+	MarshalTo([]byte) (int, error)
+	Size() int
+}
+
+type LoggingBackend_File_ struct {
+	File *LoggingBackend_File `protobuf:"bytes,3,opt,name=file,proto3,oneof"`
+}
+
+func (*LoggingBackend_File_) isLoggingBackend_Type() {}
+
+func (m *LoggingBackend) GetType() isLoggingBackend_Type {
+	if m != nil {
+		return m.Type
+	}
+	return nil
+}
+
+func (m *LoggingBackend) GetName() string {
+	if m != nil {
+		return m.Name
+	}
+	return ""
+}
+
+func (m *LoggingBackend) GetFormat() string {
+	if m != nil {
+		return m.Format
+	}
+	return ""
+}
+
+func (m *LoggingBackend) GetFile() *LoggingBackend_File {
+	if x, ok := m.GetType().(*LoggingBackend_File_); ok {
+		return x.File
+	}
+	return nil
+}
+
+// XXX_OneofFuncs is for the internal use of the proto package.
+func (*LoggingBackend) XXX_OneofFuncs() (func(msg proto.Message, b *proto.Buffer) error, func(msg proto.Message, tag, wire int, b *proto.Buffer) (bool, error), func(msg proto.Message) (n int), []interface{}) {
+	return _LoggingBackend_OneofMarshaler, _LoggingBackend_OneofUnmarshaler, _LoggingBackend_OneofSizer, []interface{}{
+		(*LoggingBackend_File_)(nil),
+	}
+}
+
+func _LoggingBackend_OneofMarshaler(msg proto.Message, b *proto.Buffer) error {
+	m := msg.(*LoggingBackend)
+	// type
+	switch x := m.Type.(type) {
+	case *LoggingBackend_File_:
+		_ = b.EncodeVarint(3<<3 | proto.WireBytes)
+		if err := b.EncodeMessage(x.File); err != nil {
+			return err
+		}
+	case nil:
+	default:
+		return fmt.Errorf("LoggingBackend.Type has unexpected type %T", x)
+	}
+	return nil
+}
+
+func _LoggingBackend_OneofUnmarshaler(msg proto.Message, tag, wire int, b *proto.Buffer) (bool, error) {
+	m := msg.(*LoggingBackend)
+	switch tag {
+	case 3: // type.file
+		if wire != proto.WireBytes {
+			return true, proto.ErrInternalBadWireType
+		}
+		msg := new(LoggingBackend_File)
+		err := b.DecodeMessage(msg)
+		m.Type = &LoggingBackend_File_{msg}
+		return true, err
+	default:
+		return false, nil
+	}
+}
+
+func _LoggingBackend_OneofSizer(msg proto.Message) (n int) {
+	m := msg.(*LoggingBackend)
+	// type
+	switch x := m.Type.(type) {
+	case *LoggingBackend_File_:
+		s := proto.Size(x.File)
+		n += 1 // tag and wire
+		n += proto.SizeVarint(uint64(s))
+		n += s
+	case nil:
+	default:
+		panic(fmt.Sprintf("proto: unexpected type %T in oneof", x))
+	}
+	return n
+}
+
+// Simple logging to file
+type LoggingBackend_File struct {
+	Path                 string   `protobuf:"bytes,1,opt,name=path,proto3" json:"path,omitempty"`
+	XXX_NoUnkeyedLiteral struct{} `json:"-"`
+	XXX_unrecognized     []byte   `json:"-"`
+	XXX_sizecache        int32    `json:"-"`
+}
+
+func (m *LoggingBackend_File) Reset()         { *m = LoggingBackend_File{} }
+func (m *LoggingBackend_File) String() string { return proto.CompactTextString(m) }
+func (*LoggingBackend_File) ProtoMessage()    {}
+func (*LoggingBackend_File) Descriptor() ([]byte, []int) {
+	return fileDescriptor_ae9b3cd8c92bbf6a, []int{4, 0}
+}
+func (m *LoggingBackend_File) XXX_Unmarshal(b []byte) error {
+	return m.Unmarshal(b)
+}
+func (m *LoggingBackend_File) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
+	if deterministic {
+		return xxx_messageInfo_LoggingBackend_File.Marshal(b, m, deterministic)
+	} else {
+		b = b[:cap(b)]
+		n, err := m.MarshalTo(b)
+		if err != nil {
+			return nil, err
+		}
+		return b[:n], nil
+	}
+}
+func (m *LoggingBackend_File) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_LoggingBackend_File.Merge(m, src)
+}
+func (m *LoggingBackend_File) XXX_Size() int {
+	return m.Size()
+}
+func (m *LoggingBackend_File) XXX_DiscardUnknown() {
+	xxx_messageInfo_LoggingBackend_File.DiscardUnknown(m)
+}
+
+var xxx_messageInfo_LoggingBackend_File proto.InternalMessageInfo
+
+func (m *LoggingBackend_File) GetPath() string {
+	if m != nil {
+		return m.Path
+	}
+	return ""
+}
+
 func init() {
 	proto.RegisterType((*Mesh)(nil), "kuma.mesh.v1alpha1.Mesh")
 	proto.RegisterType((*Mesh_Mtls)(nil), "kuma.mesh.v1alpha1.Mesh.Mtls")
@@ -598,35 +808,44 @@ func init() {
 	proto.RegisterType((*Tracing_Zipkin)(nil), "kuma.mesh.v1alpha1.Tracing.Zipkin")
 	proto.RegisterType((*Logging)(nil), "kuma.mesh.v1alpha1.Logging")
 	proto.RegisterType((*Logging_AccessLogs)(nil), "kuma.mesh.v1alpha1.Logging.AccessLogs")
+	proto.RegisterType((*LoggingBackend)(nil), "kuma.mesh.v1alpha1.LoggingBackend")
+	proto.RegisterType((*LoggingBackend_File)(nil), "kuma.mesh.v1alpha1.LoggingBackend.File")
 }
 
 func init() { proto.RegisterFile("mesh/v1alpha1/mesh.proto", fileDescriptor_ae9b3cd8c92bbf6a) }
 
 var fileDescriptor_ae9b3cd8c92bbf6a = []byte{
-	// 367 bytes of a gzipped FileDescriptorProto
-	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff, 0x8c, 0x92, 0x41, 0x4b, 0xc3, 0x30,
-	0x14, 0xc7, 0xd7, 0x5a, 0xda, 0xed, 0x79, 0x0b, 0x22, 0xa5, 0xe2, 0x90, 0x1e, 0x64, 0xa7, 0xcc,
-	0x29, 0x82, 0x07, 0x2f, 0xab, 0x20, 0x3b, 0x6c, 0x20, 0xc1, 0xd3, 0x6e, 0x59, 0x97, 0xb5, 0x61,
-	0xdd, 0x5a, 0x9a, 0x4c, 0x99, 0x57, 0x3f, 0x83, 0xdf, 0xc9, 0xa3, 0x1f, 0x41, 0xf6, 0x49, 0xa4,
-	0x69, 0x53, 0x27, 0xce, 0xe1, 0xf1, 0xbd, 0xfc, 0x7e, 0xfd, 0xa7, 0xef, 0x05, 0xdc, 0x05, 0x13,
-	0x71, 0xf7, 0xa9, 0x47, 0x93, 0x2c, 0xa6, 0xbd, 0x6e, 0x51, 0xe1, 0x2c, 0x4f, 0x65, 0x8a, 0xd0,
-	0x7c, 0xb5, 0xa0, 0x58, 0x35, 0xf4, 0xb1, 0xff, 0x6a, 0x82, 0x35, 0x62, 0x22, 0x46, 0x3d, 0xb0,
-	0x16, 0x32, 0x11, 0xae, 0x71, 0x66, 0x74, 0x0e, 0x2f, 0x4f, 0xf1, 0x6f, 0x16, 0x17, 0x1c, 0x1e,
-	0xc9, 0x44, 0x10, 0x85, 0xa2, 0x6b, 0x70, 0x64, 0x4e, 0x43, 0xbe, 0x8c, 0x5c, 0x53, 0x59, 0x27,
-	0xbb, 0xac, 0xc7, 0x12, 0x21, 0x9a, 0x2d, 0xb4, 0x24, 0x8d, 0xa2, 0x42, 0x3b, 0xf8, 0x5b, 0x1b,
-	0x96, 0x08, 0xd1, 0xac, 0x37, 0x06, 0xab, 0xc8, 0x46, 0x37, 0x60, 0x86, 0xb4, 0xba, 0x66, 0x67,
-	0x97, 0x79, 0xc7, 0x72, 0xc9, 0x67, 0x3c, 0xa4, 0x92, 0xf5, 0x57, 0x32, 0x4e, 0x73, 0x2e, 0xd7,
-	0xc4, 0x0c, 0x29, 0x72, 0xc1, 0x61, 0x4b, 0x3a, 0x49, 0xd8, 0x54, 0xdd, 0xb7, 0x49, 0x74, 0xe9,
-	0x3f, 0xc3, 0xd1, 0x2e, 0x0b, 0x0d, 0xc1, 0x99, 0xac, 0x78, 0x22, 0xf9, 0xb2, 0x0a, 0xbc, 0xf8,
-	0x6f, 0x20, 0x0e, 0x4a, 0x6f, 0xd0, 0x20, 0xfa, 0x13, 0x5e, 0x0b, 0x9c, 0xaa, 0x1b, 0xd8, 0x60,
-	0xc9, 0x75, 0xc6, 0x7c, 0x01, 0x4e, 0x35, 0x1f, 0x74, 0x0b, 0xf6, 0x0b, 0xcf, 0xe6, 0x75, 0x94,
-	0xbf, 0x67, 0x98, 0x78, 0xac, 0xc8, 0x41, 0x83, 0x54, 0x8e, 0xe7, 0x83, 0x5d, 0xf6, 0x8a, 0xbf,
-	0xa4, 0xd3, 0x69, 0xce, 0x44, 0xb9, 0xcb, 0x16, 0xd1, 0x65, 0x1d, 0xfa, 0x66, 0x80, 0x53, 0x8d,
-	0x17, 0xdd, 0x03, 0xd0, 0x30, 0x64, 0x42, 0x0c, 0xd3, 0x48, 0x2f, 0xff, 0x7c, 0xcf, 0x3e, 0x70,
-	0xbf, 0xa6, 0xc9, 0x96, 0xe9, 0x05, 0x00, 0xdf, 0x27, 0xdb, 0x93, 0x36, 0x7e, 0x4c, 0x1a, 0x79,
-	0xd0, 0x9c, 0xf1, 0x84, 0x3d, 0x50, 0x19, 0xab, 0x25, 0xb4, 0x48, 0x5d, 0x07, 0xc7, 0xef, 0x9b,
-	0xb6, 0xf1, 0xb1, 0x69, 0x1b, 0x9f, 0x9b, 0xb6, 0x31, 0x6e, 0xea, 0xe8, 0x89, 0xad, 0x9e, 0xef,
-	0xd5, 0x57, 0x00, 0x00, 0x00, 0xff, 0xff, 0x05, 0x13, 0xca, 0x3d, 0xda, 0x02, 0x00, 0x00,
+	// 469 bytes of a gzipped FileDescriptorProto
+	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff, 0x8c, 0x93, 0xcf, 0x6e, 0xd3, 0x40,
+	0x10, 0xc6, 0xe3, 0xc4, 0xb2, 0x93, 0x41, 0xea, 0x61, 0x85, 0x2a, 0xcb, 0x88, 0xa8, 0xf2, 0xa1,
+	0xf4, 0xb4, 0x25, 0x20, 0x24, 0x0e, 0x80, 0x54, 0x23, 0x55, 0x39, 0xa4, 0x12, 0x5a, 0x71, 0xca,
+	0x6d, 0xe3, 0x6c, 0xe2, 0x55, 0xd6, 0x7f, 0xe4, 0x5d, 0x83, 0xca, 0x95, 0x07, 0xe1, 0x75, 0x38,
+	0xf2, 0x08, 0x28, 0xef, 0x81, 0x84, 0x76, 0xbd, 0x6b, 0x5a, 0x48, 0x4b, 0x6f, 0x33, 0x93, 0xef,
+	0x37, 0xdf, 0xec, 0x4c, 0x0c, 0x51, 0xc1, 0x64, 0x7e, 0xfe, 0x69, 0x46, 0x45, 0x9d, 0xd3, 0xd9,
+	0xb9, 0xce, 0x70, 0xdd, 0x54, 0xaa, 0x42, 0x68, 0xd7, 0x16, 0x14, 0x9b, 0x82, 0xfb, 0x39, 0xf9,
+	0x3a, 0x04, 0xff, 0x8a, 0xc9, 0x1c, 0xcd, 0xc0, 0x2f, 0x94, 0x90, 0x91, 0x77, 0xe2, 0x9d, 0x3d,
+	0x7a, 0xf1, 0x14, 0xff, 0xab, 0xc5, 0x5a, 0x87, 0xaf, 0x94, 0x90, 0xc4, 0x48, 0xd1, 0x2b, 0x08,
+	0x55, 0x43, 0x33, 0x5e, 0x6e, 0xa3, 0xa1, 0xa1, 0x9e, 0x1c, 0xa2, 0x3e, 0x76, 0x12, 0xe2, 0xb4,
+	0x1a, 0x13, 0xd5, 0x76, 0xab, 0xb1, 0xd1, 0xdd, 0xd8, 0xa2, 0x93, 0x10, 0xa7, 0x8d, 0x97, 0xe0,
+	0x6b, 0x6f, 0xf4, 0x1a, 0x86, 0x19, 0xb5, 0x63, 0x9e, 0x1d, 0x22, 0xdf, 0xb3, 0x46, 0xf1, 0x0d,
+	0xcf, 0xa8, 0x62, 0x17, 0xad, 0xca, 0xab, 0x86, 0xab, 0x6b, 0x32, 0xcc, 0x28, 0x8a, 0x20, 0x64,
+	0x25, 0x5d, 0x09, 0xb6, 0x36, 0xf3, 0x8e, 0x89, 0x4b, 0x93, 0xcf, 0xf0, 0xf8, 0x10, 0x85, 0x16,
+	0x10, 0xae, 0x5a, 0x2e, 0x14, 0x2f, 0xad, 0xe1, 0xf3, 0x87, 0x1a, 0xe2, 0xb4, 0xe3, 0xe6, 0x03,
+	0xe2, 0x5a, 0xc4, 0x13, 0x08, 0x6d, 0x35, 0x0d, 0xc0, 0x57, 0xd7, 0x35, 0x4b, 0x24, 0x84, 0x76,
+	0x3f, 0xe8, 0x0d, 0x04, 0x5f, 0x78, 0xbd, 0xeb, 0xad, 0x92, 0x7b, 0x96, 0x89, 0x97, 0x46, 0x39,
+	0x1f, 0x10, 0xcb, 0xc4, 0x09, 0x04, 0x5d, 0x4d, 0xbf, 0x92, 0xae, 0xd7, 0x0d, 0x93, 0xdd, 0x2d,
+	0x27, 0xc4, 0xa5, 0xbd, 0xe9, 0x2f, 0x0f, 0x42, 0xbb, 0x5e, 0x74, 0x09, 0x40, 0xb3, 0x8c, 0x49,
+	0xb9, 0xa8, 0xb6, 0xee, 0xf8, 0xa7, 0xf7, 0xdc, 0x03, 0x5f, 0xf4, 0x6a, 0x72, 0x83, 0x44, 0xa7,
+	0x70, 0xb4, 0x66, 0x1b, 0xda, 0x0a, 0x95, 0xd2, 0x6c, 0xc7, 0xca, 0x6e, 0xc5, 0x13, 0xf2, 0x57,
+	0x15, 0xbd, 0x83, 0xf1, 0xaa, 0x0b, 0x65, 0x34, 0x3a, 0x19, 0xdd, 0xf5, 0x4e, 0xeb, 0x66, 0x29,
+	0xd2, 0x33, 0x71, 0x0a, 0xf0, 0x67, 0x82, 0x9b, 0x17, 0xf5, 0x6e, 0x5d, 0x14, 0xc5, 0x30, 0xde,
+	0x70, 0xc1, 0x3e, 0x50, 0x95, 0xdb, 0x49, 0xfa, 0x3c, 0xf9, 0xe6, 0xc1, 0xd1, 0x6d, 0x03, 0x84,
+	0xc0, 0x2f, 0x69, 0xc1, 0xec, 0xc6, 0x4c, 0x8c, 0x8e, 0x21, 0xd8, 0x54, 0x4d, 0x41, 0x95, 0x6d,
+	0x60, 0x33, 0xf4, 0x16, 0x7c, 0xdd, 0xca, 0xfe, 0x79, 0x9f, 0xfd, 0x7f, 0x7c, 0x7c, 0xc9, 0x05,
+	0x9b, 0x0f, 0x88, 0xc1, 0xe2, 0x18, 0x7c, 0x9d, 0x6b, 0xcb, 0x5a, 0x4f, 0x67, 0x2d, 0x75, 0xec,
+	0x2e, 0x94, 0x1e, 0x7f, 0xdf, 0x4f, 0xbd, 0x1f, 0xfb, 0xa9, 0xf7, 0x73, 0x3f, 0xf5, 0x96, 0x63,
+	0xd7, 0x77, 0x15, 0x98, 0x0f, 0xf9, 0xe5, 0xef, 0x00, 0x00, 0x00, 0xff, 0xff, 0x00, 0x14, 0xd4,
+	0xf6, 0xe4, 0x03, 0x00, 0x00,
 }
 
 func (m *Mesh) Marshal() (dAtA []byte, err error) {
@@ -878,6 +1097,24 @@ func (m *Logging) MarshalTo(dAtA []byte) (int, error) {
 		}
 		i += n9
 	}
+	if len(m.DefaultBackend) > 0 {
+		dAtA[i] = 0x12
+		i++
+		i = encodeVarintMesh(dAtA, i, uint64(len(m.DefaultBackend)))
+		i += copy(dAtA[i:], m.DefaultBackend)
+	}
+	if len(m.Backends) > 0 {
+		for _, msg := range m.Backends {
+			dAtA[i] = 0x1a
+			i++
+			i = encodeVarintMesh(dAtA, i, uint64(msg.Size()))
+			n, err := msg.MarshalTo(dAtA[i:])
+			if err != nil {
+				return 0, err
+			}
+			i += n
+		}
+	}
 	if m.XXX_unrecognized != nil {
 		i += copy(dAtA[i:], m.XXX_unrecognized)
 	}
@@ -914,6 +1151,87 @@ func (m *Logging_AccessLogs) MarshalTo(dAtA []byte) (int, error) {
 		i++
 		i = encodeVarintMesh(dAtA, i, uint64(len(m.FilePath)))
 		i += copy(dAtA[i:], m.FilePath)
+	}
+	if m.XXX_unrecognized != nil {
+		i += copy(dAtA[i:], m.XXX_unrecognized)
+	}
+	return i, nil
+}
+
+func (m *LoggingBackend) Marshal() (dAtA []byte, err error) {
+	size := m.Size()
+	dAtA = make([]byte, size)
+	n, err := m.MarshalTo(dAtA)
+	if err != nil {
+		return nil, err
+	}
+	return dAtA[:n], nil
+}
+
+func (m *LoggingBackend) MarshalTo(dAtA []byte) (int, error) {
+	var i int
+	_ = i
+	var l int
+	_ = l
+	if len(m.Name) > 0 {
+		dAtA[i] = 0xa
+		i++
+		i = encodeVarintMesh(dAtA, i, uint64(len(m.Name)))
+		i += copy(dAtA[i:], m.Name)
+	}
+	if len(m.Format) > 0 {
+		dAtA[i] = 0x12
+		i++
+		i = encodeVarintMesh(dAtA, i, uint64(len(m.Format)))
+		i += copy(dAtA[i:], m.Format)
+	}
+	if m.Type != nil {
+		nn10, err := m.Type.MarshalTo(dAtA[i:])
+		if err != nil {
+			return 0, err
+		}
+		i += nn10
+	}
+	if m.XXX_unrecognized != nil {
+		i += copy(dAtA[i:], m.XXX_unrecognized)
+	}
+	return i, nil
+}
+
+func (m *LoggingBackend_File_) MarshalTo(dAtA []byte) (int, error) {
+	i := 0
+	if m.File != nil {
+		dAtA[i] = 0x1a
+		i++
+		i = encodeVarintMesh(dAtA, i, uint64(m.File.Size()))
+		n11, err := m.File.MarshalTo(dAtA[i:])
+		if err != nil {
+			return 0, err
+		}
+		i += n11
+	}
+	return i, nil
+}
+func (m *LoggingBackend_File) Marshal() (dAtA []byte, err error) {
+	size := m.Size()
+	dAtA = make([]byte, size)
+	n, err := m.MarshalTo(dAtA)
+	if err != nil {
+		return nil, err
+	}
+	return dAtA[:n], nil
+}
+
+func (m *LoggingBackend_File) MarshalTo(dAtA []byte) (int, error) {
+	var i int
+	_ = i
+	var l int
+	_ = l
+	if len(m.Path) > 0 {
+		dAtA[i] = 0xa
+		i++
+		i = encodeVarintMesh(dAtA, i, uint64(len(m.Path)))
+		i += copy(dAtA[i:], m.Path)
 	}
 	if m.XXX_unrecognized != nil {
 		i += copy(dAtA[i:], m.XXX_unrecognized)
@@ -1065,6 +1383,16 @@ func (m *Logging) Size() (n int) {
 		l = m.AccessLogs.Size()
 		n += 1 + l + sovMesh(uint64(l))
 	}
+	l = len(m.DefaultBackend)
+	if l > 0 {
+		n += 1 + l + sovMesh(uint64(l))
+	}
+	if len(m.Backends) > 0 {
+		for _, e := range m.Backends {
+			l = e.Size()
+			n += 1 + l + sovMesh(uint64(l))
+		}
+	}
 	if m.XXX_unrecognized != nil {
 		n += len(m.XXX_unrecognized)
 	}
@@ -1081,6 +1409,57 @@ func (m *Logging_AccessLogs) Size() (n int) {
 		n += 2
 	}
 	l = len(m.FilePath)
+	if l > 0 {
+		n += 1 + l + sovMesh(uint64(l))
+	}
+	if m.XXX_unrecognized != nil {
+		n += len(m.XXX_unrecognized)
+	}
+	return n
+}
+
+func (m *LoggingBackend) Size() (n int) {
+	if m == nil {
+		return 0
+	}
+	var l int
+	_ = l
+	l = len(m.Name)
+	if l > 0 {
+		n += 1 + l + sovMesh(uint64(l))
+	}
+	l = len(m.Format)
+	if l > 0 {
+		n += 1 + l + sovMesh(uint64(l))
+	}
+	if m.Type != nil {
+		n += m.Type.Size()
+	}
+	if m.XXX_unrecognized != nil {
+		n += len(m.XXX_unrecognized)
+	}
+	return n
+}
+
+func (m *LoggingBackend_File_) Size() (n int) {
+	if m == nil {
+		return 0
+	}
+	var l int
+	_ = l
+	if m.File != nil {
+		l = m.File.Size()
+		n += 1 + l + sovMesh(uint64(l))
+	}
+	return n
+}
+func (m *LoggingBackend_File) Size() (n int) {
+	if m == nil {
+		return 0
+	}
+	var l int
+	_ = l
+	l = len(m.Path)
 	if l > 0 {
 		n += 1 + l + sovMesh(uint64(l))
 	}
@@ -1758,6 +2137,72 @@ func (m *Logging) Unmarshal(dAtA []byte) error {
 				return err
 			}
 			iNdEx = postIndex
+		case 2:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field DefaultBackend", wireType)
+			}
+			var stringLen uint64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowMesh
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				stringLen |= uint64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			intStringLen := int(stringLen)
+			if intStringLen < 0 {
+				return ErrInvalidLengthMesh
+			}
+			postIndex := iNdEx + intStringLen
+			if postIndex < 0 {
+				return ErrInvalidLengthMesh
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.DefaultBackend = string(dAtA[iNdEx:postIndex])
+			iNdEx = postIndex
+		case 3:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Backends", wireType)
+			}
+			var msglen int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowMesh
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				msglen |= int(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			if msglen < 0 {
+				return ErrInvalidLengthMesh
+			}
+			postIndex := iNdEx + msglen
+			if postIndex < 0 {
+				return ErrInvalidLengthMesh
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.Backends = append(m.Backends, &LoggingBackend{})
+			if err := m.Backends[len(m.Backends)-1].Unmarshal(dAtA[iNdEx:postIndex]); err != nil {
+				return err
+			}
+			iNdEx = postIndex
 		default:
 			iNdEx = preIndex
 			skippy, err := skipMesh(dAtA[iNdEx:])
@@ -1863,6 +2308,245 @@ func (m *Logging_AccessLogs) Unmarshal(dAtA []byte) error {
 				return io.ErrUnexpectedEOF
 			}
 			m.FilePath = string(dAtA[iNdEx:postIndex])
+			iNdEx = postIndex
+		default:
+			iNdEx = preIndex
+			skippy, err := skipMesh(dAtA[iNdEx:])
+			if err != nil {
+				return err
+			}
+			if skippy < 0 {
+				return ErrInvalidLengthMesh
+			}
+			if (iNdEx + skippy) < 0 {
+				return ErrInvalidLengthMesh
+			}
+			if (iNdEx + skippy) > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.XXX_unrecognized = append(m.XXX_unrecognized, dAtA[iNdEx:iNdEx+skippy]...)
+			iNdEx += skippy
+		}
+	}
+
+	if iNdEx > l {
+		return io.ErrUnexpectedEOF
+	}
+	return nil
+}
+func (m *LoggingBackend) Unmarshal(dAtA []byte) error {
+	l := len(dAtA)
+	iNdEx := 0
+	for iNdEx < l {
+		preIndex := iNdEx
+		var wire uint64
+		for shift := uint(0); ; shift += 7 {
+			if shift >= 64 {
+				return ErrIntOverflowMesh
+			}
+			if iNdEx >= l {
+				return io.ErrUnexpectedEOF
+			}
+			b := dAtA[iNdEx]
+			iNdEx++
+			wire |= uint64(b&0x7F) << shift
+			if b < 0x80 {
+				break
+			}
+		}
+		fieldNum := int32(wire >> 3)
+		wireType := int(wire & 0x7)
+		if wireType == 4 {
+			return fmt.Errorf("proto: LoggingBackend: wiretype end group for non-group")
+		}
+		if fieldNum <= 0 {
+			return fmt.Errorf("proto: LoggingBackend: illegal tag %d (wire type %d)", fieldNum, wire)
+		}
+		switch fieldNum {
+		case 1:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Name", wireType)
+			}
+			var stringLen uint64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowMesh
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				stringLen |= uint64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			intStringLen := int(stringLen)
+			if intStringLen < 0 {
+				return ErrInvalidLengthMesh
+			}
+			postIndex := iNdEx + intStringLen
+			if postIndex < 0 {
+				return ErrInvalidLengthMesh
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.Name = string(dAtA[iNdEx:postIndex])
+			iNdEx = postIndex
+		case 2:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Format", wireType)
+			}
+			var stringLen uint64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowMesh
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				stringLen |= uint64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			intStringLen := int(stringLen)
+			if intStringLen < 0 {
+				return ErrInvalidLengthMesh
+			}
+			postIndex := iNdEx + intStringLen
+			if postIndex < 0 {
+				return ErrInvalidLengthMesh
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.Format = string(dAtA[iNdEx:postIndex])
+			iNdEx = postIndex
+		case 3:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field File", wireType)
+			}
+			var msglen int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowMesh
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				msglen |= int(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			if msglen < 0 {
+				return ErrInvalidLengthMesh
+			}
+			postIndex := iNdEx + msglen
+			if postIndex < 0 {
+				return ErrInvalidLengthMesh
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			v := &LoggingBackend_File{}
+			if err := v.Unmarshal(dAtA[iNdEx:postIndex]); err != nil {
+				return err
+			}
+			m.Type = &LoggingBackend_File_{v}
+			iNdEx = postIndex
+		default:
+			iNdEx = preIndex
+			skippy, err := skipMesh(dAtA[iNdEx:])
+			if err != nil {
+				return err
+			}
+			if skippy < 0 {
+				return ErrInvalidLengthMesh
+			}
+			if (iNdEx + skippy) < 0 {
+				return ErrInvalidLengthMesh
+			}
+			if (iNdEx + skippy) > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.XXX_unrecognized = append(m.XXX_unrecognized, dAtA[iNdEx:iNdEx+skippy]...)
+			iNdEx += skippy
+		}
+	}
+
+	if iNdEx > l {
+		return io.ErrUnexpectedEOF
+	}
+	return nil
+}
+func (m *LoggingBackend_File) Unmarshal(dAtA []byte) error {
+	l := len(dAtA)
+	iNdEx := 0
+	for iNdEx < l {
+		preIndex := iNdEx
+		var wire uint64
+		for shift := uint(0); ; shift += 7 {
+			if shift >= 64 {
+				return ErrIntOverflowMesh
+			}
+			if iNdEx >= l {
+				return io.ErrUnexpectedEOF
+			}
+			b := dAtA[iNdEx]
+			iNdEx++
+			wire |= uint64(b&0x7F) << shift
+			if b < 0x80 {
+				break
+			}
+		}
+		fieldNum := int32(wire >> 3)
+		wireType := int(wire & 0x7)
+		if wireType == 4 {
+			return fmt.Errorf("proto: File: wiretype end group for non-group")
+		}
+		if fieldNum <= 0 {
+			return fmt.Errorf("proto: File: illegal tag %d (wire type %d)", fieldNum, wire)
+		}
+		switch fieldNum {
+		case 1:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Path", wireType)
+			}
+			var stringLen uint64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowMesh
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				stringLen |= uint64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			intStringLen := int(stringLen)
+			if intStringLen < 0 {
+				return ErrInvalidLengthMesh
+			}
+			postIndex := iNdEx + intStringLen
+			if postIndex < 0 {
+				return ErrInvalidLengthMesh
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.Path = string(dAtA[iNdEx:postIndex])
 			iNdEx = postIndex
 		default:
 			iNdEx = preIndex

--- a/api/mesh/v1alpha1/mesh.proto
+++ b/api/mesh/v1alpha1/mesh.proto
@@ -71,4 +71,27 @@ message Logging {
   }
 
   AccessLogs accessLogs = 1;
+
+  // Name of the default backend
+  string defaultBackend = 2;
+
+  // List of available logging backends
+  repeated LoggingBackend backends = 3;
+}
+
+// LoggingBackend defines logging backend available to mesh. Backends can be
+// used in TrafficLog rules.
+message LoggingBackend {
+  // Name of the backend, can be then used in Mesh.logging.defaultBackend or in
+  // TrafficLogging
+  string name = 1;
+
+  // Format of access logs. Placehodlers available on
+  // https://www.envoyproxy.io/docs/envoy/latest/configuration/observability/access_log
+  string format = 2;
+
+  // Simple logging to file
+  message File { string path = 1; }
+
+  oneof type { File file = 3; }
 }

--- a/pkg/core/logs/matcher.go
+++ b/pkg/core/logs/matcher.go
@@ -1,0 +1,141 @@
+package logs
+
+import (
+	"context"
+	mesh_proto "github.com/Kong/kuma/api/mesh/v1alpha1"
+	"github.com/Kong/kuma/pkg/core"
+	mesh_core "github.com/Kong/kuma/pkg/core/resources/apis/mesh"
+	"github.com/Kong/kuma/pkg/core/resources/manager"
+	"github.com/Kong/kuma/pkg/core/resources/store"
+	"github.com/pkg/errors"
+)
+
+var logger = core.Log.WithName("logs")
+
+// Current limitations:
+// 1) Right now we only generate and place access logs for outbound listeners
+// 2) We match all tags in source section of TrafficLog but only service tag on destination
+// 3) Let's assume we've got following dataplanes:
+//    Dataplane 1 with services: kong and kong-admin
+//    Dataplane 2 with services: backend
+//    If we define rule kong->backend, it is also applied for kong-admin because there is no way to differentiate
+//    traffic from services that are using one dataplane.
+type TrafficLogsMatcher struct {
+	ResourceManager manager.ResourceManager
+}
+
+type MatchedLogs struct {
+	Outbounds map[string][]*mesh_proto.LoggingBackend
+}
+
+func NewMatchedLogs() *MatchedLogs {
+	return &MatchedLogs{
+		Outbounds: map[string][]*mesh_proto.LoggingBackend{},
+	}
+}
+
+func (m *MatchedLogs) AddForOutbound(outbound string, backend *mesh_proto.LoggingBackend) {
+	if _, ok := m.Outbounds[outbound]; !ok {
+		m.Outbounds[outbound] = []*mesh_proto.LoggingBackend{}
+	}
+	m.Outbounds[outbound] = append(m.Outbounds[outbound], backend)
+}
+
+func (m *TrafficLogsMatcher) Match(ctx context.Context, dataplane *mesh_core.DataplaneResource) (*MatchedLogs, error) {
+	logs := &mesh_core.TrafficLogResourceList{}
+	if err := m.ResourceManager.List(ctx, logs, store.ListByMesh(dataplane.GetMeta().GetMesh())); err != nil {
+		return nil, errors.Wrap(err, "could not retrieve traffic logs")
+	}
+	backends, err := m.backendsByName(ctx, dataplane)
+	if err != nil {
+		return nil, err
+	}
+	matchedLog := NewMatchedLogs()
+	for outbound, backendsNames := range matchBackends(&dataplane.Spec, logs) {
+		for backendName, _ := range backendsNames {
+			backend, found := backends[backendName]
+			if !found {
+				logger.Info("Logging backend is not found. Ignoring.", "name", backendName)
+				continue
+			}
+			matchedLog.AddForOutbound(outbound, backend)
+		}
+	}
+	return matchedLog, nil
+}
+
+func (m *TrafficLogsMatcher) backendsByName(ctx context.Context, dataplane *mesh_core.DataplaneResource) (map[string]*mesh_proto.LoggingBackend, error) {
+	meshes := &mesh_core.MeshResourceList{}
+	// todo(jakubydszkiewicz) simplify to Get after we solve namespace problem
+	if err := m.ResourceManager.List(ctx, meshes, store.ListByMesh(dataplane.GetMeta().GetMesh())); err != nil {
+		return nil, errors.Wrap(err, "could not retrieve meshes")
+	}
+	if len(meshes.Items) != 1 {
+		return nil, errors.Errorf("found %d meshes. There should be only one mesh of name %s", len(meshes.Items), dataplane.GetMeta().GetMesh())
+	}
+	backendsByName := map[string]*mesh_proto.LoggingBackend{}
+	for _, backend := range meshes.Items[0].Spec.GetLogging().GetBackends() {
+		backendsByName[backend.Name] = backend
+	}
+	defaultBackend := meshes.Items[0].Spec.GetLogging().GetDefaultBackend()
+	if defaultBackend != "" {
+		backendsByName[""] = backendsByName[defaultBackend]
+	}
+	return backendsByName, nil
+}
+
+func matchBackends(dataplane *mesh_proto.Dataplane, logs *mesh_core.TrafficLogResourceList) map[string]map[string]bool {
+	outboundToBackend := map[string]map[string]bool{}
+	for _, outbound := range dataplane.GetNetworking().GetOutbound() {
+		for _, logRes := range matchOutbound(outbound, dataplane.Networking.Inbound, logs.Items) {
+			for _, rule := range logRes.Spec.Rules {
+				if _, ok := outboundToBackend[outbound.Interface]; !ok {
+					outboundToBackend[outbound.Interface] = map[string]bool{}
+				}
+				outboundToBackend[outbound.Interface][rule.Conf.GetBackend()] = true
+			}
+		}
+	}
+	return outboundToBackend
+}
+
+// To Match outbound, we need to match service tag of outbound and all tags of any inbound interface
+func matchOutbound(outbound *mesh_proto.Dataplane_Networking_Outbound, inbounds []*mesh_proto.Dataplane_Networking_Inbound, logs []*mesh_core.TrafficLogResource) []*mesh_core.TrafficLogResource {
+	matchedLogs := []*mesh_core.TrafficLogResource{}
+	for _, perm := range logs {
+		matchedRules := []*mesh_proto.TrafficLog_Rule{}
+
+		for _, rule := range perm.Spec.Rules {
+			if !anySelectorMatchAnyInbound(rule.Sources, inbounds) {
+				continue
+			}
+			for _, dest := range rule.Destinations {
+				if outbound.MatchTags(dest.Match) {
+					matchedRules = append(matchedRules, rule)
+				}
+			}
+		}
+
+		if len(matchedRules) > 0 {
+			// construct copy of the resource but only with matched rules
+			matchedLogs = append(matchedLogs, &mesh_core.TrafficLogResource{
+				Meta: perm.Meta,
+				Spec: mesh_proto.TrafficLog{
+					Rules: matchedRules,
+				},
+			})
+		}
+	}
+	return matchedLogs
+}
+
+func anySelectorMatchAnyInbound(selectors []*mesh_proto.Selector, inbounds []*mesh_proto.Dataplane_Networking_Inbound) bool {
+	for _, inbound := range inbounds {
+		for _, selector := range selectors {
+			if inbound.MatchTags(selector.Match) {
+				return true
+			}
+		}
+	}
+	return false
+}

--- a/pkg/core/logs/matcher_suite_test.go
+++ b/pkg/core/logs/matcher_suite_test.go
@@ -1,0 +1,13 @@
+package logs_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+func TestMatcher(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Log Matcher Suite")
+}

--- a/pkg/core/logs/matcher_test.go
+++ b/pkg/core/logs/matcher_test.go
@@ -1,0 +1,253 @@
+package logs_test
+
+import (
+	"context"
+	mesh_proto "github.com/Kong/kuma/api/mesh/v1alpha1"
+	"github.com/Kong/kuma/pkg/core/logs"
+	core_mesh "github.com/Kong/kuma/pkg/core/resources/apis/mesh"
+	core_manager "github.com/Kong/kuma/pkg/core/resources/manager"
+	"github.com/Kong/kuma/pkg/core/resources/store"
+	"github.com/Kong/kuma/pkg/plugins/resources/memory"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("Matcher", func() {
+
+	var manager core_manager.ResourceManager
+	var matcher logs.TrafficLogsMatcher
+	var dpRes core_mesh.DataplaneResource
+
+	var backendFile1 *mesh_proto.LoggingBackend
+	var backendFile2 *mesh_proto.LoggingBackend
+	var backendFile3 *mesh_proto.LoggingBackend
+
+	BeforeEach(func() {
+		manager = core_manager.NewResourceManager(memory.NewStore())
+		matcher = logs.TrafficLogsMatcher{manager}
+
+		// given mesh with 3 backends and file1 backend as default
+		backendFile1 = &mesh_proto.LoggingBackend{
+			Name: "file1",
+		}
+		backendFile2 = &mesh_proto.LoggingBackend{
+			Name: "file2",
+		}
+		backendFile3 = &mesh_proto.LoggingBackend{
+			Name: "file3",
+		}
+		meshRes := core_mesh.MeshResource{
+			Spec: mesh_proto.Mesh{
+				Logging: &mesh_proto.Logging{
+					Backends:       []*mesh_proto.LoggingBackend{backendFile1, backendFile2, backendFile3},
+					DefaultBackend: "file1",
+				},
+			},
+		}
+		err := manager.Create(context.Background(), &meshRes, store.CreateByKey("default", "sample", "sample"))
+		Expect(err).ToNot(HaveOccurred())
+
+		// and
+		dpRes = core_mesh.DataplaneResource{
+			Spec: mesh_proto.Dataplane{
+				Networking: &mesh_proto.Dataplane_Networking{
+					Inbound: []*mesh_proto.Dataplane_Networking_Inbound{
+						{
+							Interface: "127.0.0.1:8080:8081",
+							Tags: map[string]string{
+								"service": "kong",
+							},
+						},
+						{
+							Interface: "127.0.0.1:8090:8091",
+							Tags: map[string]string{
+								"service": "kong-admin",
+							},
+						},
+					},
+					Outbound: []*mesh_proto.Dataplane_Networking_Outbound{
+						{
+							Interface: ":9091",
+							Service:   "backend",
+						},
+						{
+							Interface: ":9092",
+							Service:   "web",
+						},
+					},
+				},
+			},
+		}
+		err = manager.Create(context.Background(), &dpRes, store.CreateByKey("default", "dp-1", "sample"))
+		Expect(err).ToNot(HaveOccurred())
+	})
+
+	It("should match rules", func() {
+		// given
+		logRes1 := core_mesh.TrafficLogResource{
+			Spec: mesh_proto.TrafficLog{
+				Rules: []*mesh_proto.TrafficLog_Rule{
+					{
+						Sources: []*mesh_proto.Selector{
+							{
+								Match: map[string]string{
+									"service": "kong",
+								},
+							},
+						},
+						Destinations: []*mesh_proto.Selector{
+							{
+								Match: map[string]string{
+									"service": "backend",
+								},
+							},
+						},
+						Conf: &mesh_proto.TrafficLog_Rule_Conf{
+							Backend: "file2",
+						},
+					},
+					{
+						Sources: []*mesh_proto.Selector{
+							{
+								Match: map[string]string{
+									"service": "kong-admin",
+								},
+							},
+						},
+						Destinations: []*mesh_proto.Selector{
+							{
+								Match: map[string]string{
+									"service": "web",
+								},
+							},
+						},
+						Conf: &mesh_proto.TrafficLog_Rule_Conf{
+							Backend: "file3",
+						},
+					},
+				},
+			},
+		}
+		err := manager.Create(context.Background(), &logRes1, store.CreateByKey("default", "lr-1", "sample"))
+		Expect(err).ToNot(HaveOccurred())
+
+		// and
+		logRes2 := core_mesh.TrafficLogResource{
+			Spec: mesh_proto.TrafficLog{
+				Rules: []*mesh_proto.TrafficLog_Rule{
+					{
+						Sources: []*mesh_proto.Selector{
+							{
+								Match: map[string]string{
+									"service": "*",
+								},
+							},
+						},
+						Destinations: []*mesh_proto.Selector{
+							{
+								Match: map[string]string{
+									"service": "*",
+								},
+							},
+						},
+					},
+				},
+			},
+		}
+		err = manager.Create(context.Background(), &logRes2, store.CreateByKey("default", "lr-2", "sample"))
+		Expect(err).ToNot(HaveOccurred())
+
+		// when
+		log, err := matcher.Match(context.Background(), &dpRes)
+
+		// then
+		Expect(err).ToNot(HaveOccurred())
+		Expect(log.Outbounds[":9091"]).To(HaveLen(2))
+		// should match because *->* rule with file-1 logging backend as default
+		Expect(log.Outbounds[":9091"]).To(ContainElement(backendFile1))
+		// should match because kong->backend rule
+		Expect(log.Outbounds[":9091"]).To(ContainElement(backendFile2))
+
+		Expect(log.Outbounds[":9092"]).To(HaveLen(2))
+		// should match because *->* rule with file-1 logging backend as default
+		Expect(log.Outbounds[":9092"]).To(ContainElement(backendFile1))
+		// should match because kong-admin->web rule
+		Expect(log.Outbounds[":9092"]).To(ContainElement(backendFile3))
+	})
+
+	It("should not match services", func() {
+		// given
+		logRes := core_mesh.TrafficLogResource{
+			Spec: mesh_proto.TrafficLog{
+				Rules: []*mesh_proto.TrafficLog_Rule{
+					{
+						Sources: []*mesh_proto.Selector{
+							{
+								Match: map[string]string{
+									"service": "web",
+								},
+							},
+						},
+						Destinations: []*mesh_proto.Selector{
+							{
+								Match: map[string]string{
+									"service": "backend",
+								},
+							},
+						},
+						Conf: &mesh_proto.TrafficLog_Rule_Conf{
+							Backend: "file2",
+						},
+					},
+				},
+			},
+		}
+		err := manager.Create(context.Background(), &logRes, store.CreateByKey("default", "lr-1", "sample"))
+		Expect(err).ToNot(HaveOccurred())
+
+		// when
+		log, err := matcher.Match(context.Background(), &dpRes)
+
+		// then
+		Expect(err).ToNot(HaveOccurred())
+		Expect(log.Outbounds).To(HaveLen(0))
+	})
+
+	It("should skip unknown backends", func() {
+		// given
+		logRes := core_mesh.TrafficLogResource{
+			Spec: mesh_proto.TrafficLog{
+				Rules: []*mesh_proto.TrafficLog_Rule{
+					{
+						Sources: []*mesh_proto.Selector{
+							{
+								Match: map[string]string{
+									"service": "*",
+								},
+							},
+						},
+						Destinations: []*mesh_proto.Selector{
+							{
+								Match: map[string]string{
+									"service": "*",
+								},
+							},
+						},
+						Conf: &mesh_proto.TrafficLog_Rule_Conf{
+							Backend: "unknown-backend",
+						},
+					},
+				},
+			},
+		}
+		err := manager.Create(context.Background(), &logRes, store.CreateByKey("default", "lr-1", "sample"))
+		Expect(err).ToNot(HaveOccurred())
+
+		// when
+		log, err := matcher.Match(context.Background(), &dpRes)
+
+		// then
+		Expect(err).ToNot(HaveOccurred())
+		Expect(log.Outbounds).To(HaveLen(0))
+	})
+})

--- a/pkg/core/xds/types.go
+++ b/pkg/core/xds/types.go
@@ -2,6 +2,7 @@ package xds
 
 import (
 	"fmt"
+	"github.com/Kong/kuma/pkg/core/logs"
 	"github.com/Kong/kuma/pkg/core/permissions"
 	"net"
 	"strings"
@@ -28,6 +29,7 @@ type Proxy struct {
 	Id                 ProxyId
 	Dataplane          *mesh_core.DataplaneResource
 	TrafficPermissions permissions.MatchedPermissions
+	Logs               *logs.MatchedLogs
 	OutboundTargets    map[string][]net.SRV
 }
 

--- a/pkg/xds/envoy/access_logs.go
+++ b/pkg/xds/envoy/access_logs.go
@@ -1,0 +1,55 @@
+package envoy
+
+import (
+	"github.com/Kong/kuma/api/mesh/v1alpha1"
+	accesslog "github.com/envoyproxy/go-control-plane/envoy/config/accesslog/v2"
+	filter_accesslog "github.com/envoyproxy/go-control-plane/envoy/config/filter/accesslog/v2"
+	"github.com/envoyproxy/go-control-plane/pkg/util"
+	"github.com/gogo/protobuf/types"
+	"github.com/pkg/errors"
+)
+
+const AccessLogDefaultFormat = "[%START_TIME%] %DOWNSTREAM_REMOTE_ADDRESS%->%UPSTREAM_HOST%(%UPSTREAM_CLUSTER%) took %DURATION%ms, sent %BYTES_SENT% bytes, received: %BYTES_RECEIVED% bytes\n"
+
+func convertLoggingBackends(backends []*v1alpha1.LoggingBackend) ([]*filter_accesslog.AccessLog, error) {
+	var result []*filter_accesslog.AccessLog
+	for _, backend := range backends {
+		log, err := convertLoggingBackend(backend)
+		if err != nil {
+			return nil, err
+		}
+		result = append(result, log)
+	}
+	return result, nil
+}
+
+func convertLoggingBackend(backend *v1alpha1.LoggingBackend) (*filter_accesslog.AccessLog, error) {
+	format := AccessLogDefaultFormat
+	if backend.Format != "" {
+		format = backend.Format
+	}
+	if file, ok := backend.GetType().(*v1alpha1.LoggingBackend_File_); ok {
+		return fileAccessLog(format, file)
+	} else {
+		return nil, errors.Errorf("could not convert LoggingBackend of type %T to AccessLog", backend.GetType())
+	}
+}
+
+func fileAccessLog(format string, file *v1alpha1.LoggingBackend_File_) (*filter_accesslog.AccessLog, error) {
+	fileAccessLog := &accesslog.FileAccessLog{
+		AccessLogFormat: &accesslog.FileAccessLog_Format{
+			Format: format,
+		},
+		Path: file.File.Path,
+	}
+	marshalled, err := types.MarshalAny(fileAccessLog)
+	if err != nil {
+		return nil, errors.Wrap(err, "could not marshall FileAccessLog")
+	}
+	return &filter_accesslog.AccessLog{
+		Name: util.FileAccessLog,
+		ConfigType: &filter_accesslog.AccessLog_TypedConfig{
+			TypedConfig: marshalled,
+		},
+	}, nil
+}

--- a/pkg/xds/generator/outbound_proxy_generator_test.go
+++ b/pkg/xds/generator/outbound_proxy_generator_test.go
@@ -1,6 +1,7 @@
 package generator_test
 
 import (
+	"github.com/Kong/kuma/pkg/core/logs"
 	"io/ioutil"
 	"net"
 	"path/filepath"
@@ -72,6 +73,7 @@ var _ = Describe("OutboundProxyGenerator", func() {
 						{Target: "192.168.0.3", Port: 5432},
 					},
 				},
+				Logs: logs.NewMatchedLogs(),
 			}
 
 			// when

--- a/pkg/xds/server/snapshot_generator_test.go
+++ b/pkg/xds/server/snapshot_generator_test.go
@@ -1,6 +1,7 @@
 package server
 
 import (
+	"github.com/Kong/kuma/pkg/core/logs"
 	"github.com/Kong/kuma/pkg/core/permissions"
 	"io/ioutil"
 	"path/filepath"
@@ -91,6 +92,7 @@ var _ = Describe("Reconcile", func() {
 						},
 					},
 				},
+				Logs: logs.NewMatchedLogs(),
 			}
 
 			// when


### PR DESCRIPTION
First version of traffic logging

### Summary

This is first version of traffic logging. It only supports file backend in mesh. The next step is to support sending it to ELK stack.

For the matching part. We match all inbounds and service on outbound and we place access log on outbound listener. For now, we apply all rules that match, we don't choose the most relevant one.

I did not reuse logic from TrafficPermission for now, because it's different. Here we match all inbound + outbound, in TrafficPermission we match destinations to inbounds.  

### Full changelog

* Implement Traffic Log matching.

### Issues resolved

#271
