### PR TITLE
github: add CODEOWNERS file

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,27 @@
+# See https://help.github.com/en/github/creating-cloning-and-archiving-repositories/about-code-owners
+
+# Code owners are automatically requested for review when someone opens a pull request that modifies code that they own.
+# Code owners are not automatically requested to review draft pull requests.
+
+# When someone with admin or owner permissions has enabled required reviews,
+# they also can optionally require approval from a code owner before the author can merge a pull request in the repository.
+
+# The people you choose as code owners must have write permissions for the repository.
+
+# When the code owner is a team, that team must have write permissions,
+# even if all the individual members of the team already have write permissions directly, 
+# through organization membership, or through another team membership.
+
+# Each CODEOWNERS file assigns the code owners for a single branch in the repository.
+
+# For code owners to receive review requests, the CODEOWNERS file must be on the base branch of the pull request.
+
+# A CODEOWNERS file uses a pattern that follows the same rules used in gitignore files. 
+# The pattern is followed by one or more GitHub usernames or team names using the standard @username or @org/team-name format.
+# You can also refer to a user by an email address that has been added to their GitHub account, for example user@example.com.
+
+
+# These owners will be the default owners for everything in this repo.
+# Unless a later match takes precedence, @Kong/team-kuma will be requested for
+# review when someone opens a pull request.
+*       @Kong/team-kuma


### PR DESCRIPTION
### Summary

* add `CODEOWNERS` file to automatically request a review from `@Kong/team-kuma` on every PR

### Context

* see https://help.github.com/en/github/creating-cloning-and-archiving-repositories/about-code-owners