### PR TITLE
kumactl: add column MESH for get proxytemplates

### DIFF
--- a/app/kumactl/cmd/get/get_proxytemplates.go
+++ b/app/kumactl/cmd/get/get_proxytemplates.go
@@ -46,7 +46,7 @@ func newGetProxyTemplatesCmd(pctx *getContext) *cobra.Command {
 
 func PrintProxyTemplates(proxyTemplates *mesh_core.ProxyTemplateResourceList, out io.Writer) error {
 	data := printers.Table{
-		Headers: []string{"NAME"},
+		Headers: []string{"MESH", "NAME"},
 		NextRow: func() func() []string {
 			i := 0
 			return func() []string {
@@ -57,7 +57,8 @@ func PrintProxyTemplates(proxyTemplates *mesh_core.ProxyTemplateResourceList, ou
 				proxyTemplate := proxyTemplates.Items[i]
 
 				return []string{
-					proxyTemplate.Meta.GetName(), // NAME
+					proxyTemplate.GetMeta().GetMesh(), // MESH
+					proxyTemplate.GetMeta().GetName(), // NAME
 				}
 			}
 		}(),

--- a/app/kumactl/cmd/get/testdata/get-proxytemplates.golden.txt
+++ b/app/kumactl/cmd/get/testdata/get-proxytemplates.golden.txt
@@ -1,3 +1,3 @@
-NAME
-custom-template
-another-template
+MESH      NAME
+default   custom-template
+default   another-template


### PR DESCRIPTION
### Summary
Change output of
```
kumactl get proxytemplates
```
from:
```
NAME
custom-template
another-template
```
to:
```
MESH      NAME
default   custom-template
default   another-template
```


### Issues resolved

Fix #358 