### PR TITLE
kuma-cp: fix an issue with Access Log Server on Kubernetes by replacing Google gRPC client with Envoy gRPC client

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,10 +2,13 @@
 
 ## [0.2.0]
 
-> Released on 2019/10/01
+> Released on 2019/10/02
 
 Changes:
 
+* Fix an issue with `Access Log Server` (integrated into `kuma-dp`) on Kubernetes
+  by replacing `Google gRPC client` with `Envoy gRPC client`
+  [#306](https://github.com/Kong/kuma/pull/306)
 * Settings of a `kuma-sidecar` container, such as `ReadinessProbe`, `LivenessProbe` and `Resources`,
   are now configurable
   [#304](https://github.com/Kong/kuma/pull/304)

--- a/pkg/xds/bootstrap/generator.go
+++ b/pkg/xds/bootstrap/generator.go
@@ -3,6 +3,7 @@ package bootstrap
 import (
 	"bytes"
 	"context"
+	"fmt"
 	"text/template"
 
 	"github.com/Kong/kuma/pkg/xds/bootstrap/rest"
@@ -53,12 +54,14 @@ func (b *bootstrapGenerator) Generate(ctx context.Context, request rest.Bootstra
 	if request.AdminPort != 0 {
 		adminPort = request.AdminPort
 	}
+	accessLogPipe := fmt.Sprintf("/tmp/kuma-access-logs-%s-%s-%s.sock", dataplane.Meta.GetName(), dataplane.Meta.GetMesh(), dataplane.Meta.GetNamespace())
 	params := configParameters{
-		Id:        proxyId.String(),
-		Service:   service,
-		AdminPort: adminPort,
-		XdsHost:   b.config.XdsHost,
-		XdsPort:   b.config.XdsPort,
+		Id:            proxyId.String(),
+		Service:       service,
+		AdminPort:     adminPort,
+		XdsHost:       b.config.XdsHost,
+		XdsPort:       b.config.XdsPort,
+		AccessLogPipe: accessLogPipe,
 	}
 	log.WithValues("params", params).Info("Generating bootstrap config")
 	return b.ConfigForParameters(params)

--- a/pkg/xds/bootstrap/template.go
+++ b/pkg/xds/bootstrap/template.go
@@ -1,11 +1,12 @@
 package bootstrap
 
 type configParameters struct {
-	Id        string
-	Service   string
-	AdminPort uint32
-	XdsHost   string
-	XdsPort   uint32
+	Id            string
+	Service       string
+	AdminPort     uint32
+	XdsHost       string
+	XdsPort       uint32
+	AccessLogPipe string
 }
 
 const configTemplate string = `
@@ -52,4 +53,21 @@ static_resources:
               socket_address:
                 address: {{ .XdsHost }}
                 port_value: {{ .XdsPort }}
+  - name: access_log_sink
+    connect_timeout: 1s
+    type: STATIC
+    lb_policy: ROUND_ROBIN
+    http2_protocol_options: {}
+    upstream_connection_options:
+      # configure a TCP keep-alive to detect and reconnect to the admin
+      # server in the event of a TCP socket half open connection
+      tcp_keepalive: {}
+    load_assignment:
+      cluster_name: access_log_sink
+      endpoints:
+      - lb_endpoints:
+        - endpoint:
+            address:
+              pipe:
+                path: {{ .AccessLogPipe }}
 `

--- a/pkg/xds/bootstrap/testdata/bootstrap.golden.yaml
+++ b/pkg/xds/bootstrap/testdata/bootstrap.golden.yaml
@@ -28,3 +28,17 @@ staticResources:
       type: STRICT_DNS
       upstreamConnectionOptions:
         tcpKeepalive: {}
+    - connectTimeout: 1s
+      http2ProtocolOptions: {}
+      loadAssignment:
+        clusterName: access_log_sink
+        endpoints:
+          - lbEndpoints:
+              - endpoint:
+                  address:
+                    pipe:
+                      path: /tmp/kuma-access-logs-dp-1-default-default.sock
+      name: access_log_sink
+      type: STATIC
+      upstreamConnectionOptions:
+        tcpKeepalive: {}

--- a/pkg/xds/bootstrap/testdata/bootstrap.overridden.golden.yaml
+++ b/pkg/xds/bootstrap/testdata/bootstrap.overridden.golden.yaml
@@ -34,3 +34,17 @@ staticResources:
       type: STRICT_DNS
       upstreamConnectionOptions:
         tcpKeepalive: {}
+    - connectTimeout: 1s
+      http2ProtocolOptions: {}
+      loadAssignment:
+        clusterName: access_log_sink
+        endpoints:
+          - lbEndpoints:
+              - endpoint:
+                  address:
+                    pipe:
+                      path: /tmp/kuma-access-logs-dp-1-default-default.sock
+      name: access_log_sink
+      type: STATIC
+      upstreamConnectionOptions:
+        tcpKeepalive: {}

--- a/pkg/xds/envoy/envoy_test.go
+++ b/pkg/xds/envoy/envoy_test.go
@@ -799,9 +799,8 @@ name: inbound:192.168.0.1:8080
                     '@type': type.googleapis.com/envoy.config.accesslog.v2.HttpGrpcAccessLogConfig
                     commonConfig:
                       grpcService:
-                        googleGrpc:
-                          statPrefix: grpc_service
-                          targetUri: unix:///tmp/kuma-access-logs-backend-example.sock
+                        envoyGrpc:
+                          clusterName: access_log_sink
                       logName: 127.0.0.1:1234;custom format
                 cluster: outbound:127.0.0.1:18080
                 statPrefix: outbound:127.0.0.1:18080


### PR DESCRIPTION
### Summary

* `Access Log Server` integrated into `kuma-dp` didn't work on Kubernetes
* Prolonged troubleshooting didn't reveal a root cause
* Replacing `Google gRPC client` with `Envoy gRPC client` was a hunch, but apparently it works