### PR TITLE
docs: remove k8s 1.15 instruction

### DIFF
--- a/examples/kubernetes/kuma-demo/README.md
+++ b/examples/kubernetes/kuma-demo/README.md
@@ -2,10 +2,10 @@
 
 ## Setup Environment
 
-1. Start a Kubernetes cluster with version 1.15 or higher and at least 4GB of memory
+### 1. Start a Kubernetes cluster with at least 4GB of memory. We've tested Kuma on Kubernetes v1.13.0 - v1.16.x, so use anything older than v1.13.0 with caution. In this demo, we'll be using v1.15.4. 
 
 ```
-$ minikube start --kubernetes-version v1.15.4
+$ minikube start --cpus 2 --memory 4096 --kubernetes-version v1.15.4
 😄  minikube v1.4.0 on Darwin 10.14.6
 🔥  Creating virtualbox VM (CPUs=2, Memory=4096MB, Disk=20000MB) ...
 🐳  Preparing Kubernetes v1.15.4 on Docker 18.09.9 ...
@@ -15,13 +15,13 @@ $ minikube start --kubernetes-version v1.15.4
 🏄  Done! kubectl is now configured to use "minikube"
 ```
 
-2. Navigate into the directory where all the kuma-demo YAML files are:
+### 2. Navigate into the directory where all the kuma-demo YAML files are:
 
 ```
 $ cd examples/kubernetes/kuma-demo/
 ```
 
-3. Deploy Kuma's sample marketplace application
+### 3. Deploy Kuma's sample marketplace application
 
 ```
 $ kubectl apply -f kuma-demo-aio.yaml
@@ -49,7 +49,7 @@ redis-master-6d4cf995c5-nsghm   1/1     Running   0          13m
 
 In the following steps, we will be using the pod name of the `kuma-demo-app-*************` pod. Please replace any `${KUMA_DEMO_APP_POD_NAME}` variables with your pod name.
 
-4. Port-forward the sample application to access the front-end UI at http://localhost:8080
+### 4. Port-forward the sample application to access the front-end UI at http://localhost:8080
 
 <pre><code>$ kubectl port-forward <b>${KUMA_DEMO_APP_POD_NAME}</b> -n kuma-demo 8080 3001
 Forwarding from 127.0.0.1:8080 -> 8080
@@ -60,10 +60,10 @@ Forwarding from [::1]:3001 -> 3001
 
 Now you can access the marketplace application through your web browser at http://localhost:8080.
 
-The items on the front page are pulled from the Elasticsearch service. While the reviews for each item sit within the Redis service. You    can query for individual items and look at their reviews. 
+The items on the front page are pulled from the Elasticsearch service. While the reviews for each item sit within the Redis service. You can query for individual items and look at their reviews.
 
 
-5. Download the latest version of Kuma
+### 5. Download the latest version of Kuma
 
 ```
 $ wget https://kong.bintray.com/kuma/kuma-0.2.2-darwin-amd64.tar.gz
@@ -84,7 +84,7 @@ kuma-0.2.2-darwin-amd64.tar.g 100%[=============================================
 2019-10-13 05:54:08 (2.09 MB/s) - ‘kuma-0.2.2-darwin-amd64.tar.gz’ saved [42892462/42892462]
 ```
 
-6. Unbundle the files to get the following components:
+### 6. Unbundle the files to get the following components:
 
 ```
 $ tar xvzf kuma-0.2.2-darwin-amd64.tar.gz
@@ -101,14 +101,14 @@ x ./README
 x ./LICENSE
 ```
 
-7. Go into the ./bin directory where the kuma components will be:
+### 7. Go into the ./bin directory where the kuma components will be:
 
 ```
 $ cd bin && ls
 envoy   kuma-cp   kuma-dp   kuma-tcp-echo kumactl
 ```
 
-8. Install the control plane using `kumactl`
+### 8. Install the control plane using `kumactl`
 
 ```
 $ ./kumactl install control-plane | kubectl apply -f -
@@ -147,7 +147,7 @@ kuma-injector-9c96cddc8-745r7         1/1     Running   0          70s
 
 In the following steps, we will be using the pod name of the `kuma-control-plane-*************` pod. Please replace any `${KUMA_CP_POD_NAME}` with your pod name.
 
-9. Delete the existing kuma-demo pods so they restart:
+### 9. Delete the existing kuma-demo pods so they restart:
 
 ```
 $ kubectl delete pods --all -n kuma-demo
@@ -166,7 +166,7 @@ kuma-demo-app-8fc49ddbf-k5z5q   3/3     Running   0          2m25s
 redis-master-6d4cf995c5-jxjjm   2/2     Running   0          2m25s
 ```
 
-10. Port-forward the sample application again to access the front-end UI at http://localhost:8080
+### 10. Port-forward the sample application again to access the front-end UI at http://localhost:8080
 
 <pre><code>$ kubectl port-forward <b>${KUMA_DEMO_APP_POD_NAME}</b> -n kuma-demo 8080 3001
 Forwarding from 127.0.0.1:8080 -> 8080
@@ -177,7 +177,7 @@ Forwarding from [::1]:3001 -> 3001
 
 Now you can access the marketplace application through your web browser at http://localhost:8080 with Envoy handling all the traffic between the services. Happy shopping!
 
-11.  Now we will port forward the kuma-control-plane so we can access it with `kumactl`
+### 11.  Now we will port forward the kuma-control-plane so we can access it with `kumactl`
 
 <pre><code>$ kubectl -n kuma-system port-forward <b>${KUMA_CP_POD_NAME}</b> 5681
 Forwarding from 127.0.0.1:5681 -> 5681
@@ -186,7 +186,7 @@ Forwarding from [::1]:5681 -> 5681
 
 Please refer to step 7 to copy the correct `${KUMA_CP_POD_NAME}`.
 
-12.  Now configure `kumactl` to point towards the control plane address
+### 12.  Now configure `kumactl` to point towards the control plane address
 
 ```
 $ ./kumactl config control-planes add --name=minikube --address=http://localhost:5681
@@ -194,7 +194,7 @@ added Control Plane "minikube"
 switched active Control Plane to "minikube"
 ```
 
-13. You can use `kumactl` to look at the dataplanes in the mesh. You should see three dataplanes that correlates with our pods in Kubernetes:
+### 13. You can use `kumactl` to look at the dataplanes in the mesh. You should see three dataplanes that correlates with our pods in Kubernetes:
 
 ```
 $ ./kumactl inspect dataplanes
@@ -204,7 +204,7 @@ default   redis-master-6d4cf995c5-jxjjm   app=redis pod-template-hash=6d4cf995c5
 default   kuma-demo-app-8fc49ddbf-k5z5q   app=kuma-demo-api pod-template-hash=8fc49ddbf service=kuma-demo-api.kuma-demo.svc:3001                    Online   9m8s                 9m7s               3               0
 ```
 
-14. You can also use `kumactl` to look at the mesh. As shown below, our default mesh does not have mTLS enabled.
+### 14. You can also use `kumactl` to look at the mesh. As shown below, our default mesh does not have mTLS enabled.
 
 ```
 $ ./kumactl get meshes
@@ -212,7 +212,7 @@ NAME      mTLS   DP ACCESS LOGS
 default   off    off
 ```
 
-15.  Let's enable mTLS.
+### 15.  Let's enable mTLS.
 
 ```
 $ cat <<EOF | kubectl apply -f - 
@@ -237,7 +237,7 @@ NAME      mTLS   DP ACCESS LOGS
 default   on     off
 ```
 
-16.  Now let's enable traffic-permission for all services so our application will work like it use to:
+### 16.  Now let's enable traffic-permission for all services so our application will work like it use to:
 
 ```
 $ cat <<EOF | kubectl apply -f - 
@@ -267,7 +267,7 @@ default   everything
 
 Now that we have traffic permission that allows any source to talk to any destination, our application should work like it use to. 
 
-17. Deploy the logstash service.
+### 17. Deploy the logstash service.
 
 ```
 $ kubectl apply -f kuma-demo-log.yaml
@@ -277,7 +277,7 @@ configmap/logstash-config created
 deployment.apps/logstash created
 ```
 
-18. Let's add logging for traffic between all services and send them to logstash: 
+### 18. Let's add logging for traffic between all services and send them to logstash: 
 ```
 $ cat <<EOF | kubectl apply -f - 
 apiVersion: kuma.io/v1alpha1
@@ -325,7 +325,7 @@ EOF
 ```
 Logs will be sent to https://kumademo.loggly.com/
 
-19. Now let's take down our Redis service because someone is spamming fake reviews. We can easily accomplish that by changing our traffic-permissions:
+### 19. Now let's take down our Redis service because someone is spamming fake reviews. We can easily accomplish that by changing our traffic-permissions:
 ```
 $ cat <<EOF | kubectl apply -f - 
 apiVersion: kuma.io/v1alpha1
@@ -347,7 +347,7 @@ EOF
 
 This traffic-permission will only allow traffic from the kuma-demo-api service to the Elasticsearch service. Now try to access the reviews on each item. They will not load because of the traffic-permissions you described in the the policy above.
 
-20. If we wanted to enable the Redis service again in the future, just change the traffic-permission back like this:
+### 20. If we wanted to enable the Redis service again in the future, just change the traffic-permission back like this:
 ```
 $ cat <<EOF | kubectl apply -f - 
 apiVersion: kuma.io/v1alpha1


### PR DESCRIPTION
### Summary

- Remove instruction for only using Kubernetes 1.15+ because the bug has been fixed. 
- Bumping docker image for kuma-demo.

### Issues resolved

Fix #325
