### PR TITLE
ci: make Bintray release repositories configurable

### DIFF
--- a/tools/releases/distros.sh
+++ b/tools/releases/distros.sh
@@ -11,7 +11,7 @@ DISTRIBUTIONS=(debian:linux ubuntu:linux rhel:linux centos:linux darwin:darwin)
 
 BINTRAY_ENDPOINT="https://api.bintray.com/"
 BINTRAY_SUBJECT="kong"
-BINTRAY_REPOSITORY="kuma"
+[ -z "$BINTRAY_REPOSITORY" ] && BINTRAY_REPOSITORY="kuma"
 
 
 function msg_green {

--- a/tools/releases/docker.sh
+++ b/tools/releases/docker.sh
@@ -2,7 +2,7 @@
 
 set -e
 
-KUMA_DOCKER_REPO="kong-docker-kuma-docker.bintray.io"
+[ -z "$KUMA_DOCKER_REPO" ] && KUMA_DOCKER_REPO="kong-docker-kuma-docker.bintray.io"
 KUMA_COMPONENTS=("kuma-cp" "kuma-dp" "kuma-injector" "kuma-tcp-echo")
 
 function msg_green {


### PR DESCRIPTION
changes:
* use `BINTRAY_REPOSITORY` env var to override repo with `*.tar.gz` files
* use `KUMA_DOCKER_REPO` env var to override repo with Docker images
