### PR TITLE
license: use proper LICENSE and NOTICE files

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -1,0 +1,4 @@
+Kuma
+Copyright 2019 Kong Inc.
+
+This product includes software developed at Kong Inc (https://konghq.com/).

--- a/tools/releases/dockerfiles/Dockerfile.kuma-cp
+++ b/tools/releases/dockerfiles/Dockerfile.kuma-cp
@@ -7,6 +7,7 @@ ADD $KUMA_ROOT/pkg/config/app/kuma-cp/kuma-cp.defaults.yaml /etc/kuma
 
 RUN mkdir /kuma
 COPY $KUMA_ROOT/tools/releases/templates/LICENSE /kuma
+COPY $KUMA_ROOT/tools/releases/templates/NOTICE /kuma
 COPY $KUMA_ROOT/tools/releases/templates/README /kuma
 
 USER nobody:nobody

--- a/tools/releases/dockerfiles/Dockerfile.kuma-dp
+++ b/tools/releases/dockerfiles/Dockerfile.kuma-dp
@@ -5,6 +5,7 @@ ADD $KUMA_ROOT/build/artifacts-linux-amd64/kuma-dp/kuma-dp /usr/bin
 
 RUN mkdir /kuma
 COPY $KUMA_ROOT/tools/releases/templates/LICENSE /kuma
+COPY $KUMA_ROOT/tools/releases/templates/NOTICE /kuma
 COPY $KUMA_ROOT/tools/releases/templates/README /kuma
 
 USER nobody:nobody

--- a/tools/releases/dockerfiles/Dockerfile.kuma-injector
+++ b/tools/releases/dockerfiles/Dockerfile.kuma-injector
@@ -4,6 +4,7 @@ ADD $KUMA_ROOT/build/artifacts-linux-amd64/kuma-injector/kuma-injector /usr/bin
 
 RUN mkdir /kuma
 COPY $KUMA_ROOT/tools/releases/templates/LICENSE /kuma
+COPY $KUMA_ROOT/tools/releases/templates/NOTICE /kuma
 COPY $KUMA_ROOT/tools/releases/templates/README /kuma
 
 USER nobody:nobody

--- a/tools/releases/dockerfiles/Dockerfile.kuma-tcp-echo
+++ b/tools/releases/dockerfiles/Dockerfile.kuma-tcp-echo
@@ -4,6 +4,7 @@ ADD $KUMA_ROOT/build/artifacts-linux-amd64/kuma-tcp-echo/kuma-tcp-echo /usr/bin
 
 RUN mkdir /kuma
 COPY $KUMA_ROOT/tools/releases/templates/LICENSE /kuma
+COPY $KUMA_ROOT/tools/releases/templates/NOTICE /kuma
 COPY $KUMA_ROOT/tools/releases/templates/README /kuma
 
 USER nobody:nobody

--- a/tools/releases/templates/LICENSE
+++ b/tools/releases/templates/LICENSE
@@ -187,7 +187,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright 2019 Kong Inc.
+   Copyright [yyyy] [name of copyright owner]
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.
@@ -200,4 +200,3 @@
    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
    See the License for the specific language governing permissions and
    limitations under the License.
-

--- a/tools/releases/templates/NOTICE
+++ b/tools/releases/templates/NOTICE
@@ -1,0 +1,4 @@
+Kuma
+Copyright 2019 Kong Inc.
+
+This product includes software developed at Kong Inc (https://konghq.com/).

--- a/tools/releases/templates/README
+++ b/tools/releases/templates/README
@@ -4,6 +4,7 @@ Welcome to Kuma!
 
 This folder contains your download of Kuma:
 ├── LICENSE
+├── NOTICE
 ├── README
 ├── bin
 │   ├── envoy


### PR DESCRIPTION
### Summary

* use proper `LICENSE` and `NOTICE` files required by the Apache License v2.0 (according to http://www.apache.org/dev/apply-license.html#new)

### Issues resolved

Fix #320
