### PR TITLE
feat: kumactl parse url 

### DIFF
--- a/app/kumactl/cmd/apply/apply.go
+++ b/app/kumactl/cmd/apply/apply.go
@@ -50,7 +50,7 @@ func NewApplyCmd(pctx *kumactl_cmd.RootContext) *cobra.Command {
 					return err
 				}
 			} else {
-				if strings.HasPrefix(ctx.args.file, "http") {
+				if strings.HasPrefix(ctx.args.file, "http://") || strings.HasPrefix(ctx.args.file, "https://") {
 					client := util_http.ClientWithTimeout(&http.Client{}, timeout)
 					req, err := http.NewRequest("GET", ctx.args.file, nil)
 					if err != nil {

--- a/app/kumactl/cmd/apply/apply.go
+++ b/app/kumactl/cmd/apply/apply.go
@@ -14,9 +14,9 @@ import (
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 	"io/ioutil"
+	"net/http"
 	"strings"
 	"time"
-	"net/http"
 
 	util_http "github.com/Kong/kuma/pkg/util/http"
 )
@@ -46,17 +46,25 @@ func NewApplyCmd(pctx *kumactl_cmd.RootContext) *cobra.Command {
 
 			if ctx.args.file == "" || ctx.args.file == "-" {
 				b, err = ioutil.ReadAll(cmd.InOrStdin())
+				if err != nil {
+					return err
+				}
 			} else {
 				if strings.HasPrefix(ctx.args.file, "http") {
 					client := util_http.ClientWithTimeout(&http.Client{}, timeout)
 					req, err := http.NewRequest("GET", ctx.args.file, nil)
-
+					if err != nil {
+						return errors.Wrap(err, "error creating new http request")
+					}
 					resp, err := client.Do(req)
 					if err != nil {
-						return errors.Wrap(err, "error parsing body from URL")
+						return errors.Wrap(err, "error with GET http request")
 					}
 					defer resp.Body.Close()
 					b, err = ioutil.ReadAll(resp.Body)
+					if err != nil {
+						return errors.Wrap(err, "error with reading GET response")
+					}
 				} else {
 					b, err = ioutil.ReadFile(ctx.args.file)
 				}

--- a/app/kumactl/cmd/apply/apply.go
+++ b/app/kumactl/cmd/apply/apply.go
@@ -15,7 +15,14 @@ import (
 	"github.com/spf13/cobra"
 	"io/ioutil"
 	"strings"
+	"time"
 	"net/http"
+
+	util_http "github.com/Kong/kuma/pkg/util/http"
+)
+
+const (
+	timeout = 10 * time.Second
 )
 
 type applyContext struct {
@@ -41,7 +48,10 @@ func NewApplyCmd(pctx *kumactl_cmd.RootContext) *cobra.Command {
 				b, err = ioutil.ReadAll(cmd.InOrStdin())
 			} else {
 				if strings.HasPrefix(ctx.args.file, "http") {
-					resp, err := http.Get(ctx.args.file)
+					client := util_http.ClientWithTimeout(&http.Client{}, timeout)
+					req, err := http.NewRequest("GET", ctx.args.file, nil)
+
+					resp, err := client.Do(req)
 					if err != nil {
 						return errors.Wrap(err, "error parsing body from URL")
 					}

--- a/app/kumactl/cmd/apply/apply_test.go
+++ b/app/kumactl/cmd/apply/apply_test.go
@@ -199,7 +199,7 @@ var _ = Describe("kumactl apply", func() {
 			}
 			Expect(resp.Body.Close()).To(Succeed())
 			return true
-		}).Should(BeTrue())
+		}, "5s", "100ms").Should(BeTrue())
 
 		// given
 		rootCmd.SetArgs([]string{

--- a/app/kumactl/cmd/apply/apply_test.go
+++ b/app/kumactl/cmd/apply/apply_test.go
@@ -2,13 +2,14 @@ package apply_test
 
 import (
 	"context"
-	"os"
-	"path/filepath"
-	"strings"
+	"fmt"
+	"log"
 	"net/http"
 	"net/http/httptest"
+	"os"
+	"path/filepath"
 	"strconv"
-	"fmt"
+	"strings"
 
 	"github.com/Kong/kuma/api/mesh/v1alpha1"
 	"github.com/Kong/kuma/app/kumactl/cmd"
@@ -181,7 +182,7 @@ var _ = Describe("kumactl apply", func() {
 		Expect(resource.Meta.GetMesh()).To(Equal(""))
 		Expect(resource.Meta.GetNamespace()).To(Equal("default"))
 	})
-	
+
 	It("should apply a new Dataplane resource from URL", func() {
 		// setup http server
 		mux := http.NewServeMux()
@@ -193,11 +194,11 @@ var _ = Describe("kumactl apply", func() {
 			defer GinkgoRecover()
 			// when
 			http.Handle("/testdata/", http.StripPrefix("/testdata/", http.FileServer(http.Dir("./testdata"))))
-			http.ListenAndServe(fmt.Sprintf(":%v", port), nil)
+			log.Fatal(http.ListenAndServe(fmt.Sprintf(":%v", port), nil))
 			// then
 			Expect(err).ToNot(HaveOccurred())
 		}()
-		
+
 		// given
 		rootCmd.SetArgs([]string{
 			"apply", "-f", fmt.Sprintf("http://localhost:%v/testdata/apply-dataplane.yaml", port)},
@@ -205,7 +206,7 @@ var _ = Describe("kumactl apply", func() {
 
 		// when
 		err = rootCmd.Execute()
-		
+
 		// then
 		Expect(err).ToNot(HaveOccurred())
 

--- a/app/kumactl/cmd/apply/apply_test.go
+++ b/app/kumactl/cmd/apply/apply_test.go
@@ -3,7 +3,6 @@ package apply_test
 import (
 	"context"
 	"fmt"
-	"log"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -190,14 +189,9 @@ var _ = Describe("kumactl apply", func() {
 		port, err := strconv.Atoi(strings.Split(server.Listener.Addr().String(), ":")[1])
 		Expect(err).ToNot(HaveOccurred())
 
-		go func() {
-			defer GinkgoRecover()
-			// when
-			http.Handle("/testdata/", http.StripPrefix("/testdata/", http.FileServer(http.Dir("./testdata"))))
-			log.Fatal(http.ListenAndServe(fmt.Sprintf(":%v", port), nil))
-			// then
-			Expect(err).ToNot(HaveOccurred())
-		}()
+		mux.Handle("/testdata/", http.StripPrefix("/testdata/", http.FileServer(http.Dir("./testdata"))))
+		// then
+		Expect(err).ToNot(HaveOccurred())
 
 		// given
 		rootCmd.SetArgs([]string{


### PR DESCRIPTION
### Summary
Kumactl apply should parse URLs, for example:
```
$ kumactl apply -f http://somewhere
```

### Full changelog

* Implement URL parsing for kumactl apply

### Issues resolved

Fix #155
