### PR TITLE
ci: make `clang-format` an optional tool

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -104,11 +104,7 @@ jobs:
         command: |
           export PATH=$HOME/go/bin:$PATH
           make dev/tools
-    - run:
-        name: "Install check tools (clang-format, ...)"
-        # `clang-format` is used to format `*.proto` files
-        command: |
-          brew install clang-format
+    # Do NOT install `clang-format` on Mac since it takes unreasonable amount of time
     - run:
         name: "Run code generators (go generate, protoc, ...) and code checks (go fmt, go vet, ...)"
         command: |

--- a/Makefile
+++ b/Makefile
@@ -335,7 +335,7 @@ fmt/go: ## Dev: Run go fmt
 	make fmt -C pkg/plugins/resources/k8s/native
 
 fmt/proto: ## Dev: Run clang-format on .proto files
-	find . -name '*.proto' | xargs -L 1 $(CLANG_FORMAT_PATH) -i
+	which $(CLANG_FORMAT_PATH) && find . -name '*.proto' | xargs -L 1 $(CLANG_FORMAT_PATH) -i || true
 
 vet: ## Dev: Run go vet
 	go vet ./...


### PR DESCRIPTION
### Summary

* make `clang-format` an optional tool (which is handy for contributors)
* as part of CI, do NOT install `clang-format` on Mac since it takes unreasonable amount of time