### PR TITLE
[WIP] kuma-ctl: adds get traffic-logs name.namespace

### DIFF
--- a/app/kumactl/cmd/get/arg_regex_validation.go
+++ b/app/kumactl/cmd/get/arg_regex_validation.go
@@ -1,0 +1,27 @@
+package get
+
+import (
+	"fmt"
+	"regexp"
+
+	"github.com/spf13/cobra"
+)
+
+// RegexArgs return error if arguments don't pass regex test
+func RegexArgs(validationMap map[int][]string) func(cmd *cobra.Command, args []string) error {
+	return func(cmd *cobra.Command, args []string) error {
+
+		// check if there are more args than expected
+		if err := cobra.MaximumNArgs(len(validationMap))(cmd, args); err != nil {
+			return err
+		}
+
+		for i, arg := range args {
+			re := regexp.MustCompile(validationMap[i][0])
+			if !re.MatchString(arg) {
+				return fmt.Errorf("expected '%s', got '%s'", validationMap[i][1], arg)
+			}
+		}
+		return nil
+	}
+}

--- a/app/kumactl/cmd/get/get_traffic_logs.go
+++ b/app/kumactl/cmd/get/get_traffic_logs.go
@@ -3,6 +3,7 @@ package get
 import (
 	"context"
 	"io"
+	"strings"
 
 	"github.com/Kong/kuma/app/kumactl/pkg/output"
 	"github.com/Kong/kuma/app/kumactl/pkg/output/printers"
@@ -18,43 +19,64 @@ func newGetTrafficLogsCmd(pctx *getContext) *cobra.Command {
 		Use:   "traffic-logs",
 		Short: "Show TrafficLogs",
 		Long:  `Show TrafficLog entities.`,
-		RunE: func(cmd *cobra.Command, _ []string) error {
+		Args: RegexArgs(map[int][]string{
+			0: []string{".*\\..*", "<name>.<namespace>"},
+		}),
+		RunE: func(cmd *cobra.Command, args []string) error {
 			rs, err := pctx.CurrentResourceStore()
 			if err != nil {
 				return err
 			}
 
-			trafficLogging := mesh.TrafficLogResourceList{}
-			if err := rs.List(context.Background(), &trafficLogging, core_store.ListByMesh(pctx.CurrentMesh())); err != nil {
-				return errors.Wrapf(err, "failed to list TrafficLog")
+			var trafficLogs mesh.TrafficLogResourceList
+
+			if len(args) == 1 {
+				s := strings.Split(args[0], ".")
+				name := s[0]
+				namespace := s[1]
+
+				trafficLog := mesh.TrafficLogResource{}
+				if err := rs.Get(context.Background(), &trafficLog, core_store.GetByKey(namespace, name, pctx.CurrentMesh())); err != nil {
+					return errors.Wrapf(err, "failed to get TrafficLog")
+				}
+
+				trafficLogs = mesh.TrafficLogResourceList{
+					Items: []*mesh.TrafficLogResource{&trafficLog},
+				}
+
+			} else {
+				trafficLogs = mesh.TrafficLogResourceList{}
+				if err := rs.List(context.Background(), &trafficLogs, core_store.ListByMesh(pctx.CurrentMesh())); err != nil {
+					return errors.Wrapf(err, "failed to list TrafficLog")
+				}
 			}
 
 			switch format := output.Format(pctx.args.outputFormat); format {
 			case output.TableFormat:
-				return printTrafficLog(&trafficLogging, cmd.OutOrStdout())
+				return printTrafficLogs(&trafficLogs, cmd.OutOrStdout())
 			default:
 				printer, err := printers.NewGenericPrinter(format)
 				if err != nil {
 					return err
 				}
-				return printer.Print(rest_types.From.ResourceList(&trafficLogging), cmd.OutOrStdout())
+				return printer.Print(rest_types.From.ResourceList(&trafficLogs), cmd.OutOrStdout())
 			}
 		},
 	}
 	return cmd
 }
 
-func printTrafficLog(trafficLogging *mesh.TrafficLogResourceList, out io.Writer) error {
+func printTrafficLogs(trafficLogs *mesh.TrafficLogResourceList, out io.Writer) error {
 	data := printers.Table{
 		Headers: []string{"MESH", "NAME"},
 		NextRow: func() func() []string {
 			i := 0
 			return func() []string {
 				defer func() { i++ }()
-				if len(trafficLogging.Items) <= i {
+				if len(trafficLogs.Items) <= i {
 					return nil
 				}
-				trafficLogging := trafficLogging.Items[i]
+				trafficLogging := trafficLogs.Items[i]
 
 				return []string{
 					trafficLogging.GetMeta().GetMesh(), // MESH

--- a/app/kumactl/cmd/get/testdata/get-traffic-logs_one_item.golden.json
+++ b/app/kumactl/cmd/get/testdata/get-traffic-logs_one_item.golden.json
@@ -1,0 +1,32 @@
+{
+  "items": [
+    {
+      "mesh": "default",
+      "name": "web2-to-backend2",
+      "rules": [
+        {
+          "sources": [
+            {
+              "match": {
+                "service": "web2",
+                "version": "1.0"
+              }
+            }
+          ],
+          "destinations": [
+            {
+              "match": {
+                "service": "backend2",
+                "env": "dev"
+              }
+            }
+          ],
+          "conf": {
+            "backend": "logstash"
+          }
+        }
+      ],
+      "type": "TrafficLog"
+    }
+  ]
+}

--- a/app/kumactl/cmd/get/testdata/get-traffic-logs_one_item.golden.txt
+++ b/app/kumactl/cmd/get/testdata/get-traffic-logs_one_item.golden.txt
@@ -1,0 +1,2 @@
+MESH      NAME
+default   web2-to-backend2

--- a/app/kumactl/cmd/get/testdata/get-traffic-logs_one_item.golden.yaml
+++ b/app/kumactl/cmd/get/testdata/get-traffic-logs_one_item.golden.yaml
@@ -1,0 +1,15 @@
+items:
+  - mesh: default
+    name: web2-to-backend2
+    rules:
+    - destinations:
+      - match:
+          env: dev
+          service: backend2
+      sources:
+      - match:
+          service: web2
+          version: "1.0"
+      conf:
+        backend: logstash
+    type: TrafficLog


### PR DESCRIPTION
[WIP]

### Summary
This is still a work in progress.

### Full changelog
* [Implement #283] - Support `kumactl get` for individual resources, e.g. `kumactl get <type> <name>`

TODO:
- [x] traffic-log
 - test on k8s backend
- [ ] DataplaneInsight
- [ ] Dataplane
- [ ] Mesh
- [ ] ProxyTemplate
- [ ] TrafficPermission