### PR TITLE
pkg/catalogue_test: fix dropped error

### DIFF
--- a/pkg/catalogue/client_test.go
+++ b/pkg/catalogue/client_test.go
@@ -58,6 +58,7 @@ var _ = Describe("Catalogue client", func() {
 		catalogue, err := client.Catalogue()
 
 		// then
+		Expect(err).ToNot(HaveOccurred())
 		Expect(catalogue).To(Equal(expected))
 	})
 


### PR DESCRIPTION
This PR fixes a dropped error in the `catalogue_test` package.