### PR TITLE
Add overwrite option

### DIFF
--- a/app/kumactl/cmd/config/config_control_planes_add.go
+++ b/app/kumactl/cmd/config/config_control_planes_add.go
@@ -46,7 +46,7 @@ func newConfigControlPlanesAddCmd(pctx *kumactl_cmd.RootContext) *cobra.Command 
 			if err := ctx.Validate(); err != nil {
 				return errors.Wrapf(err, "Context configuration is not valid")
 			}
-			if !cfg.AddContext(ctx) {
+			if !cfg.AddContext(ctx, args.overwrite) {
 				return errors.Errorf("Context with name %q already exists", ctx.Name)
 			}
 			cfg.CurrentContext = ctx.Name

--- a/app/kumactl/cmd/config/config_control_planes_add.go
+++ b/app/kumactl/cmd/config/config_control_planes_add.go
@@ -13,6 +13,7 @@ func newConfigControlPlanesAddCmd(pctx *kumactl_cmd.RootContext) *cobra.Command 
 	args := struct {
 		name         string
 		apiServerURL string
+		overwrite    bool
 	}{}
 	cmd := &cobra.Command{
 		Use:   "add",
@@ -35,7 +36,7 @@ func newConfigControlPlanesAddCmd(pctx *kumactl_cmd.RootContext) *cobra.Command 
 			if err := config.ValidateCpCoordinates(cp); err != nil {
 				return err
 			}
-			if !cfg.AddControlPlane(cp) {
+			if !cfg.AddControlPlane(cp, args.overwrite) {
 				return errors.Errorf("Control Plane with name %q already exists", cp.Name)
 			}
 			ctx := &config_proto.Context{
@@ -62,5 +63,6 @@ func newConfigControlPlanesAddCmd(pctx *kumactl_cmd.RootContext) *cobra.Command 
 	_ = cmd.MarkFlagRequired("name")
 	cmd.Flags().StringVar(&args.apiServerURL, "address", "", "URL of the Control Plane API Server (required)")
 	_ = cmd.MarkFlagRequired("address")
+	cmd.Flags().BoolVar(&args.overwrite, "overwrite", false, "Overwrite existing Control Plane config with the same reference name")
 	return cmd
 }

--- a/app/kumactl/cmd/config/config_control_planes_add.go
+++ b/app/kumactl/cmd/config/config_control_planes_add.go
@@ -63,6 +63,6 @@ func newConfigControlPlanesAddCmd(pctx *kumactl_cmd.RootContext) *cobra.Command 
 	_ = cmd.MarkFlagRequired("name")
 	cmd.Flags().StringVar(&args.apiServerURL, "address", "", "URL of the Control Plane API Server (required)")
 	_ = cmd.MarkFlagRequired("address")
-	cmd.Flags().BoolVar(&args.overwrite, "overwrite", false, "Overwrite existing Control Plane config with the same reference name")
+	cmd.Flags().BoolVar(&args.overwrite, "overwrite", false, "overwrite existing Control Plane with the same reference name")
 	return cmd
 }

--- a/app/kumactl/cmd/config/config_control_planes_add_test.go
+++ b/app/kumactl/cmd/config/config_control_planes_add_test.go
@@ -4,8 +4,6 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
-	"github.com/Kong/kuma/app/kumactl/pkg/config"
-	"github.com/Kong/kuma/pkg/api-server/types"
 	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
@@ -15,6 +13,9 @@ import (
 	"strings"
 	"time"
 	"unicode"
+
+	"github.com/Kong/kuma/app/kumactl/pkg/config"
+	"github.com/Kong/kuma/pkg/api-server/types"
 
 	"github.com/Kong/kuma/app/kumactl/cmd"
 
@@ -161,7 +162,7 @@ var _ = Describe("kumactl config control-planes add", func() {
 			configFile  string
 			goldenFile  string
 			expectedOut string
-			overwrite bool
+			overwrite   bool
 		}
 
 		DescribeTable("should add a new Control Plane by name and address",
@@ -215,7 +216,7 @@ var _ = Describe("kumactl config control-planes add", func() {
 added Control Plane "example"
 switched active Control Plane to "example"
 `,
-				overwrite:false,
+				overwrite: false,
 			}),
 			Entry("should add a second Control Plane", testCase{
 				configFile: "config-control-planes-add.02.initial.yaml",
@@ -224,8 +225,8 @@ switched active Control Plane to "example"
 added Control Plane "example"
 switched active Control Plane to "example"
 `,
-				overwrite:false,
-			}), 
+				overwrite: false,
+			}),
 			Entry("should replace the example Control Plane", testCase{
 				configFile: "config-control-planes-add.03.initial.yaml",
 				goldenFile: "config-control-planes-add.03.golden.yaml",
@@ -233,7 +234,7 @@ switched active Control Plane to "example"
 added Control Plane "example"
 switched active Control Plane to "example"
 `,
-				overwrite:true,
+				overwrite: true,
 			}),
 		)
 	})

--- a/app/kumactl/cmd/config/config_control_planes_add_test.go
+++ b/app/kumactl/cmd/config/config_control_planes_add_test.go
@@ -161,6 +161,7 @@ var _ = Describe("kumactl config control-planes add", func() {
 			configFile  string
 			goldenFile  string
 			expectedOut string
+			overwrite bool
 		}
 
 		DescribeTable("should add a new Control Plane by name and address",
@@ -174,11 +175,16 @@ var _ = Describe("kumactl config control-planes add", func() {
 				// setup cp index server for validation to pass
 				port := setupCpIndexServer()
 
-				// given
-				rootCmd.SetArgs([]string{"--config-file", configFile.Name(),
+				args := []string{"--config-file", configFile.Name(),
 					"config", "control-planes", "add",
 					"--name", "example",
-					"--address", fmt.Sprintf("http://localhost:%d", port)})
+					"--address", fmt.Sprintf("http://localhost:%d", port)}
+				if given.overwrite {
+					args = append(args, "--overwrite")
+				}
+
+				// given
+				rootCmd.SetArgs(args)
 				// when
 				err = rootCmd.Execute()
 				// then
@@ -209,6 +215,7 @@ var _ = Describe("kumactl config control-planes add", func() {
 added Control Plane "example"
 switched active Control Plane to "example"
 `,
+				overwrite:false,
 			}),
 			Entry("should add a second Control Plane", testCase{
 				configFile: "config-control-planes-add.02.initial.yaml",
@@ -217,6 +224,16 @@ switched active Control Plane to "example"
 added Control Plane "example"
 switched active Control Plane to "example"
 `,
+				overwrite:false,
+			}), 
+			Entry("should replace the example Control Plane", testCase{
+				configFile: "config-control-planes-add.03.initial.yaml",
+				goldenFile: "config-control-planes-add.03.golden.yaml",
+				expectedOut: `
+added Control Plane "example"
+switched active Control Plane to "example"
+`,
+				overwrite:true,
 			}),
 		)
 	})

--- a/app/kumactl/cmd/config/testdata/config-control-planes-add.03.golden.yaml
+++ b/app/kumactl/cmd/config/testdata/config-control-planes-add.03.golden.yaml
@@ -1,0 +1,17 @@
+contexts:
+  - controlPlane: test1
+    defaults:
+      mesh: pilot
+    name: test1
+  - controlPlane: example
+    name: example
+controlPlanes:
+  - coordinates:
+      apiServer:
+        url: https://test1.internal:5681
+    name: test1
+  - coordinates:
+      apiServer:
+        url: http://placeholder-address
+    name: example
+currentContext: example

--- a/app/kumactl/cmd/config/testdata/config-control-planes-add.03.initial.yaml
+++ b/app/kumactl/cmd/config/testdata/config-control-planes-add.03.initial.yaml
@@ -1,0 +1,19 @@
+contexts:
+  - controlPlane: test1
+    defaults:
+      mesh: pilot
+    name: test1
+  - controlPlane: test2
+    defaults:
+      mesh: default
+    name: example
+controlPlanes:
+  - coordinates:
+      apiServer:
+        url: https://test1.internal:5681
+    name: test1
+  - coordinates:
+      apiServer:
+        url: https://test2.internal:5681
+    name: example
+currentContext: test1

--- a/docs/cmd/kumactl/HELP.md
+++ b/docs/cmd/kumactl/HELP.md
@@ -139,6 +139,7 @@ Flags:
       --address string   URL of the Control Plane API Server (required)
   -h, --help             help for add
       --name string      reference name for the Control Plane (required)
+      --overwrite        Overwrite existing Control Plane config with the same reference name
 
 Global Flags:
       --config-file string   path to the configuration file to use
@@ -218,7 +219,7 @@ Flags:
       --admission-server-tls-key string     TLS key for the admission web hooks implemented by the Kuma Control Plane
       --control-plane-image string          image of the Kuma Control Plane component (default "kong-docker-kuma-docker.bintray.io/kuma-cp")
       --control-plane-service-name string   Service name of the Kuma Control Plane (default "kuma-control-plane")
-      --control-plane-version string        version shared by all components of the Kuma Control Plane (default "latest")
+      --control-plane-version string        version shared by all components of the Kuma Control Plane (default "0.2.2-48-ga7b73e9")
       --dataplane-image string              image of the Kuma Dataplane component (default "kong-docker-kuma-docker.bintray.io/kuma-dp")
       --dataplane-init-image string         init image of the Kuma Dataplane component (default "docker.io/istio/proxy_init")
       --dataplane-init-version string       version of the init image of the Kuma Dataplane component (default "1.1.2")

--- a/docs/cmd/kumactl/HELP.md
+++ b/docs/cmd/kumactl/HELP.md
@@ -139,7 +139,7 @@ Flags:
       --address string   URL of the Control Plane API Server (required)
   -h, --help             help for add
       --name string      reference name for the Control Plane (required)
-      --overwrite        Overwrite existing Control Plane config with the same reference name
+      --overwrite        overwrite existing Control Plane with the same reference name
 
 Global Flags:
       --config-file string   path to the configuration file to use
@@ -219,7 +219,7 @@ Flags:
       --admission-server-tls-key string     TLS key for the admission web hooks implemented by the Kuma Control Plane
       --control-plane-image string          image of the Kuma Control Plane component (default "kong-docker-kuma-docker.bintray.io/kuma-cp")
       --control-plane-service-name string   Service name of the Kuma Control Plane (default "kuma-control-plane")
-      --control-plane-version string        version shared by all components of the Kuma Control Plane (default "0.2.2-48-ga7b73e9")
+      --control-plane-version string        version shared by all components of the Kuma Control Plane (default "latest")
       --dataplane-image string              image of the Kuma Dataplane component (default "kong-docker-kuma-docker.bintray.io/kuma-dp")
       --dataplane-init-image string         init image of the Kuma Dataplane component (default "docker.io/istio/proxy_init")
       --dataplane-init-version string       version of the init image of the Kuma Dataplane component (default "1.1.2")

--- a/pkg/config/app/kumactl/v1alpha1/config_helpers.go
+++ b/pkg/config/app/kumactl/v1alpha1/config_helpers.go
@@ -67,7 +67,6 @@ func (cfg *Configuration) AddControlPlane(cp *ControlPlane, force bool) bool {
 			return false
 		}
 		cfg.ControlPlanes[idx] = cp
-
 	} else {
 		cfg.ControlPlanes = append(cfg.ControlPlanes, cp)
 	}

--- a/pkg/config/app/kumactl/v1alpha1/config_helpers.go
+++ b/pkg/config/app/kumactl/v1alpha1/config_helpers.go
@@ -14,12 +14,16 @@ func (cfg *Configuration) GetContext(name string) (int, *Context) {
 	return -1, nil
 }
 
-func (cfg *Configuration) AddContext(c *Context) bool {
-	_, old := cfg.GetContext(c.Name)
+func (cfg *Configuration) AddContext(c *Context, force bool) bool {
+	idx, old := cfg.GetContext(c.Name)
 	if old != nil {
-		return false
+		if !force {
+			return false
+		}
+		cfg.Contexts[idx] = c
+	} else {
+		cfg.Contexts = append(cfg.Contexts, c)
 	}
-	cfg.Contexts = append(cfg.Contexts, c)
 	return true
 }
 

--- a/pkg/config/app/kumactl/v1alpha1/config_helpers.go
+++ b/pkg/config/app/kumactl/v1alpha1/config_helpers.go
@@ -56,12 +56,18 @@ func (cfg *Configuration) GetControlPlane(name string) (int, *ControlPlane) {
 	return -1, nil
 }
 
-func (cfg *Configuration) AddControlPlane(cp *ControlPlane) bool {
-	_, old := cfg.GetControlPlane(cp.Name)
+func (cfg *Configuration) AddControlPlane(cp *ControlPlane, force bool) bool {
+	idx, old := cfg.GetControlPlane(cp.Name)
 	if old != nil {
-		return false
+		if !force {
+			return false
+		}
+		cfg.ControlPlanes[idx] = cp
+
+	} else {
+		cfg.ControlPlanes = append(cfg.ControlPlanes, cp)
 	}
-	cfg.ControlPlanes = append(cfg.ControlPlanes, cp)
+
 	return true
 }
 


### PR DESCRIPTION
### Summary

Add the possibility to overwrite an existing control plane configuration.

### Full changelog
  - [x] Add `--overwrite` option to config control-planes add command
  - [x] Add unit test

### Issues resolved

Fix #380 
