### PR TITLE
kuma-cp: set TypeMeta on all k8s resources (pre-requirement for k8s Admission WebHooks to work as expected)

### DIFF
--- a/pkg/plugins/resources/k8s/native/api/v1alpha1/dataplane_insight_types_helpers.go
+++ b/pkg/plugins/resources/k8s/native/api/v1alpha1/dataplane_insight_types_helpers.go
@@ -40,6 +40,16 @@ func (l *DataplaneInsightList) GetItems() []model.KubernetesObject {
 }
 
 func init() {
-	registry.RegisterObjectType(&proto.DataplaneInsight{}, &DataplaneInsight{})
-	registry.RegisterListType(&proto.DataplaneInsight{}, &DataplaneInsightList{})
+	registry.RegisterObjectType(&proto.DataplaneInsight{}, &DataplaneInsight{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: GroupVersion.String(),
+			Kind:       "DataplaneInsight",
+		},
+	})
+	registry.RegisterListType(&proto.DataplaneInsight{}, &DataplaneInsightList{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: GroupVersion.String(),
+			Kind:       "DataplaneInsightList",
+		},
+	})
 }

--- a/pkg/plugins/resources/k8s/native/api/v1alpha1/dataplane_types_helpers.go
+++ b/pkg/plugins/resources/k8s/native/api/v1alpha1/dataplane_types_helpers.go
@@ -40,6 +40,16 @@ func (l *DataplaneList) GetItems() []model.KubernetesObject {
 }
 
 func init() {
-	registry.RegisterObjectType(&proto.Dataplane{}, &Dataplane{})
-	registry.RegisterListType(&proto.Dataplane{}, &DataplaneList{})
+	registry.RegisterObjectType(&proto.Dataplane{}, &Dataplane{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: GroupVersion.String(),
+			Kind:       "Dataplane",
+		},
+	})
+	registry.RegisterListType(&proto.Dataplane{}, &DataplaneList{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: GroupVersion.String(),
+			Kind:       "DataplaneList",
+		},
+	})
 }

--- a/pkg/plugins/resources/k8s/native/api/v1alpha1/global_type_registry_test.go
+++ b/pkg/plugins/resources/k8s/native/api/v1alpha1/global_type_registry_test.go
@@ -1,0 +1,121 @@
+package v1alpha1
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/ginkgo/extensions/table"
+	. "github.com/onsi/gomega"
+
+	proto "github.com/Kong/kuma/api/mesh/v1alpha1"
+	"github.com/Kong/kuma/pkg/plugins/resources/k8s/native/pkg/model"
+	"github.com/Kong/kuma/pkg/plugins/resources/k8s/native/pkg/registry"
+)
+
+var _ = Describe("global TypeRegistry", func() {
+
+	Context("object types", func() {
+		type testCase struct {
+			inputType    registry.ResourceType
+			expectedType model.KubernetesObject
+			expectedKind string
+		}
+
+		DescribeTable("should include all mesh types",
+			func(given testCase) {
+				// given
+				expectedAPIVersion := GroupVersion
+
+				// when
+				obj, err := registry.Global().NewObject(given.inputType)
+
+				// then
+				Expect(err).ToNot(HaveOccurred())
+				Expect(obj).ToNot(BeNil())
+				Expect(obj).To(BeAssignableToTypeOf(given.expectedType))
+				// and
+				Expect(obj.GetObjectKind().GroupVersionKind()).To(Equal(expectedAPIVersion.WithKind(given.expectedKind)))
+			},
+			Entry("Mesh", testCase{
+				inputType:    &proto.Mesh{},
+				expectedType: &Mesh{},
+				expectedKind: "Mesh",
+			}),
+			Entry("Dataplane", testCase{
+				inputType:    &proto.Dataplane{},
+				expectedType: &Dataplane{},
+				expectedKind: "Dataplane",
+			}),
+			Entry("DataplaneInsight", testCase{
+				inputType:    &proto.DataplaneInsight{},
+				expectedType: &DataplaneInsight{},
+				expectedKind: "DataplaneInsight",
+			}),
+			Entry("ProxyTemplate", testCase{
+				inputType:    &proto.ProxyTemplate{},
+				expectedType: &ProxyTemplate{},
+				expectedKind: "ProxyTemplate",
+			}),
+			Entry("TrafficPermission", testCase{
+				inputType:    &proto.TrafficPermission{},
+				expectedType: &TrafficPermission{},
+				expectedKind: "TrafficPermission",
+			}),
+			Entry("TrafficLog", testCase{
+				inputType:    &proto.TrafficLog{},
+				expectedType: &TrafficLog{},
+				expectedKind: "TrafficLog",
+			}),
+		)
+	})
+
+	Context("list types", func() {
+		type testCase struct {
+			inputType    registry.ResourceType
+			expectedType model.KubernetesList
+			expectedKind string
+		}
+
+		DescribeTable("should include all mesh types",
+			func(given testCase) {
+				// when
+				obj, err := registry.Global().NewList(given.inputType)
+
+				// then
+				Expect(err).ToNot(HaveOccurred())
+				Expect(obj).ToNot(BeNil())
+				Expect(obj).To(BeAssignableToTypeOf(given.expectedType))
+				// and
+				Expect(obj.GetObjectKind().GroupVersionKind()).To(Equal(GroupVersion.WithKind(given.expectedKind)))
+			},
+			Entry("MeshList", testCase{
+				inputType:    &proto.Mesh{},
+				expectedType: &MeshList{},
+				expectedKind: "MeshList",
+			}),
+			Entry("DataplaneList", testCase{
+				inputType:    &proto.Dataplane{},
+				expectedType: &DataplaneList{},
+				expectedKind: "DataplaneList",
+			}),
+			Entry("DataplaneInsightList", testCase{
+				inputType:    &proto.DataplaneInsight{},
+				expectedType: &DataplaneInsightList{},
+				expectedKind: "DataplaneInsightList",
+			}),
+			Entry("ProxyTemplateList", testCase{
+				inputType:    &proto.ProxyTemplate{},
+				expectedType: &ProxyTemplateList{},
+				expectedKind: "ProxyTemplateList",
+			}),
+			Entry("TrafficPermissionList", testCase{
+				inputType:    &proto.TrafficPermission{},
+				expectedType: &TrafficPermissionList{},
+				expectedKind: "TrafficPermissionList",
+			}),
+			Entry("TrafficLogList", testCase{
+				inputType:    &proto.TrafficLog{},
+				expectedType: &TrafficLogList{},
+				expectedKind: "TrafficLogList",
+			}),
+		)
+	})
+})

--- a/pkg/plugins/resources/k8s/native/api/v1alpha1/mesh_types_helpers.go
+++ b/pkg/plugins/resources/k8s/native/api/v1alpha1/mesh_types_helpers.go
@@ -40,6 +40,16 @@ func (l *MeshList) GetItems() []model.KubernetesObject {
 }
 
 func init() {
-	registry.RegisterObjectType(&proto.Mesh{}, &Mesh{})
-	registry.RegisterListType(&proto.Mesh{}, &MeshList{})
+	registry.RegisterObjectType(&proto.Mesh{}, &Mesh{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: GroupVersion.String(),
+			Kind:       "Mesh",
+		},
+	})
+	registry.RegisterListType(&proto.Mesh{}, &MeshList{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: GroupVersion.String(),
+			Kind:       "MeshList",
+		},
+	})
 }

--- a/pkg/plugins/resources/k8s/native/api/v1alpha1/proxytemplate_types_helpers.go
+++ b/pkg/plugins/resources/k8s/native/api/v1alpha1/proxytemplate_types_helpers.go
@@ -40,6 +40,16 @@ func (l *ProxyTemplateList) GetItems() []model.KubernetesObject {
 }
 
 func init() {
-	registry.RegisterObjectType(&proto.ProxyTemplate{}, &ProxyTemplate{})
-	registry.RegisterListType(&proto.ProxyTemplate{}, &ProxyTemplateList{})
+	registry.RegisterObjectType(&proto.ProxyTemplate{}, &ProxyTemplate{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: GroupVersion.String(),
+			Kind:       "ProxyTemplate",
+		},
+	})
+	registry.RegisterListType(&proto.ProxyTemplate{}, &ProxyTemplateList{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: GroupVersion.String(),
+			Kind:       "ProxyTemplateList",
+		},
+	})
 }

--- a/pkg/plugins/resources/k8s/native/api/v1alpha1/trafficlogging_types_helpers.go
+++ b/pkg/plugins/resources/k8s/native/api/v1alpha1/trafficlogging_types_helpers.go
@@ -40,6 +40,16 @@ func (l *TrafficLogList) GetItems() []model.KubernetesObject {
 }
 
 func init() {
-	registry.RegisterObjectType(&proto.TrafficLog{}, &TrafficLog{})
-	registry.RegisterListType(&proto.TrafficLog{}, &TrafficLogList{})
+	registry.RegisterObjectType(&proto.TrafficLog{}, &TrafficLog{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: GroupVersion.String(),
+			Kind:       "TrafficLog",
+		},
+	})
+	registry.RegisterListType(&proto.TrafficLog{}, &TrafficLogList{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: GroupVersion.String(),
+			Kind:       "TrafficLogList",
+		},
+	})
 }

--- a/pkg/plugins/resources/k8s/native/api/v1alpha1/trafficpermission_types_helpers.go
+++ b/pkg/plugins/resources/k8s/native/api/v1alpha1/trafficpermission_types_helpers.go
@@ -40,6 +40,16 @@ func (l *TrafficPermissionList) GetItems() []model.KubernetesObject {
 }
 
 func init() {
-	registry.RegisterObjectType(&proto.TrafficPermission{}, &TrafficPermission{})
-	registry.RegisterListType(&proto.TrafficPermission{}, &TrafficPermissionList{})
+	registry.RegisterObjectType(&proto.TrafficPermission{}, &TrafficPermission{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: GroupVersion.String(),
+			Kind:       "TrafficPermission",
+		},
+	})
+	registry.RegisterListType(&proto.TrafficPermission{}, &TrafficPermissionList{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: GroupVersion.String(),
+			Kind:       "TrafficPermissionList",
+		},
+	})
 }


### PR DESCRIPTION
changes:
* set TypeMeta on prototype k8s resource (all other k8s resources get created by calling `DeepClone()` on them)