### PR TITLE
kuma-cp: SDS server should support DiscoveryRequests with an empty list of resource names

### DIFF
--- a/pkg/sds/server/sds.go
+++ b/pkg/sds/server/sds.go
@@ -185,6 +185,13 @@ func (s *server) process(stream stream, reqCh <-chan *envoy.DiscoveryRequest, de
 				}
 			}
 
+			if len(req.ResourceNames) == 0 {
+				// Do not respond to SDS requests with an empty list of resource names.
+				// In practice, such requests can be observed when Envoy is removing
+				// Listeners and Clusters with TLS configuration that refers to SDS.
+				continue
+			}
+
 			if err := s.validateSdsRequest(&state, req); err != nil {
 				return err
 			}


### PR DESCRIPTION
### Summary

* `SDS` server should support `DiscoveryRequests` with an empty list of resource names

### Issues resolved

Fix #328
