### PR TITLE
ci(*) introduce golangci-lint

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -84,6 +84,9 @@ jobs:
       GO_VERSION: *go_version
       GO111MODULE: "on"
       CLANG_FORMAT_PATH: clang-format-6.0
+      # if GOPATH is not set, `golang-ci` fails with an obscure message
+      # "ERRO Running error: context loading failed: failed to load program with go/packages: could not determine GOARCH and Go compiler"
+      GOPATH: /root/.go-kuma-go
     steps:
     - checkout
     - run:
@@ -125,6 +128,10 @@ jobs:
 
   dev_mac:
     executor: mac
+    environment:
+      # if GOPATH is not set, `golang-ci` fails with an obscure message
+      # "ERRO Running error: context loading failed: failed to load program with go/packages: could not determine GOARCH and Go compiler"
+      GOPATH: /Users/distiller/.go-kuma-go
     steps:
     - checkout
     - run:
@@ -278,7 +285,7 @@ jobs:
   integration:
     executor: vm
     environment:
-      GOPATH: /home/circleci/.go
+      GOPATH: /home/circleci/.go-kuma-go
     steps:
     - checkout
     - run:
@@ -304,7 +311,7 @@ jobs:
     - save_cache:
         key: vm-executor-go.mod-{{ .Branch }}-{{ checksum "go.sum" }}
         paths:
-          - "/home/circleci/.go"
+          - "/home/circleci/.go-kuma-go"
     - run:
         name: "Install all development tools"
         command: |

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -8,10 +8,10 @@ linters:
 
 run:
   skip-files:
-    - app/kumactl/pkg/k8s/kubectl_proxy.go
-    - pkg/sds/server/sds.go
-    - pkg/xds/server/server.go
-    - pkg/xds/server/server_test.go
+    - app/kumactl/pkg/k8s/kubectl_proxy.go # excluded to keep as close to original file from K8S repository
+    - pkg/sds/server/sds.go # excluded to keep as close to original file from Envoy repository
+    - pkg/xds/server/server.go # excluded to keep as close to original file from Envoy repository
+    - pkg/xds/server/server_test.go # excluded to keep as close to original file from Envoy repository
   modules-download-mode: readonly
 
 linters-settings:

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,20 @@
+linters:
+  enable:
+    - gocritic
+    - unconvert
+    - bodyclose
+    - whitespace
+    - misspell
+
+run:
+  skip-files:
+    - app/kumactl/pkg/k8s/kubectl_proxy.go
+    - pkg/sds/server/sds.go
+    - pkg/xds/server/server.go
+    - pkg/xds/server/server_test.go
+  modules-download-mode: readonly
+
+linters-settings:
+  gocritic:
+    disabled-checks:
+      - singleCaseSwitch

--- a/Makefile
+++ b/Makefile
@@ -107,6 +107,7 @@ endif
 PROTOC_VERSION := 3.6.1
 PROTOC_PGV_VERSION := v0.1.0
 GOGO_PROTOBUF_VERSION := v1.2.1
+GOLANGCI_LINT_VERSION := v1.21.0
 
 CI_KUBEBUILDER_VERSION ?= 2.0.0
 CI_KIND_VERSION ?= v0.5.1
@@ -130,6 +131,7 @@ MINIKUBE_PATH := $(CI_TOOLS_DIR)/minikube
 KUBECTL_PATH := $(CI_TOOLS_DIR)/kubectl
 KUBE_APISERVER_PATH := $(CI_TOOLS_DIR)/kube-apiserver
 ETCD_PATH := $(CI_TOOLS_DIR)/etcd
+GOLANGCI_LINT_DIR := $(CI_TOOLS_DIR)
 
 PROTO_DIR := ./pkg/config
 
@@ -240,7 +242,10 @@ vet: ## Dev: Run go vet
 	@# for consistency with `fmt`
 	make vet -C pkg/plugins/resources/k8s/native
 
-check: generate fmt vet docs ## Dev: Run code checks (go fmt, go vet, ...)
+golangci-lint: ## Dev: Runs golangci-lint linter
+	$(GOLANGCI_LINT_DIR)/golangci-lint run -v
+
+check: generate fmt vet docs golangci-lint ## Dev: Run code checks (go fmt, go vet, ...)
 	make generate manifests -C pkg/plugins/resources/k8s/native
 	git diff --quiet || test $$(git diff --name-only | grep -v -e 'go.mod$$' -e 'go.sum$$' | wc -l) -eq 0 || ( echo "The following changes (result of code generators and code checks) have been detected:" && git --no-pager diff && false ) # fail if Git working tree is dirty
 

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@
 		deploy/example-app/k8s deploy/control-plane/k8s \
 		kind/load/control-plane kind/load/kuma-dp kind/load/kuma-injector \
 		generate protoc/pkg/config/app/kumactl/v1alpha1 generate/kumactl/install/control-plane \
-		fmt fmt/go fmt/proto vet check test integration build run/k8s run/universal/memory run/universal/postgres \
+		fmt fmt/go fmt/proto vet golangci-lint check test integration build run/k8s run/universal/memory run/universal/postgres \
 		images image/kuma-cp image/kuma-dp image/kumactl image/kuma-injector image/kuma-tcp-echo \
 		docker/build docker/build/kuma-cp docker/build/kuma-dp docker/build/kumactl docker/build/kuma-injector docker/build/kuma-tcp-echo \
 		docker/save docker/save/kuma-cp docker/save/kuma-dp docker/save/kumactl docker/save/kuma-injector docker/save/kuma-tcp-echo \

--- a/Makefile.dev.mk
+++ b/Makefile.dev.mk
@@ -10,7 +10,8 @@ dev/tools: dev/tools/all ## Bootstrap: Install all development tools
 dev/tools/all: dev/install/protoc dev/install/protoc-gen-gogofast dev/install/protoc-gen-validate \
 	dev/install/ginkgo \
 	dev/install/kubebuilder dev/install/kustomize \
-	dev/install/kubectl dev/install/kind dev/install/minikube
+	dev/install/kubectl dev/install/kind dev/install/minikube \
+	dev/install/golangci-lint
 
 dev/install/protoc: ## Bootstrap: Install Protoc (protobuf compiler)
 	@if [ -e $(PROTOC_PATH) ]; then echo "Protoc $$( $(PROTOC_PATH) --version ) is already installed at $(PROTOC_PATH)" ; fi

--- a/Makefile.dev.mk
+++ b/Makefile.dev.mk
@@ -2,7 +2,8 @@
 		dev/install/protoc dev/install/protoc-gen-gogofast dev/install/protoc-gen-validate \
 		dev/install/ginkgo \
 		dev/install/kubebuilder dev/install/kustomize \
-		dev/install/kubectl dev/install/kind dev/install/minikube
+		dev/install/kubectl dev/install/kind dev/install/minikube \
+		dev/install/golangci-lint
 
 dev/tools: dev/tools/all ## Bootstrap: Install all development tools
 
@@ -107,3 +108,6 @@ dev/install/minikube: ## Bootstrap: Install Minikube
 		&& mv minikube $(MINIKUBE_PATH) \
 		&& set +x \
 		&& echo "Minikube $(CI_MINIKUBE_VERSION) has been installed at $(MINIKUBE_PATH)" ; fi
+
+dev/install/golangci-lint: ## Bootstrap: Install golangci-lint
+	curl -sfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh| sh -s -- -b $(GOLANGCI_LINT_DIR) $(GOLANGCI_LINT_VERSION)

--- a/pkg/catalogue/client/client.go
+++ b/pkg/catalogue/client/client.go
@@ -45,6 +45,7 @@ func (h *httpCatalogueClient) Catalogue() (catalogue.Catalogue, error) {
 	if err != nil {
 		return result, errors.Wrap(err, "could not execute the request")
 	}
+	defer resp.Body.Close()
 	if resp.StatusCode != 200 {
 		return result, errors.Errorf("unexpected status code %d. Expected 200", resp.StatusCode)
 	}


### PR DESCRIPTION
### Summary

Introducing [golangci-lint](https://github.com/golangci/golangci-lint). It is run on `make check` and also checked on CI.