### PR TITLE
kuma-injector: mutating web hook must explicitly copy ServiceAccount volume mount into containers it creates

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -509,23 +509,20 @@ workflows:
 #        requires:
 #        - build
 
-    # TODO(yskopets): Bring back tests for versions of Kubernetes prior to v1.15.0
-    # once issue with mTLS is fixed (ServiceAccount token is not injected into Kuma sidecar container)
-    #
-    # - example_minikube:
-    #     name: minikube_v1_13_0
-    #     requires:
-    #     - images
-    #     # custom parameters
-    #     kubernetes_version: v1.13.0
-    #     use_local_kuma_images: "yes"
-    # - example_minikube:
-    #     name: minikube_v1_14_0
-    #     requires:
-    #     - images
-    #     # custom parameters
-    #     kubernetes_version: v1.14.0
-    #     use_local_kuma_images: "yes"
+    - example_minikube:
+        name: minikube_v1_13_0
+        requires:
+        - images
+        # custom parameters
+        kubernetes_version: v1.13.0
+        use_local_kuma_images: "yes"
+    - example_minikube:
+        name: minikube_v1_14_0
+        requires:
+        - images
+        # custom parameters
+        kubernetes_version: v1.14.0
+        use_local_kuma_images: "yes"
     - example_minikube:
         name: minikube_v1_15_0
         requires:
@@ -567,23 +564,20 @@ workflows:
         requires:
         - test
         - integration
-    # TODO(yskopets): Bring back tests for versions of Kubernetes prior to v1.15.0
-    # once issue with mTLS is fixed (ServiceAccount token is not injected into Kuma sidecar container)
-    #
-    # - example_minikube:
-    #     <<: *release_workflow_filters
-    #     name: minikube_v1_13_0
-    #     requires:
-    #     - release
-    #     # custom parameters
-    #     kubernetes_version: v1.13.0
-    # - example_minikube:
-    #     <<: *release_workflow_filters
-    #     name: minikube_v1_14_0
-    #     requires:
-    #     - release
-    #     # custom parameters
-    #     kubernetes_version: v1.14.0
+    - example_minikube:
+        <<: *release_workflow_filters
+        name: minikube_v1_13_0
+        requires:
+        - release
+        # custom parameters
+        kubernetes_version: v1.13.0
+    - example_minikube:
+        <<: *release_workflow_filters
+        name: minikube_v1_14_0
+        requires:
+        - release
+        # custom parameters
+        kubernetes_version: v1.14.0
     - example_minikube:
         <<: *release_workflow_filters
         name: minikube_v1_15_0

--- a/app/kuma-injector/pkg/injector/injector_test.go
+++ b/app/kuma-injector/pkg/injector/injector_test.go
@@ -82,5 +82,8 @@ var _ = Describe("Injector", func() {
 		Entry("04. Pod with explicitly selected Mesh", testCase{
 			num: "04",
 		}),
+		Entry("05. Pod without ServiceAccount token", testCase{
+			num: "05",
+		}),
 	)
 })

--- a/app/kuma-injector/pkg/injector/testdata/inject.02.golden.yaml
+++ b/app/kuma-injector/pkg/injector/testdata/inject.02.golden.yaml
@@ -84,6 +84,10 @@ spec:
     securityContext:
       runAsGroup: 5678
       runAsUser: 5678
+    volumeMounts:
+    - name: default-token-w7dxf
+      readOnly: true
+      mountPath: "/var/run/secrets/kubernetes.io/serviceaccount"
   initContainers:
   - command:
     - sh

--- a/app/kuma-injector/pkg/injector/testdata/inject.03.golden.yaml
+++ b/app/kuma-injector/pkg/injector/testdata/inject.03.golden.yaml
@@ -143,6 +143,10 @@ spec:
     securityContext:
       runAsGroup: 5678
       runAsUser: 5678
+    volumeMounts:
+    - name: coredns-token-9gmrh
+      readOnly: true
+      mountPath: "/var/run/secrets/kubernetes.io/serviceaccount"
   dnsPolicy: Default
   enableServiceLinks: true
   initContainers:

--- a/app/kuma-injector/pkg/injector/testdata/inject.04.golden.yaml
+++ b/app/kuma-injector/pkg/injector/testdata/inject.04.golden.yaml
@@ -83,6 +83,10 @@ spec:
     securityContext:
       runAsGroup: 5678
       runAsUser: 5678
+    volumeMounts:
+    - name: default-token-w7dxf
+      readOnly: true
+      mountPath: "/var/run/secrets/kubernetes.io/serviceaccount"
   initContainers:
   - args:
     - -p

--- a/app/kuma-injector/pkg/injector/testdata/inject.05.golden.yaml
+++ b/app/kuma-injector/pkg/injector/testdata/inject.05.golden.yaml
@@ -11,14 +11,11 @@ metadata:
     run: busybox
   name: busybox
 spec:
+  automountServiceAccountToken: false
   containers:
   - image: busybox
     name: busybox
     resources: {}
-    volumeMounts:
-    - mountPath: /var/run/secrets/kubernetes.io/serviceaccount
-      name: default-token-w7dxf
-      readOnly: true
   - args:
     - run
     - --log-level=info
@@ -83,10 +80,6 @@ spec:
     securityContext:
       runAsGroup: 5678
       runAsUser: 5678
-    volumeMounts:
-    - mountPath: /var/run/secrets/kubernetes.io/serviceaccount
-      name: default-token-w7dxf
-      readOnly: true
   initContainers:
   - args:
     - -p
@@ -115,8 +108,4 @@ spec:
       capabilities:
         add:
         - NET_ADMIN
-  volumes:
-  - name: default-token-w7dxf
-    secret:
-      secretName: default-token-w7dxf
 status: {}

--- a/app/kuma-injector/pkg/injector/testdata/inject.05.input.yaml
+++ b/app/kuma-injector/pkg/injector/testdata/inject.05.input.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: busybox
+  labels:
+    run: busybox
+spec:
+  automountServiceAccountToken: false
+  containers:
+  - name: busybox
+    image: busybox
+    resources: {}


### PR DESCRIPTION
### Summary

* to support versions of `Kubernetes` prior to `v1.15.0`, mutating web hook must explicitly copy `ServiceAccount` volume mount into containers it creates

### Issues resolved

Fix #325
