### PR TITLE
kuma-cp: add `TrafficRouteResource` to core model

### DIFF
--- a/dev/examples/universal/traffic-routes/web-to-backend.yaml
+++ b/dev/examples/universal/traffic-routes/web-to-backend.yaml
@@ -1,0 +1,22 @@
+type: TrafficRoute
+name: web-to-backend
+mesh: default
+sources:
+- match:
+    service: web
+    region: us-east-1
+    version: v10
+destinations:
+- match:
+      # NOTE: only `service` tag can be used here (in `universal` all TCP connections will have `127.0.0.1` as destination => it's not enough info to infer any other destination tags)
+    service: backend
+conf:
+- weight: 90
+  destination:
+    service: backend
+    region: us-east-1
+    version: v2
+- weight: 10
+  destination:
+    service: backend
+    version: v3

--- a/pkg/api-server/definitions/all.go
+++ b/pkg/api-server/definitions/all.go
@@ -7,4 +7,5 @@ var All = []ResourceWsDefinition{
 	ProxyTemplateWsDefinition,
 	TrafficPermissionWsDefinition,
 	TrafficLogWsDefinition,
+	TrafficRouteWsDefinition,
 }

--- a/pkg/api-server/definitions/traffic_route.go
+++ b/pkg/api-server/definitions/traffic_route.go
@@ -1,0 +1,17 @@
+package definitions
+
+import (
+	"github.com/Kong/kuma/pkg/core/resources/apis/mesh"
+	"github.com/Kong/kuma/pkg/core/resources/model"
+)
+
+var TrafficRouteWsDefinition = ResourceWsDefinition{
+	Name: "TrafficRoute",
+	Path: "traffic-routes",
+	ResourceFactory: func() model.Resource {
+		return &mesh.TrafficRouteResource{}
+	},
+	ResourceListFactory: func() model.ResourceList {
+		return &mesh.TrafficRouteResourceList{}
+	},
+}

--- a/pkg/api-server/read_only_resource_ws_test.go
+++ b/pkg/api-server/read_only_resource_ws_test.go
@@ -1,7 +1,7 @@
 package api_server_test
 
 import (
-	"github.com/Kong/kuma/pkg/api-server"
+	api_server "github.com/Kong/kuma/pkg/api-server"
 	config "github.com/Kong/kuma/pkg/config/api-server"
 	"github.com/Kong/kuma/pkg/core/resources/model/rest"
 	"github.com/Kong/kuma/pkg/core/resources/store"
@@ -28,7 +28,7 @@ var _ = Describe("Read only Resource WS", func() {
 		apiServer = createTestApiServer(resourceStore, cfg)
 		client = resourceApiClient{
 			address: apiServer.Address(),
-			path:    "/meshes/" + mesh + "/traffic-routes",
+			path:    "/meshes/" + mesh + "/sample-traffic-routes",
 		}
 		stop = make(chan struct{})
 		go func() {

--- a/pkg/api-server/resource_api_client_test.go
+++ b/pkg/api-server/resource_api_client_test.go
@@ -3,7 +3,8 @@ package api_server_test
 import (
 	"bytes"
 	"context"
-	"github.com/Kong/kuma/pkg/api-server"
+
+	api_server "github.com/Kong/kuma/pkg/api-server"
 	"github.com/Kong/kuma/pkg/api-server/definitions"
 	config_api_server "github.com/Kong/kuma/pkg/config/api-server"
 	"github.com/Kong/kuma/pkg/core/resources/manager"
@@ -12,8 +13,9 @@ import (
 	sample_proto "github.com/Kong/kuma/pkg/test/apis/sample/v1alpha1"
 	sample_model "github.com/Kong/kuma/pkg/test/resources/apis/sample"
 
-	. "github.com/onsi/gomega"
 	"net/http"
+
+	. "github.com/onsi/gomega"
 
 	"github.com/Kong/kuma/pkg/core/resources/model/rest"
 )
@@ -95,16 +97,16 @@ func putSampleResourceIntoStore(resourceStore store.ResourceStore, name string, 
 	Expect(err).NotTo(HaveOccurred())
 }
 
-func createTestApiServer(store store.ResourceStore, config *config_api_server.ApiServerConfig) *api_server.ApiServer {
+func createTestApiServer(store store.ResourceStore, config *config_api_server.ApiServerConfig, defs ...definitions.ResourceWsDefinition) *api_server.ApiServer {
 	// we have to manually search for port and put it into config. There is no way to retrieve port of running
 	// http.Server and we need it later for the client
 	port, err := test.GetFreePort()
 	Expect(err).NotTo(HaveOccurred())
 	config.Port = port
-	defs := []definitions.ResourceWsDefinition{
+	defs = append([]definitions.ResourceWsDefinition{
 		TrafficRouteWsDefinition,
 		definitions.MeshWsDefinition,
-	}
+	}, defs...)
 	resources := manager.NewResourceManager(store)
 	return api_server.NewApiServer(resources, defs, config)
 }

--- a/pkg/api-server/resource_api_client_test.go
+++ b/pkg/api-server/resource_api_client_test.go
@@ -97,16 +97,13 @@ func putSampleResourceIntoStore(resourceStore store.ResourceStore, name string, 
 	Expect(err).NotTo(HaveOccurred())
 }
 
-func createTestApiServer(store store.ResourceStore, config *config_api_server.ApiServerConfig, defs ...definitions.ResourceWsDefinition) *api_server.ApiServer {
+func createTestApiServer(store store.ResourceStore, config *config_api_server.ApiServerConfig) *api_server.ApiServer {
 	// we have to manually search for port and put it into config. There is no way to retrieve port of running
 	// http.Server and we need it later for the client
 	port, err := test.GetFreePort()
 	Expect(err).NotTo(HaveOccurred())
 	config.Port = port
-	defs = append([]definitions.ResourceWsDefinition{
-		TrafficRouteWsDefinition,
-		definitions.MeshWsDefinition,
-	}, defs...)
+	defs := append(definitions.All, SampleTrafficRouteWsDefinition)
 	resources := manager.NewResourceManager(store)
 	return api_server.NewApiServer(resources, defs, config)
 }

--- a/pkg/api-server/resource_ws_test.go
+++ b/pkg/api-server/resource_ws_test.go
@@ -3,7 +3,10 @@ package api_server_test
 import (
 	"context"
 	"fmt"
-	"github.com/Kong/kuma/pkg/api-server"
+	"io/ioutil"
+	"net/http"
+
+	api_server "github.com/Kong/kuma/pkg/api-server"
 	config "github.com/Kong/kuma/pkg/config/api-server"
 	mesh_res "github.com/Kong/kuma/pkg/core/resources/apis/mesh"
 	"github.com/Kong/kuma/pkg/core/resources/model/rest"
@@ -14,8 +17,6 @@ import (
 	"github.com/emicklei/go-restful"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
-	"io/ioutil"
-	"net/http"
 )
 
 var _ = Describe("Resource WS", func() {
@@ -32,7 +33,7 @@ var _ = Describe("Resource WS", func() {
 		apiServer = createTestApiServer(resourceStore, config.DefaultApiServerConfig())
 		client = resourceApiClient{
 			address: apiServer.Address(),
-			path:    "/meshes/" + mesh + "/traffic-routes",
+			path:    "/meshes/" + mesh + "/sample-traffic-routes",
 		}
 		stop = make(chan struct{})
 		go func() {
@@ -67,7 +68,7 @@ var _ = Describe("Resource WS", func() {
 			Expect(err).ToNot(HaveOccurred())
 			json := `
 			{
-				"type": "TrafficRoute",
+				"type": "SampleTrafficRoute",
 				"name": "tr-1",
 				"mesh": "default",
 				"path": "/sample-path"
@@ -105,14 +106,14 @@ var _ = Describe("Resource WS", func() {
 			Expect(response.StatusCode).To(Equal(200))
 			json1 := `
 			{
-				"type": "TrafficRoute",
+				"type": "SampleTrafficRoute",
 				"name": "tr-1",
 				"mesh": "default",
 				"path": "/sample-path"
 			}`
 			json2 := `
 			{
-				"type": "TrafficRoute",
+				"type": "SampleTrafficRoute",
 				"name": "tr-2",
 				"mesh": "default",
 				"path": "/sample-path"
@@ -211,7 +212,7 @@ var _ = Describe("Resource WS", func() {
 			// given
 			json := `
 			{
-				"type": "TrafficRoute",
+				"type": "SampleTrafficRoute",
 				"name": "different-name",
 				"mesh": "default",
 				"path": "/sample-path"
@@ -245,7 +246,7 @@ var _ = Describe("Resource WS", func() {
 			// given
 			json := `
 			{
-				"type": "TrafficRoute",
+				"type": "SampleTrafficRoute",
 				"name": "tr-1",
 				"mesh": "different-mesh",
 				"path": "/sample-path"
@@ -278,7 +279,7 @@ var _ = Describe("Resource WS", func() {
 			// given
 			json := `
 			{
-				"type": "TrafficRoute",
+				"type": "SampleTrafficRoute",
 				"name": "tr-1",
 				"mesh": "default",
 				"path": ""
@@ -314,7 +315,7 @@ var _ = Describe("Resource WS", func() {
 			// given
 			json := `
 			{
-				"type": "TrafficRoute",
+				"type": "SampleTrafficRoute",
 				"name": "invalid@",
 				"mesh": "invalid$",
 				"path": "/path"
@@ -324,7 +325,7 @@ var _ = Describe("Resource WS", func() {
 			// when
 			client = resourceApiClient{
 				address: apiServer.Address(),
-				path:    "/meshes/invalid$/traffic-routes",
+				path:    "/meshes/invalid$/sample-traffic-routes",
 			}
 			response := client.putJson("invalid@", []byte(json))
 
@@ -423,7 +424,7 @@ var _ = Describe("Resource WS", func() {
 
 	It("should support CORS", func() {
 		// when
-		req, err := http.NewRequest("GET", fmt.Sprintf("http://%s/meshes/%s/traffic-routes", apiServer.Address(), mesh), nil)
+		req, err := http.NewRequest("GET", fmt.Sprintf("http://%s/meshes/%s/sample-traffic-routes", apiServer.Address(), mesh), nil)
 		Expect(err).NotTo(HaveOccurred())
 		req.Header.Add(restful.HEADER_Origin, "test")
 

--- a/pkg/api-server/sample_resource_definition_test.go
+++ b/pkg/api-server/sample_resource_definition_test.go
@@ -7,8 +7,8 @@ import (
 )
 
 var TrafficRouteWsDefinition = definitions.ResourceWsDefinition{
-	Name: "Traffic Route",
-	Path: "traffic-routes",
+	Name: "Sample Traffic Route",
+	Path: "sample-traffic-routes",
 	ResourceFactory: func() model.Resource {
 		return &sample_model.TrafficRouteResource{}
 	},

--- a/pkg/api-server/sample_resource_definition_test.go
+++ b/pkg/api-server/sample_resource_definition_test.go
@@ -6,7 +6,7 @@ import (
 	sample_model "github.com/Kong/kuma/pkg/test/resources/apis/sample"
 )
 
-var TrafficRouteWsDefinition = definitions.ResourceWsDefinition{
+var SampleTrafficRouteWsDefinition = definitions.ResourceWsDefinition{
 	Name: "Sample Traffic Route",
 	Path: "sample-traffic-routes",
 	ResourceFactory: func() model.Resource {

--- a/pkg/api-server/traffic_route_ws_test.go
+++ b/pkg/api-server/traffic_route_ws_test.go
@@ -1,0 +1,113 @@
+package api_server_test
+
+import (
+	"context"
+	"io/ioutil"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	"github.com/ghodss/yaml"
+
+	mesh_proto "github.com/Kong/kuma/api/mesh/v1alpha1"
+	api_server "github.com/Kong/kuma/pkg/api-server"
+	"github.com/Kong/kuma/pkg/api-server/definitions"
+	config "github.com/Kong/kuma/pkg/config/api-server"
+	mesh_core "github.com/Kong/kuma/pkg/core/resources/apis/mesh"
+	"github.com/Kong/kuma/pkg/core/resources/model/rest"
+	"github.com/Kong/kuma/pkg/core/resources/store"
+	"github.com/Kong/kuma/pkg/plugins/resources/memory"
+)
+
+var _ = Describe("TrafficRoute WS", func() {
+	var apiServer *api_server.ApiServer
+	var resourceStore store.ResourceStore
+	var client resourceApiClient
+	var stop chan struct{}
+
+	BeforeEach(func() {
+		resourceStore = memory.NewStore()
+		apiServer = createTestApiServer(resourceStore, config.DefaultApiServerConfig(), definitions.TrafficRouteWsDefinition)
+		client = resourceApiClient{
+			apiServer.Address(),
+			"/meshes/default/traffic-routes",
+		}
+		stop = make(chan struct{})
+		go func() {
+			defer GinkgoRecover()
+			err := apiServer.Start(stop)
+			Expect(err).ToNot(HaveOccurred())
+		}()
+		waitForServer(&client)
+	}, 5)
+
+	AfterEach(func() {
+		close(stop)
+	})
+
+	BeforeEach(func() {
+		// when
+		err := resourceStore.Create(context.Background(), &mesh_core.MeshResource{}, store.CreateByKey("default", "default", "default"))
+		// then
+		Expect(err).ToNot(HaveOccurred())
+	})
+
+	Describe("PUT => GET", func() {
+
+		given := `
+        type: TrafficRoute
+        name: web-to-backend
+        mesh: default
+        sources:
+        - match:
+            service: web
+            region: us-east-1
+            version: v10
+        destinations:
+        - match:
+            service: backend
+        conf:
+        - weight: 90
+          destination:
+            service: backend
+            region: us-east-1
+            version: v2
+        - weight: 10
+          destination:
+            service: backend
+            version: v3
+`
+		It("GET should return data saved by PUT", func() {
+			// given
+			resource := rest.Resource{
+				Spec: &mesh_proto.TrafficRoute{},
+			}
+
+			// when
+			err := yaml.Unmarshal([]byte(given), &resource)
+			// then
+			Expect(err).ToNot(HaveOccurred())
+
+			// when
+			response := client.put(resource)
+			// then
+			Expect(response.StatusCode).To(Equal(201))
+
+			// when
+			response = client.get("web-to-backend")
+			// then
+			Expect(response.StatusCode).To(Equal(200))
+			// when
+			body, err := ioutil.ReadAll(response.Body)
+			// then
+			Expect(err).ToNot(HaveOccurred())
+
+			// when
+			actual, err := yaml.JSONToYAML(body)
+			// then
+			Expect(err).ToNot(HaveOccurred())
+			// and
+			Expect(actual).To(MatchYAML(given))
+		})
+	})
+})

--- a/pkg/api-server/traffic_route_ws_test.go
+++ b/pkg/api-server/traffic_route_ws_test.go
@@ -11,7 +11,6 @@ import (
 
 	mesh_proto "github.com/Kong/kuma/api/mesh/v1alpha1"
 	api_server "github.com/Kong/kuma/pkg/api-server"
-	"github.com/Kong/kuma/pkg/api-server/definitions"
 	config "github.com/Kong/kuma/pkg/config/api-server"
 	mesh_core "github.com/Kong/kuma/pkg/core/resources/apis/mesh"
 	"github.com/Kong/kuma/pkg/core/resources/model/rest"
@@ -27,7 +26,7 @@ var _ = Describe("TrafficRoute WS", func() {
 
 	BeforeEach(func() {
 		resourceStore = memory.NewStore()
-		apiServer = createTestApiServer(resourceStore, config.DefaultApiServerConfig(), definitions.TrafficRouteWsDefinition)
+		apiServer = createTestApiServer(resourceStore, config.DefaultApiServerConfig())
 		client = resourceApiClient{
 			apiServer.Address(),
 			"/meshes/default/traffic-routes",

--- a/pkg/core/resources/apis/mesh/traffic_route.go
+++ b/pkg/core/resources/apis/mesh/traffic_route.go
@@ -1,23 +1,22 @@
-package sample
+package mesh
 
 import (
 	"github.com/pkg/errors"
 
+	mesh_proto "github.com/Kong/kuma/api/mesh/v1alpha1"
 	"github.com/Kong/kuma/pkg/core/resources/model"
 	"github.com/Kong/kuma/pkg/core/resources/registry"
-	"github.com/Kong/kuma/pkg/core/validators"
-	proto "github.com/Kong/kuma/pkg/test/apis/sample/v1alpha1"
 )
 
 const (
-	TrafficRouteType model.ResourceType = "SampleTrafficRoute"
+	TrafficRouteType model.ResourceType = "TrafficRoute"
 )
 
 var _ model.Resource = &TrafficRouteResource{}
 
 type TrafficRouteResource struct {
 	Meta model.ResourceMeta
-	Spec proto.TrafficRoute
+	Spec mesh_proto.TrafficRoute
 }
 
 func (t *TrafficRouteResource) GetType() model.ResourceType {
@@ -33,20 +32,16 @@ func (t *TrafficRouteResource) GetSpec() model.ResourceSpec {
 	return &t.Spec
 }
 func (t *TrafficRouteResource) SetSpec(spec model.ResourceSpec) error {
-	route, ok := spec.(*proto.TrafficRoute)
+	template, ok := spec.(*mesh_proto.TrafficRoute)
 	if !ok {
 		return errors.New("invalid type of spec")
 	} else {
-		t.Spec = *route
+		t.Spec = *template
 		return nil
 	}
 }
 func (t *TrafficRouteResource) Validate() error {
-	err := validators.ValidationError{}
-	if t.Spec.Path == "" {
-		err.AddViolation("path", "cannot be empty")
-	}
-	return err.OrNil()
+	return nil
 }
 
 var _ model.ResourceList = &TrafficRouteResourceList{}
@@ -62,7 +57,6 @@ func (l *TrafficRouteResourceList) GetItems() []model.Resource {
 	}
 	return res
 }
-
 func (l *TrafficRouteResourceList) GetItemType() model.ResourceType {
 	return TrafficRouteType
 }

--- a/pkg/plugins/resources/remote/store_test.go
+++ b/pkg/plugins/resources/remote/store_test.go
@@ -120,7 +120,7 @@ var _ = Describe("RemoteStore", func() {
 				Expect(req.URL.Path).To(Equal(fmt.Sprintf("/meshes/default/trafficroutes/%s", name)))
 				bytes, err := ioutil.ReadAll(req.Body)
 				Expect(err).ToNot(HaveOccurred())
-				Expect(string(bytes)).To(Equal(`{"mesh":"default","name":"res-1","path":"/some-path","type":"TrafficRoute"}`))
+				Expect(string(bytes)).To(Equal(`{"mesh":"default","name":"res-1","path":"/some-path","type":"SampleTrafficRoute"}`))
 			})
 
 			// when
@@ -164,7 +164,7 @@ var _ = Describe("RemoteStore", func() {
 				Expect(req.URL.Path).To(Equal(fmt.Sprintf("/meshes/default/trafficroutes/%s", name)))
 				bytes, err := ioutil.ReadAll(req.Body)
 				Expect(err).ToNot(HaveOccurred())
-				Expect(string(bytes)).To(Equal(`{"mesh":"default","name":"res-1","path":"/some-path","type":"TrafficRoute"}`))
+				Expect(string(bytes)).To(Equal(`{"mesh":"default","name":"res-1","path":"/some-path","type":"SampleTrafficRoute"}`))
 			})
 
 			// when


### PR DESCRIPTION
### Summary

* add `TrafficRouteResource` to core model
* update unit tests to avoid collisions with `sample.TrafficRouteResource`