### PR TITLE
feat(kuma-cp) support CORS in api server

### DIFF
--- a/pkg/api-server/resource_ws_test.go
+++ b/pkg/api-server/resource_ws_test.go
@@ -11,9 +11,11 @@ import (
 	"github.com/Kong/kuma/pkg/plugins/resources/memory"
 	sample_proto "github.com/Kong/kuma/pkg/test/apis/sample/v1alpha1"
 	sample_model "github.com/Kong/kuma/pkg/test/resources/apis/sample"
+	"github.com/emicklei/go-restful"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	"io/ioutil"
+	"net/http"
 )
 
 var _ = Describe("Resource WS", func() {
@@ -417,5 +419,24 @@ var _ = Describe("Resource WS", func() {
 			// then
 			Expect(response.StatusCode).To(Equal(200))
 		})
+	})
+
+	It("should support CORS", func() {
+		// when
+		req, err := http.NewRequest("GET", fmt.Sprintf("http://%s/meshes/%s/traffic-routes", apiServer.Address(), mesh), nil)
+		Expect(err).NotTo(HaveOccurred())
+		req.Header.Add(restful.HEADER_Origin, "test")
+
+		// when
+		response, err := http.DefaultClient.Do(req)
+
+		// then
+		Expect(err).NotTo(HaveOccurred())
+
+		// when
+		value := response.Header.Get(restful.HEADER_AccessControlAllowOrigin)
+
+		// then server returns that the domain is allowed
+		Expect(value).To(Equal("test"))
 	})
 })

--- a/pkg/api-server/server.go
+++ b/pkg/api-server/server.go
@@ -32,6 +32,12 @@ func NewApiServer(resManager manager.ResourceManager, defs []definitions.Resourc
 		Handler: container.ServeMux,
 	}
 
+	cors := restful.CrossOriginResourceSharing{
+		ExposeHeaders:  []string{restful.HEADER_AccessControlAllowOrigin},
+		AllowedDomains: serverConfig.CorsAllowedDomains,
+		Container:      container,
+	}
+
 	ws := new(restful.WebService)
 	ws.
 		Path("/meshes").
@@ -43,6 +49,7 @@ func NewApiServer(resManager manager.ResourceManager, defs []definitions.Resourc
 	container.Add(indexWs())
 	container.Add(catalogueWs(*serverConfig.Catalogue))
 
+	ws.Filter(cors.Filter)
 	return &ApiServer{
 		server: srv,
 	}

--- a/pkg/config/api-server/config.go
+++ b/pkg/config/api-server/config.go
@@ -17,6 +17,8 @@ type ApiServerConfig struct {
 	ReadOnly bool `yaml:"readOnly" envconfig:"kuma_api_server_read_only"`
 	// API Catalogue
 	Catalogue *catalogue.CatalogueConfig
+	// Allowed domains for Cross-Origin Resource Sharing. The value can be either domain or regexp
+	CorsAllowedDomains []string `yaml:"corsAllowedDomains" envconfig:"kuma_api_server_cors_allowed_domains"`
 }
 
 func (a *ApiServerConfig) Validate() error {
@@ -28,8 +30,9 @@ func (a *ApiServerConfig) Validate() error {
 
 func DefaultApiServerConfig() *ApiServerConfig {
 	return &ApiServerConfig{
-		Port:      5681,
-		ReadOnly:  false,
-		Catalogue: &catalogue.CatalogueConfig{},
+		Port:               5681,
+		ReadOnly:           false,
+		Catalogue:          &catalogue.CatalogueConfig{},
+		CorsAllowedDomains: []string{".*"},
 	}
 }

--- a/pkg/config/app/kuma-cp/kuma-cp.defaults.yaml
+++ b/pkg/config/app/kuma-cp/kuma-cp.defaults.yaml
@@ -90,6 +90,9 @@ apiServer:
   port: 5681 # ENV: KUMA_API_SERVER_PORT
   # If true, then API Server will operate in read only mode (serving GET requests)
   readOnly: false # ENV: KUMA_API_SERVER_READ_ONLY
+  # Allowed domains for Cross-Origin Resource Sharing. The value can be either domain or regexp
+  corsAllowedDomains:
+    - ".*" # ENV: KUMA_API_SERVER_CORS_ALLOWED_DOMAINS
 
 # Environment-specific configuration
 runtime:

--- a/pkg/config/loader_test.go
+++ b/pkg/config/loader_test.go
@@ -80,6 +80,7 @@ var _ = Describe("Config loader", func() {
 
 			Expect(cfg.ApiServer.Port).To(Equal(9090))
 			Expect(cfg.ApiServer.ReadOnly).To(Equal(true))
+			Expect(cfg.ApiServer.CorsAllowedDomains).To(Equal([]string{"https://kuma", "https://someapi"}))
 
 			Expect(cfg.DataplaneTokenServer.Local.Port).To(Equal(uint32(1111)))
 			Expect(cfg.DataplaneTokenServer.Public.Port).To(Equal(uint32(2222)))
@@ -121,6 +122,9 @@ bootstrapServer:
 apiServer:
   port: 9090
   readOnly: true
+  corsAllowedDomains:
+    - https://kuma
+    - https://someapi
 dataplaneTokenServer:
   local:
     port: 1111
@@ -173,6 +177,7 @@ general:
 				"KUMA_KUBERNETES_ADMISSION_SERVER_PORT":                "9443",
 				"KUMA_KUBERNETES_ADMISSION_SERVER_CERT_DIR":            "/var/run/secrets/kuma.io/kuma-admission-server/tls-cert",
 				"KUMA_GENERAL_ADVERTISED_HOSTNAME":                     "kuma.internal",
+				"KUMA_API_SERVER_CORS_ALLOWED_DOMAINS":                 "https://kuma,https://someapi",
 			},
 			yamlFileConfig: "",
 		}),


### PR DESCRIPTION
### Summary

Use support of CORS in go-restful.

### Issues resolved

Fix #409
