### PR TITLE
language revision for the config 404 message

### DIFF
--- a/app/kuma-dp/pkg/dataplane/envoy/remote_bootstrap.go
+++ b/app/kuma-dp/pkg/dataplane/envoy/remote_bootstrap.go
@@ -44,7 +44,7 @@ func (b *remoteBootstrap) Generate(cfg kuma_dp.Config) (proto.Message, error) {
 	defer resp.Body.Close()
 	if resp.StatusCode != 200 {
 		if resp.StatusCode == 404 {
-			return nil, errors.New("status: 404. Did you first applied Dataplane resource?")
+			return nil, errors.New("status: 404. Did you first apply a Dataplane resource?")
 		}
 		return nil, errors.Errorf("unexpected status code: %d", resp.StatusCode)
 	}


### PR DESCRIPTION
### Summary

Slight language revision for the error log message that appears when trying to run kuma-dp with no dataplane config supplied.