### PR TITLE
kuma-cp: introduce RuntimePlugin

### DIFF
--- a/pkg/core/plugins/interfaces.go
+++ b/pkg/core/plugins/interfaces.go
@@ -40,3 +40,10 @@ type DiscoveryPlugin interface {
 	Plugin
 	NewDiscoverySource(PluginContext, PluginConfig) (core_discovery.DiscoverySource, error)
 }
+
+// RuntimePlugin is responsible for registering environment-specific components,
+// e.g. Kubernetes admission web hooks.
+type RuntimePlugin interface {
+	Plugin
+	Customize(core_runtime.Runtime) error
+}


### PR DESCRIPTION
changes:
* introduce a new plugin type - `RuntimePlugin` - which can be used to add arbitrary environment-specific features (e.g., Admission WebHook Server in `k8s` environment)