### PR TITLE
kuma-cp: fix an issue with Access Log Server on k8s (`kuma-cp` was configuring Envoy to use a Unix socket other than `kuma-dp` was actually listening on)

### DIFF
--- a/pkg/xds/bootstrap/generator.go
+++ b/pkg/xds/bootstrap/generator.go
@@ -54,7 +54,7 @@ func (b *bootstrapGenerator) Generate(ctx context.Context, request rest.Bootstra
 	if request.AdminPort != 0 {
 		adminPort = request.AdminPort
 	}
-	accessLogPipe := fmt.Sprintf("/tmp/kuma-access-logs-%s-%s-%s.sock", dataplane.Meta.GetName(), dataplane.Meta.GetMesh(), dataplane.Meta.GetNamespace())
+	accessLogPipe := fmt.Sprintf("/tmp/kuma-access-logs-%s-%s.sock", request.Name, request.Mesh)
 	params := configParameters{
 		Id:            proxyId.String(),
 		Service:       service,

--- a/pkg/xds/bootstrap/server_test.go
+++ b/pkg/xds/bootstrap/server_test.go
@@ -2,6 +2,12 @@ package bootstrap
 
 import (
 	"context"
+	"io/ioutil"
+	"net/http"
+	"path/filepath"
+	"strconv"
+	"strings"
+
 	mesh_proto "github.com/Kong/kuma/api/mesh/v1alpha1"
 	xds_config "github.com/Kong/kuma/pkg/config/xds"
 	"github.com/Kong/kuma/pkg/core/resources/apis/mesh"
@@ -12,11 +18,6 @@ import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/ginkgo/extensions/table"
 	. "github.com/onsi/gomega"
-	"io/ioutil"
-	"net/http"
-	"path/filepath"
-	"strconv"
-	"strings"
 )
 
 var _ = Describe("Bootstrap Server", func() {
@@ -102,11 +103,11 @@ var _ = Describe("Bootstrap Server", func() {
 		},
 		Entry("minimal data provided (universal)", testCase{
 			body:               `{ "mesh": "default", "name": "dp-1" }`,
-			expectedConfigFile: "bootstrap.golden.yaml",
+			expectedConfigFile: "bootstrap.universal.golden.yaml",
 		}),
 		Entry("minimal data provided (k8s)", testCase{
 			body:               `{ "mesh": "default", "name": "dp-1.default" }`,
-			expectedConfigFile: "bootstrap.golden.yaml",
+			expectedConfigFile: "bootstrap.k8s.golden.yaml",
 		}),
 		Entry("overridden admin port", testCase{
 			body:               `{ "mesh": "default", "name": "dp-1.default", "adminPort": 1234 }`,

--- a/pkg/xds/bootstrap/testdata/bootstrap.k8s.golden.yaml
+++ b/pkg/xds/bootstrap/testdata/bootstrap.k8s.golden.yaml
@@ -37,7 +37,7 @@ staticResources:
               - endpoint:
                   address:
                     pipe:
-                      path: /tmp/kuma-access-logs-dp-1-default-default.sock
+                      path: /tmp/kuma-access-logs-dp-1.default-default.sock
       name: access_log_sink
       type: STATIC
       upstreamConnectionOptions:

--- a/pkg/xds/bootstrap/testdata/bootstrap.universal.golden.yaml
+++ b/pkg/xds/bootstrap/testdata/bootstrap.universal.golden.yaml
@@ -1,9 +1,3 @@
-admin:
-  accessLogPath: /dev/null
-  address:
-    socketAddress:
-      address: 127.0.0.1
-      portValue: 1234
 dynamicResources:
   adsConfig:
     apiType: GRPC
@@ -43,7 +37,7 @@ staticResources:
               - endpoint:
                   address:
                     pipe:
-                      path: /tmp/kuma-access-logs-dp-1.default-default.sock
+                      path: /tmp/kuma-access-logs-dp-1-default.sock
       name: access_log_sink
       type: STATIC
       upstreamConnectionOptions:


### PR DESCRIPTION
changes:
* make sure that `kuma-dp` and `kuma-cp` use the same name for Unix socket