### PR TITLE
kuma-cp: move `EnvironmentType` into `config/core` package

### DIFF
--- a/pkg/config/app/kuma-cp/config.go
+++ b/pkg/config/app/kuma-cp/config.go
@@ -4,6 +4,7 @@ import (
 	"github.com/Kong/kuma/api/mesh/v1alpha1"
 	"github.com/Kong/kuma/pkg/config"
 	api_server "github.com/Kong/kuma/pkg/config/api-server"
+	"github.com/Kong/kuma/pkg/config/core"
 	"github.com/Kong/kuma/pkg/config/core/discovery"
 	"github.com/Kong/kuma/pkg/config/core/resources/store"
 	"github.com/Kong/kuma/pkg/config/sds"
@@ -14,13 +15,6 @@ import (
 )
 
 var _ config.Config = &Config{}
-
-type EnvironmentType = string
-
-const (
-	KubernetesEnvironment EnvironmentType = "kubernetes"
-	UniversalEnvironment  EnvironmentType = "universal"
-)
 
 var _ config.Config = &Defaults{}
 
@@ -49,7 +43,7 @@ type Reports struct {
 
 type Config struct {
 	// Environment Type, can be either "kubernetes" or "universal"
-	Environment EnvironmentType `yaml:"environment" envconfig:"kuma_environment"`
+	Environment core.EnvironmentType `yaml:"environment" envconfig:"kuma_environment"`
 	// Resource Store configuration
 	Store *store.StoreConfig `yaml:"store"`
 	// Discovery configuration
@@ -70,7 +64,7 @@ type Config struct {
 
 func DefaultConfig() Config {
 	return Config{
-		Environment:     UniversalEnvironment,
+		Environment:     core.UniversalEnvironment,
 		Store:           store.DefaultStoreConfig(),
 		XdsServer:       xds.DefaultXdsServerConfig(),
 		SdsServer:       sds.DefaultSdsServerConfig(),
@@ -101,8 +95,8 @@ func (c *Config) Validate() error {
 	if err := c.SdsServer.Validate(); err != nil {
 		return errors.Wrap(err, "SDS Server validation failed")
 	}
-	if c.Environment != KubernetesEnvironment && c.Environment != UniversalEnvironment {
-		return errors.Errorf("Environment should be either %s or %s", KubernetesEnvironment, UniversalEnvironment)
+	if c.Environment != core.KubernetesEnvironment && c.Environment != core.UniversalEnvironment {
+		return errors.Errorf("Environment should be either %s or %s", core.KubernetesEnvironment, core.UniversalEnvironment)
 	}
 	if err := c.Store.Validate(); err != nil {
 		return errors.Wrap(err, "Store validation failed")

--- a/pkg/config/core/config.go
+++ b/pkg/config/core/config.go
@@ -1,0 +1,8 @@
+package core
+
+type EnvironmentType = string
+
+const (
+	KubernetesEnvironment EnvironmentType = "kubernetes"
+	UniversalEnvironment  EnvironmentType = "universal"
+)

--- a/pkg/config/loader_test.go
+++ b/pkg/config/loader_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/Kong/kuma/pkg/config"
 	kuma_cp "github.com/Kong/kuma/pkg/config/app/kuma-cp"
+	config_core "github.com/Kong/kuma/pkg/config/core"
 	"github.com/Kong/kuma/pkg/config/core/resources/store"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -77,7 +78,7 @@ reports:
 		Expect(cfg.BootstrapServer.Params.XdsHost).To(Equal("kuma-control-plane"))
 		Expect(cfg.BootstrapServer.Params.XdsPort).To(Equal(uint32(4321)))
 
-		Expect(cfg.Environment).To(Equal(kuma_cp.KubernetesEnvironment))
+		Expect(cfg.Environment).To(Equal(config_core.KubernetesEnvironment))
 
 		Expect(cfg.Store.Type).To(Equal(store.PostgresStore))
 
@@ -133,7 +134,7 @@ reports:
 		Expect(cfg.BootstrapServer.Params.XdsHost).To(Equal("kuma-control-plane"))
 		Expect(cfg.BootstrapServer.Params.XdsPort).To(Equal(uint32(4321)))
 
-		Expect(cfg.Environment).To(Equal(kuma_cp.KubernetesEnvironment))
+		Expect(cfg.Environment).To(Equal(config_core.KubernetesEnvironment))
 
 		Expect(cfg.Store.Type).To(Equal(store.PostgresStore))
 		Expect(cfg.Store.Postgres.Host).To(Equal("postgres.host"))

--- a/pkg/core/bootstrap/autoconfig.go
+++ b/pkg/core/bootstrap/autoconfig.go
@@ -7,6 +7,7 @@ import (
 	"github.com/pkg/errors"
 
 	kuma_cp "github.com/Kong/kuma/pkg/config/app/kuma-cp"
+	config_core "github.com/Kong/kuma/pkg/config/core"
 	"github.com/Kong/kuma/pkg/core"
 	"github.com/Kong/kuma/pkg/tls"
 )
@@ -19,7 +20,7 @@ func autoconfigure(cfg *kuma_cp.Config) error {
 
 func autoconfigureSds(cfg *kuma_cp.Config) error {
 	// to improve UX, we want to auto-generate TLS cert for SDS if possible
-	if cfg.Environment == kuma_cp.UniversalEnvironment {
+	if cfg.Environment == config_core.UniversalEnvironment {
 		if cfg.SdsServer.TlsCertFile == "" {
 			hosts := []string{
 				cfg.BootstrapServer.Params.XdsHost,

--- a/pkg/core/bootstrap/bootstrap.go
+++ b/pkg/core/bootstrap/bootstrap.go
@@ -4,6 +4,7 @@ import (
 	"context"
 
 	kuma_cp "github.com/Kong/kuma/pkg/config/app/kuma-cp"
+	config_core "github.com/Kong/kuma/pkg/config/core"
 	"github.com/Kong/kuma/pkg/config/core/resources/store"
 	"github.com/Kong/kuma/pkg/core"
 	builtin_ca "github.com/Kong/kuma/pkg/core/ca/builtin"
@@ -59,7 +60,7 @@ func createDefaultMesh(runtime core_runtime.Runtime) error {
 	cfg := runtime.Config()
 
 	namespace := core_model.DefaultNamespace
-	if runtime.Config().Environment == kuma_cp.KubernetesEnvironment {
+	if runtime.Config().Environment == config_core.KubernetesEnvironment {
 		namespace = runtime.Config().Store.Kubernetes.SystemNamespace
 	}
 
@@ -122,9 +123,9 @@ func onStartup(runtime core_runtime.Runtime, cfg kuma_cp.Config) error {
 func initializeBootstrap(cfg kuma_cp.Config, builder *core_runtime.Builder) error {
 	var pluginName core_plugins.PluginName
 	switch cfg.Environment {
-	case kuma_cp.KubernetesEnvironment:
+	case config_core.KubernetesEnvironment:
 		pluginName = core_plugins.Kubernetes
-	case kuma_cp.UniversalEnvironment:
+	case config_core.UniversalEnvironment:
 		pluginName = core_plugins.Universal
 	default:
 		return errors.Errorf("unknown environment type %s", cfg.Environment)
@@ -197,10 +198,10 @@ func initializeDiscovery(cfg kuma_cp.Config, builder *core_runtime.Builder) erro
 	var pluginName core_plugins.PluginName
 	var pluginConfig core_plugins.PluginConfig
 	switch cfg.Environment {
-	case kuma_cp.KubernetesEnvironment:
+	case config_core.KubernetesEnvironment:
 		pluginName = core_plugins.Kubernetes
 		pluginConfig = nil
-	case kuma_cp.UniversalEnvironment:
+	case config_core.UniversalEnvironment:
 		pluginName = core_plugins.Universal
 		pluginConfig = cfg.Discovery.Universal
 	default:

--- a/pkg/sds/server/components.go
+++ b/pkg/sds/server/components.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/pkg/errors"
 
-	kuma_cp "github.com/Kong/kuma/pkg/config/app/kuma-cp"
+	config_core "github.com/Kong/kuma/pkg/config/core"
 	core_mesh "github.com/Kong/kuma/pkg/core/resources/apis/mesh"
 	core_manager "github.com/Kong/kuma/pkg/core/resources/manager"
 	core_store "github.com/Kong/kuma/pkg/core/resources/store"
@@ -47,9 +47,9 @@ func NewUniversalAuthenticator(rt core_runtime.Runtime) (sds_auth.Authenticator,
 
 func DefaultAuthenticator(rt core_runtime.Runtime) (sds_auth.Authenticator, error) {
 	switch env := rt.Config().Environment; env {
-	case kuma_cp.KubernetesEnvironment:
+	case config_core.KubernetesEnvironment:
 		return NewKubeAuthenticator(rt)
-	case kuma_cp.UniversalEnvironment:
+	case config_core.UniversalEnvironment:
 		return NewUniversalAuthenticator(rt)
 	default:
 		return nil, errors.Errorf("unable to choose SDS authenticator for environment type %q", env)

--- a/pkg/xds/context/context.go
+++ b/pkg/xds/context/context.go
@@ -5,6 +5,7 @@ import (
 	"io/ioutil"
 
 	kuma_cp "github.com/Kong/kuma/pkg/config/app/kuma-cp"
+	config_core "github.com/Kong/kuma/pkg/config/core"
 )
 
 type Context struct {
@@ -36,7 +37,7 @@ func BuildControlPlaneContext(config kuma_cp.Config) (*ControlPlaneContext, erro
 	}
 	sdsLocation := fmt.Sprintf("%s:%d", config.BootstrapServer.Params.XdsHost, config.SdsServer.GrpcPort)
 	dataplaneTokenFile := ""
-	if config.Environment == kuma_cp.KubernetesEnvironment {
+	if config.Environment == config_core.KubernetesEnvironment {
 		dataplaneTokenFile = "/var/run/secrets/kubernetes.io/serviceaccount/token"
 	}
 


### PR DESCRIPTION
changes:
* move `EnvironmentType` into `config/core` package (to make it reusable in other parts of the configuration)