### PR TITLE
feat(kumacp) Delete related mesh resources

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -365,7 +365,7 @@ test/kuma-injector: test ## Dev: Run 'kuma injector' tests only
 
 integration: ## Dev: Run integration tests
 	mkdir -p "$(shell dirname "$(COVERAGE_INTEGRATION_PROFILE)")"
-	tools/test/run-integration-tests.sh '$(GO_TEST) -race -covermode=atomic -tags=integration -count=1 -coverpkg=./... -coverprofile=$(COVERAGE_INTEGRATION_PROFILE) $(PKG_LIST)'
+	tools/test/run-integration-tests.sh '$(GO_TEST) $(GO_TEST_OPTS) -race -covermode=atomic -tags=integration -count=1 -coverpkg=./... -coverprofile=$(COVERAGE_INTEGRATION_PROFILE) $(PKG_LIST)'
 	go tool cover -html="$(COVERAGE_INTEGRATION_PROFILE)" -o "$(COVERAGE_INTEGRATION_REPORT_HTML)"
 
 build: build/kuma-cp build/kuma-dp build/kumactl build/kuma-injector build/kuma-tcp-echo ## Dev: Build all binaries

--- a/pkg/core/managers/apis/mesh/mesh_manager.go
+++ b/pkg/core/managers/apis/mesh/mesh_manager.go
@@ -75,6 +75,8 @@ func (m *meshManager) Create(ctx context.Context, resource core_model.Resource, 
 }
 
 func (m *meshManager) Delete(ctx context.Context, resource core_model.Resource, fs ...core_store.DeleteOptionsFunc) error {
+	opts := core_store.NewDeleteOptions(fs...)
+
 	mesh, err := m.mesh(resource)
 	if err != nil {
 		return err
@@ -88,6 +90,10 @@ func (m *meshManager) Delete(ctx context.Context, resource core_model.Resource, 
 	name := core_store.NewDeleteOptions(fs...).Mesh
 	if err := m.builtinCaManager.Delete(ctx, name); err != nil {
 		return errors.Wrapf(err, "failed to delete Builtin CA for a given mesh")
+	}
+	// delete associated resources
+	if err := m.store.DeleteMany(ctx, core_store.DeleteManyByMesh(opts.Name)); err != nil {
+		return errors.Wrapf(err, "failed to delete associated resources")
 	}
 	return nil
 }

--- a/pkg/core/managers/apis/mesh/mesh_manager_suite_test.go
+++ b/pkg/core/managers/apis/mesh/mesh_manager_suite_test.go
@@ -1,0 +1,13 @@
+package mesh
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+func TestMeshManager(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Mesh Manager Suite")
+}

--- a/pkg/core/managers/apis/mesh/mesh_manager_test.go
+++ b/pkg/core/managers/apis/mesh/mesh_manager_test.go
@@ -1,0 +1,87 @@
+package mesh
+
+import (
+	"context"
+	"github.com/Kong/kuma/pkg/core/ca/builtin"
+	core_mesh "github.com/Kong/kuma/pkg/core/resources/apis/mesh"
+	"github.com/Kong/kuma/pkg/core/resources/manager"
+	"github.com/Kong/kuma/pkg/core/resources/model"
+	"github.com/Kong/kuma/pkg/core/resources/store"
+	"github.com/Kong/kuma/pkg/core/secrets/cipher"
+	secrets_manager "github.com/Kong/kuma/pkg/core/secrets/manager"
+	secrets_store "github.com/Kong/kuma/pkg/core/secrets/store"
+	"github.com/Kong/kuma/pkg/plugins/resources/memory"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("Mesh Manager", func() {
+
+	const namespace = "default"
+
+	var resManager manager.ResourceManager
+	var resStore store.ResourceStore
+	var caManager builtin.BuiltinCaManager
+
+	BeforeEach(func() {
+		resStore = memory.NewStore()
+		caManager = builtin.NewBuiltinCaManager(secrets_manager.NewSecretManager(secrets_store.NewSecretStore(resStore), cipher.None()))
+		resManager = NewMeshManager(resStore, caManager)
+	})
+
+	It("Create() should also create a built-in CA", func() {
+		// given
+		meshName := "mesh-1"
+		resKey := model.ResourceKey{
+			Mesh:      meshName,
+			Namespace: namespace,
+			Name:      meshName,
+		}
+
+		// when
+		mesh := core_mesh.MeshResource{}
+		err := resManager.Create(context.Background(), &mesh, store.CreateBy(resKey))
+
+		// then
+		Expect(err).ToNot(HaveOccurred())
+
+		// and built-in CA is created
+		certs, err := caManager.GetRootCerts(context.Background(), meshName)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(certs).To(HaveLen(1))
+	})
+
+	It("Delete() should delete all associated resources", func() {
+		// given mesh
+		meshName := "mesh-1"
+
+		mesh := core_mesh.MeshResource{}
+		resKey := model.ResourceKey{
+			Mesh:      meshName,
+			Namespace: namespace,
+			Name:      meshName,
+		}
+		err := resManager.Create(context.Background(), &mesh, store.CreateBy(resKey))
+		Expect(err).ToNot(HaveOccurred())
+
+		// and resource associated with it
+		dp := core_mesh.DataplaneResource{}
+		err = resStore.Create(context.Background(), &dp, store.CreateByKey(namespace, "dp-1", meshName))
+		Expect(err).ToNot(HaveOccurred())
+
+		// when mesh is deleted
+		err = resManager.Delete(context.Background(), &mesh, store.DeleteBy(resKey))
+
+		// then
+		Expect(err).ToNot(HaveOccurred())
+
+		// and resource is deleted
+		err = resStore.Get(context.Background(), &core_mesh.DataplaneResource{}, store.GetByKey(namespace, "dp-1", meshName))
+		Expect(store.IsResourceNotFound(err)).To(BeTrue())
+
+		// and built-in mesh CA is deleted
+		_, err = caManager.GetRootCerts(context.Background(), meshName)
+		Expect(err).ToNot(BeNil())
+		Expect(err.Error()).To(Equal("failed to load CA key pair for Mesh \"mesh-1\": Resource not found: type=\"Secret\" namespace=\"default\" name=\"builtinca.mesh-1\" mesh=\"mesh-1\""))
+	})
+})

--- a/pkg/core/resources/store/options.go
+++ b/pkg/core/resources/store/options.go
@@ -73,6 +73,26 @@ func DeleteByKey(ns, name, mesh string) DeleteOptionsFunc {
 	}
 }
 
+type DeleteManyOptions struct {
+	Mesh string
+}
+
+type DeleteManyOptionsFunc func(*DeleteManyOptions)
+
+func NewDeleteManyOptions(fs ...DeleteManyOptionsFunc) *DeleteManyOptions {
+	opts := &DeleteManyOptions{}
+	for _, f := range fs {
+		f(opts)
+	}
+	return opts
+}
+
+func DeleteManyByMesh(mesh string) DeleteManyOptionsFunc {
+	return func(opts *DeleteManyOptions) {
+		opts.Mesh = mesh
+	}
+}
+
 type GetOptions struct {
 	Namespace string
 	Name      string

--- a/pkg/core/resources/store/store.go
+++ b/pkg/core/resources/store/store.go
@@ -13,6 +13,7 @@ type ResourceStore interface {
 	Create(context.Context, model.Resource, ...CreateOptionsFunc) error
 	Update(context.Context, model.Resource, ...UpdateOptionsFunc) error
 	Delete(context.Context, model.Resource, ...DeleteOptionsFunc) error
+	DeleteMany(context.Context, ...DeleteManyOptionsFunc) error
 	Get(context.Context, model.Resource, ...GetOptionsFunc) error
 	List(context.Context, model.ResourceList, ...ListOptionsFunc) error
 }
@@ -87,6 +88,9 @@ func (s *strictResourceStore) Delete(ctx context.Context, r model.Resource, fs .
 		}
 	}
 	return s.delegate.Delete(ctx, r, fs...)
+}
+func (s *strictResourceStore) DeleteMany(ctx context.Context, fs ...DeleteManyOptionsFunc) error {
+	return s.delegate.DeleteMany(ctx, fs...)
 }
 func (s *strictResourceStore) Get(ctx context.Context, r model.Resource, fs ...GetOptionsFunc) error {
 	if r == nil {

--- a/pkg/plugins/resources/k8s/k8s_suite_test.go
+++ b/pkg/plugins/resources/k8s/k8s_suite_test.go
@@ -30,7 +30,8 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 
 	// +kubebuilder:scaffold:imports
-	sample_v1alpha1 "github.com/Kong/kuma/pkg/plugins/resources/k8s/native/test/api/sample/v1alpha1"
+	mesh_proto "github.com/Kong/kuma/pkg/plugins/resources/k8s/native/api/v1alpha1"
+	sample_proto "github.com/Kong/kuma/pkg/plugins/resources/k8s/native/test/api/sample/v1alpha1"
 )
 
 var k8sClient client.Client
@@ -50,14 +51,20 @@ var _ = BeforeSuite(func(done Done) {
 
 	By("bootstrapping test environment")
 	testEnv = &envtest.Environment{
-		CRDDirectoryPaths: []string{filepath.Join("native", "test", "config", "crd", "bases")},
+		CRDDirectoryPaths: []string{
+			filepath.Join("native", "test", "config", "crd", "bases"),
+			filepath.Join("native", "config", "crd", "bases"),
+		},
 	}
 
 	cfg, err := testEnv.Start()
 	Expect(err).ToNot(HaveOccurred())
 	Expect(cfg).ToNot(BeNil())
 
-	err = sample_v1alpha1.AddToScheme(k8sClientScheme)
+	err = sample_proto.AddToScheme(k8sClientScheme)
+	Expect(err).NotTo(HaveOccurred())
+
+	err = mesh_proto.AddToScheme(k8sClientScheme)
 	Expect(err).NotTo(HaveOccurred())
 
 	// +kubebuilder:scaffold:scheme

--- a/pkg/plugins/resources/k8s/native/pkg/registry/interfaces.go
+++ b/pkg/plugins/resources/k8s/native/pkg/registry/interfaces.go
@@ -10,6 +10,8 @@ type ResourceType = proto.Message
 type TypeRegistry interface {
 	RegisterObjectType(ResourceType, model.KubernetesObject) error
 	RegisterListType(ResourceType, model.KubernetesList) error
+	RegisteredObjects() []model.KubernetesObject
+	RegisteredLists() []model.KubernetesList
 
 	NewObject(ResourceType) (model.KubernetesObject, error)
 	NewList(ResourceType) (model.KubernetesList, error)

--- a/pkg/plugins/resources/k8s/native/pkg/registry/registry.go
+++ b/pkg/plugins/resources/k8s/native/pkg/registry/registry.go
@@ -20,6 +20,22 @@ type typeRegistry struct {
 	objectListTypes map[string]model.KubernetesList
 }
 
+func (r *typeRegistry) RegisteredObjects() []model.KubernetesObject {
+	var objs []model.KubernetesObject
+	for _, obj := range r.objectTypes {
+		objs = append(objs, obj.DeepCopyObject().(model.KubernetesObject))
+	}
+	return objs
+}
+
+func (r *typeRegistry) RegisteredLists() []model.KubernetesList {
+	var lists []model.KubernetesList
+	for _, list := range r.objectListTypes {
+		lists = append(lists, list.DeepCopyObject().(model.KubernetesList))
+	}
+	return lists
+}
+
 func (r *typeRegistry) RegisterObjectType(typ ResourceType, obj model.KubernetesObject) error {
 	name := proto.MessageName(typ)
 	if previous, ok := r.objectTypes[name]; ok {

--- a/pkg/plugins/resources/k8s/store_template_test.go
+++ b/pkg/plugins/resources/k8s/store_template_test.go
@@ -4,8 +4,10 @@ import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 
+	mesh_proto "github.com/Kong/kuma/api/mesh/v1alpha1"
 	"github.com/Kong/kuma/pkg/core/resources/store"
 	"github.com/Kong/kuma/pkg/plugins/resources/k8s"
+	mesh_k8s "github.com/Kong/kuma/pkg/plugins/resources/k8s/native/api/v1alpha1"
 	k8s_registry "github.com/Kong/kuma/pkg/plugins/resources/k8s/native/pkg/registry"
 	sample_k8s "github.com/Kong/kuma/pkg/plugins/resources/k8s/native/test/api/sample/v1alpha1"
 	sample_proto "github.com/Kong/kuma/pkg/test/apis/sample/v1alpha1"
@@ -15,7 +17,9 @@ var _ = Describe("KubernetesStore template", func() {
 
 	store.ExecuteStoreTests(func() store.ResourceStore {
 		kubeTypes := k8s_registry.NewTypeRegistry()
+		Expect(kubeTypes.RegisterObjectType(&mesh_proto.Dataplane{}, &mesh_k8s.Dataplane{})).To(Succeed())
 		Expect(kubeTypes.RegisterObjectType(&sample_proto.TrafficRoute{}, &sample_k8s.TrafficRoute{})).To(Succeed())
+		Expect(kubeTypes.RegisterListType(&mesh_proto.Dataplane{}, &mesh_k8s.DataplaneList{})).To(Succeed())
 		Expect(kubeTypes.RegisterListType(&sample_proto.TrafficRoute{}, &sample_k8s.TrafficRouteList{})).To(Succeed())
 
 		ks := &k8s.KubernetesStore{
@@ -25,6 +29,7 @@ var _ = Describe("KubernetesStore template", func() {
 					KubeTypes: kubeTypes,
 				},
 			},
+			TypeRegistry: kubeTypes,
 		}
 		s := store.NewStrictResourceStore(ks)
 		return s

--- a/pkg/plugins/resources/memory/store.go
+++ b/pkg/plugins/resources/memory/store.go
@@ -151,6 +151,21 @@ func (c *memoryStore) Delete(_ context.Context, r model.Resource, fs ...store.De
 	}
 	return nil
 }
+func (c *memoryStore) DeleteMany(_ context.Context, fs ...store.DeleteManyOptionsFunc) error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	opts := store.NewDeleteManyOptions(fs...)
+
+	retained := memoryStoreRecords{}
+	for _, record := range c.records {
+		if opts.Mesh != "" && opts.Mesh != record.Mesh {
+			retained = append(retained, record)
+		}
+	}
+	c.records = retained
+	return nil
+}
 
 func (c *memoryStore) Get(_ context.Context, r model.Resource, fs ...store.GetOptionsFunc) error {
 	c.mu.RLock()

--- a/pkg/plugins/resources/postgres/store.go
+++ b/pkg/plugins/resources/postgres/store.go
@@ -127,6 +127,20 @@ func (r *postgresResourceStore) Delete(_ context.Context, resource model.Resourc
 	return nil
 }
 
+func (r *postgresResourceStore) DeleteMany(ctx context.Context, fs ...store.DeleteManyOptionsFunc) error {
+	opts := store.NewDeleteManyOptions(fs...)
+	statement := `DELETE FROM resources`
+	var statementArgs []interface{}
+	if opts.Mesh != "" {
+		statement += ` WHERE mesh=$1`
+		statementArgs = append(statementArgs, opts.Mesh)
+	}
+	if _, err := r.db.Exec(statement, statementArgs...); err != nil {
+		return errors.Wrapf(err, "failed to execute query: %s", statement)
+	}
+	return nil
+}
+
 func (r *postgresResourceStore) Get(_ context.Context, resource model.Resource, fs ...store.GetOptionsFunc) error {
 	opts := store.NewGetOptions(fs...)
 

--- a/pkg/plugins/resources/remote/store.go
+++ b/pkg/plugins/resources/remote/store.go
@@ -89,6 +89,9 @@ func (s *remoteStore) upsert(ctx context.Context, res model.Resource, meta rest.
 func (s *remoteStore) Delete(context.Context, model.Resource, ...store.DeleteOptionsFunc) error {
 	return errors.Errorf("not implemented yet")
 }
+func (s *remoteStore) DeleteMany(context.Context, ...store.DeleteManyOptionsFunc) error {
+	return errors.Errorf("not implemented yet")
+}
 func (s *remoteStore) Get(ctx context.Context, res model.Resource, fs ...store.GetOptionsFunc) error {
 	resourceApi, err := s.api.GetResourceApi(res.GetType())
 	if err != nil {

--- a/pkg/plugins/runtime/k8s/plugin.go
+++ b/pkg/plugins/runtime/k8s/plugin.go
@@ -73,6 +73,7 @@ func addMeshReconciler(mgr kube_ctrl.Manager, rt core_runtime.Runtime) error {
 		Converter:        k8s_resources.DefaultConverter(),
 		BuiltinCaManager: rt.BuiltinCaManager(),
 		SystemNamespace:  rt.Config().Store.Kubernetes.SystemNamespace,
+		ResourceManager:  rt.ResourceManager(),
 	}
 	return reconciler.SetupWithManager(mgr)
 }


### PR DESCRIPTION
### Summary

Delete related mesh resources when mesh entity is deleted.
On K8S there is no option to delete many entities with given field, that's why we retrieve all of them and filter in memory.

### Full changelog

* Implement removing related mesh resources

### Issues resolved

Fix #191
