### PR TITLE
kuma-cp: pick a single the most specific TrafficRoute for every outbound interface of a Dataplane

### DIFF
--- a/api/mesh/v1alpha1/dataplane_helpers.go
+++ b/api/mesh/v1alpha1/dataplane_helpers.go
@@ -223,6 +223,10 @@ func MatchAll() TagSelector {
 	return nil
 }
 
+func MatchAnyService() TagSelector {
+	return MatchService(MatchAllTag)
+}
+
 func MatchService(service string) TagSelector {
 	return TagSelector{ServiceTag: service}
 }

--- a/api/mesh/v1alpha1/dataplane_helpers.go
+++ b/api/mesh/v1alpha1/dataplane_helpers.go
@@ -162,6 +162,14 @@ func (n *Dataplane_Networking) GetInboundInterfaces() ([]InboundInterface, error
 	return ifaces, nil
 }
 
+// Matches is simply an alias for MatchTags to make source code more aesthetic.
+func (d *Dataplane) Matches(selector TagSelector) bool {
+	if d != nil {
+		return d.MatchTags(selector)
+	}
+	return false
+}
+
 func (d *Dataplane) MatchTags(selector TagSelector) bool {
 	for _, inbound := range d.GetNetworking().GetInbound() {
 		if inbound.MatchTags(selector) {
@@ -200,9 +208,36 @@ func (s TagSelector) Matches(tags map[string]string) bool {
 	return true
 }
 
-type Tags map[string]map[string]bool
+func (s TagSelector) Rank() (r TagSelectorRank) {
+	for _, value := range s {
+		if value == MatchAllTag {
+			r.WildcardMatches++
+		} else {
+			r.ExactMatches++
+		}
+	}
+	return
+}
 
-func (t Tags) Values(key string) []string {
+func MatchAll() TagSelector {
+	return nil
+}
+
+func MatchService(service string) TagSelector {
+	return TagSelector{ServiceTag: service}
+}
+
+func MatchTags(tags map[string]string) TagSelector {
+	return TagSelector(tags)
+}
+
+// Set of tags that only allows a single value per key.
+type SingleValueTagSet map[string]string
+
+// Set of tags that allows multiple values per key.
+type MultiValueTagSet map[string]map[string]bool
+
+func (t MultiValueTagSet) Values(key string) []string {
 	if t == nil {
 		return nil
 	}
@@ -214,8 +249,8 @@ func (t Tags) Values(key string) []string {
 	return result
 }
 
-func (d *Dataplane) Tags() Tags {
-	tags := Tags{}
+func (d *Dataplane) Tags() MultiValueTagSet {
+	tags := MultiValueTagSet{}
 	for _, inbound := range d.GetNetworking().GetInbound() {
 		for tag, value := range inbound.Tags {
 			_, exists := tags[tag]
@@ -236,11 +271,35 @@ func (d *Dataplane) GetIdentifyingService() string {
 	return ServiceUnknown
 }
 
-func (t Tags) String() string {
+func (t MultiValueTagSet) String() string {
 	var tags []string
 	for tag := range t {
 		tags = append(tags, fmt.Sprintf("%s=%s", tag, strings.Join(t.Values(tag), ",")))
 	}
 	sort.Strings(tags)
 	return strings.Join(tags, " ")
+}
+
+// TagSelectorRank helps to decide which of 2 selectors is more specific.
+type TagSelectorRank struct {
+	// Number of tags that match by the exact value.
+	ExactMatches int
+	// Number of tags that match by a wildcard ('*').
+	WildcardMatches int
+}
+
+func (r TagSelectorRank) CombinedWith(other TagSelectorRank) TagSelectorRank {
+	return TagSelectorRank{
+		ExactMatches:    r.ExactMatches + other.ExactMatches,
+		WildcardMatches: r.WildcardMatches + other.WildcardMatches,
+	}
+}
+
+func (r TagSelectorRank) CompareTo(other TagSelectorRank) int {
+	thisTotal := r.ExactMatches + r.WildcardMatches
+	otherTotal := other.ExactMatches + other.WildcardMatches
+	if thisTotal == otherTotal {
+		return r.ExactMatches - other.ExactMatches
+	}
+	return thisTotal - otherTotal
 }

--- a/pkg/xds/envoy/envoy.go
+++ b/pkg/xds/envoy/envoy.go
@@ -1,7 +1,6 @@
 package envoy
 
 import (
-	"net"
 	"time"
 
 	"github.com/Kong/kuma/api/mesh/v1alpha1"
@@ -56,7 +55,7 @@ func CreateStaticEndpoint(clusterName string, address string, port uint32) *v2.C
 	}
 }
 
-func CreateClusterLoadAssignment(clusterName string, endpoints []net.SRV) *v2.ClusterLoadAssignment {
+func CreateClusterLoadAssignment(clusterName string, endpoints []core_xds.Endpoint) *v2.ClusterLoadAssignment {
 	lbEndpoints := make([]*envoy_endpoint.LbEndpoint, 0, len(endpoints))
 	for _, ep := range endpoints {
 		lbEndpoints = append(lbEndpoints, &envoy_endpoint.LbEndpoint{
@@ -68,7 +67,7 @@ func CreateClusterLoadAssignment(clusterName string, endpoints []net.SRV) *v2.Cl
 								Protocol: envoy_core.SocketAddress_TCP,
 								Address:  ep.Target,
 								PortSpecifier: &envoy_core.SocketAddress_PortValue{
-									PortValue: uint32(ep.Port),
+									PortValue: ep.Port,
 								},
 							},
 						},

--- a/pkg/xds/envoy/envoy_test.go
+++ b/pkg/xds/envoy/envoy_test.go
@@ -1,8 +1,6 @@
 package envoy_test
 
 import (
-	"net"
-
 	"github.com/Kong/kuma/pkg/core/xds"
 
 	. "github.com/onsi/ginkgo"
@@ -257,7 +255,7 @@ var _ = Describe("Envoy", func() {
 `
 		// when
 		resource := envoy.CreateClusterLoadAssignment("127.0.0.1:8080",
-			[]net.SRV{
+			[]xds.Endpoint{
 				{Target: "192.168.0.1", Port: 8081},
 				{Target: "192.168.0.2", Port: 8082},
 			})

--- a/pkg/xds/generator/outbound_proxy_generator_test.go
+++ b/pkg/xds/generator/outbound_proxy_generator_test.go
@@ -1,10 +1,10 @@
 package generator_test
 
 import (
-	"github.com/Kong/kuma/pkg/core/logs"
 	"io/ioutil"
-	"net"
 	"path/filepath"
+
+	"github.com/Kong/kuma/pkg/core/logs"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/ginkgo/extensions/table"
@@ -64,12 +64,12 @@ var _ = Describe("OutboundProxyGenerator", func() {
 					},
 					Spec: dataplane,
 				},
-				OutboundTargets: map[string][]net.SRV{
-					"backend": []net.SRV{
+				OutboundTargets: map[string][]model.Endpoint{
+					"backend": []model.Endpoint{
 						{Target: "192.168.0.1", Port: 8081},
 						{Target: "192.168.0.2", Port: 8082},
 					},
-					"db": []net.SRV{
+					"db": []model.Endpoint{
 						{Target: "192.168.0.3", Port: 5432},
 					},
 				},

--- a/pkg/xds/server/components.go
+++ b/pkg/xds/server/components.go
@@ -113,7 +113,17 @@ func DefaultDataplaneSyncTracker(rt core_runtime.Runtime, reconciler SnapshotRec
 					},
 				}
 
-				outbound, err := xds_topology.GetOutboundTargets(ctx, dataplane, rt.ResourceManager())
+				// pick a single the most specific route for each outbound interface
+				routes, err := xds_topology.GetRoutes(ctx, dataplane, rt.ResourceManager())
+				if err != nil {
+					return err
+				}
+
+				// create creates a map of selectors to match other dataplanes reachable via given routes
+				destinations := xds_topology.BuildDestinationMap(dataplane, routes)
+
+				// resolve all endpoints that match given selectors
+				outbound, err := xds_topology.GetOutboundTargets(ctx, dataplane, destinations, rt.ResourceManager())
 				if err != nil {
 					return err
 				}
@@ -132,6 +142,7 @@ func DefaultDataplaneSyncTracker(rt core_runtime.Runtime, reconciler SnapshotRec
 					Id:                 proxyID,
 					Dataplane:          dataplane,
 					TrafficPermissions: matchedPermissions,
+					TrafficRoutes:      routes,
 					OutboundTargets:    outbound,
 					Logs:               matchedLogs,
 					Metadata:           metadataTracker.Metadata(streamId),

--- a/pkg/xds/topology/outbound.go
+++ b/pkg/xds/topology/outbound.go
@@ -2,38 +2,62 @@ package topology
 
 import (
 	"context"
-	"net"
 
 	mesh_proto "github.com/Kong/kuma/api/mesh/v1alpha1"
 	mesh_core "github.com/Kong/kuma/pkg/core/resources/apis/mesh"
 	core_manager "github.com/Kong/kuma/pkg/core/resources/manager"
 	core_store "github.com/Kong/kuma/pkg/core/resources/store"
+	core_xds "github.com/Kong/kuma/pkg/core/xds"
 )
 
-func GetOutboundTargets(ctx context.Context, dataplane *mesh_core.DataplaneResource, manager core_manager.ResourceManager) (map[string][]net.SRV, error) {
-	outbound := make(map[string][]net.SRV)
-	if len(dataplane.Spec.Networking.GetOutbound()) > 0 {
-		dataplanes := &mesh_core.DataplaneResourceList{}
-		if err := manager.List(ctx, dataplanes, core_store.ListByMesh(dataplane.Meta.GetMesh())); err != nil {
-			return nil, err
-		}
-		for _, oface := range dataplane.Spec.Networking.GetOutbound() {
-			outbound[oface.Service] = make([]net.SRV, 0)
-		}
-		for _, dataplane := range dataplanes.Items {
-			for _, inbound := range dataplane.Spec.Networking.GetInbound() {
-				service := inbound.Tags[mesh_proto.ServiceTag]
-				endpoints, ok := outbound[service]
-				if !ok {
-					continue
-				}
-				iface, err := mesh_proto.ParseInboundInterface(inbound.Interface)
-				if err != nil {
-					return nil, err
-				}
-				outbound[service] = append(endpoints, net.SRV{Target: iface.DataplaneIP, Port: uint16(iface.DataplanePort)})
+// GetOutboundTargets resolves all endpoints reachable from a given dataplane.
+func GetOutboundTargets(ctx context.Context, dataplane *mesh_core.DataplaneResource, destinations core_xds.DestinationMap, manager core_manager.ResourceManager) (core_xds.EndpointMap, error) {
+	if len(destinations) == 0 {
+		return nil, nil
+	}
+	dataplanes := &mesh_core.DataplaneResourceList{}
+	if err := manager.List(ctx, dataplanes, core_store.ListByMesh(dataplane.Meta.GetMesh())); err != nil {
+		return nil, err
+	}
+	return BuildEndpointMap(destinations, dataplanes.Items), nil
+}
+
+// BuildEndpointMap creates a map of all endpoints that match given selectors.
+func BuildEndpointMap(destinations core_xds.DestinationMap, dataplanes []*mesh_core.DataplaneResource) core_xds.EndpointMap {
+	if len(destinations) == 0 {
+		return nil
+	}
+	outbound := core_xds.EndpointMap{}
+	for _, dataplane := range dataplanes {
+		for _, inbound := range dataplane.Spec.Networking.GetInbound() {
+			service := inbound.Tags[mesh_proto.ServiceTag]
+			selectors, ok := destinations[service]
+			if !ok {
+				continue
 			}
+			matches := false
+			for _, selector := range selectors {
+				if selector.Matches(inbound.Tags) {
+					matches = true
+					break
+				}
+			}
+			if !matches {
+				continue
+			}
+			iface, err := mesh_proto.ParseInboundInterface(inbound.Interface)
+			if err != nil {
+				// skip dataplanes with invalid configuration
+				continue
+			}
+			// TODO(yskopets): do we need to dedup?
+			// TODO(yskopets): sort ?
+			outbound[service] = append(outbound[service], core_xds.Endpoint{
+				Target: iface.DataplaneIP,
+				Port:   iface.DataplanePort,
+				Tags:   inbound.Tags,
+			})
 		}
 	}
-	return outbound, nil
+	return outbound
 }

--- a/pkg/xds/topology/outbound_test.go
+++ b/pkg/xds/topology/outbound_test.go
@@ -1,0 +1,386 @@
+package topology_test
+
+import (
+	"context"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/ginkgo/extensions/table"
+	. "github.com/onsi/gomega"
+
+	. "github.com/Kong/kuma/pkg/xds/topology"
+
+	mesh_proto "github.com/Kong/kuma/api/mesh/v1alpha1"
+	mesh_core "github.com/Kong/kuma/pkg/core/resources/apis/mesh"
+	core_manager "github.com/Kong/kuma/pkg/core/resources/manager"
+	core_model "github.com/Kong/kuma/pkg/core/resources/model"
+	core_store "github.com/Kong/kuma/pkg/core/resources/store"
+	core_xds "github.com/Kong/kuma/pkg/core/xds"
+	memory_resources "github.com/Kong/kuma/pkg/plugins/resources/memory"
+	test_model "github.com/Kong/kuma/pkg/test/resources/model"
+)
+
+var _ = Describe("TrafficRoute", func() {
+
+	var ctx context.Context
+	var rm core_manager.ResourceManager
+
+	BeforeEach(func() {
+		ctx = context.Background()
+		rm = core_manager.NewResourceManager(memory_resources.NewStore())
+	})
+
+	Describe("GetOutboundTargets()", func() {
+
+		It("should pick proper dataplanes for each outbound destination", func() {
+			// given
+			mesh := &mesh_core.MeshResource{ // mesh that is relevant to this test case
+				Meta: &test_model.ResourceMeta{
+					Mesh: "demo",
+					Name: "demo",
+				},
+			}
+			otherMesh := &mesh_core.MeshResource{ // mesh that is irrelevant to this test case
+				Meta: &test_model.ResourceMeta{
+					Mesh: "default",
+					Name: "default",
+				},
+			}
+			backend := &mesh_core.DataplaneResource{ // dataplane that is a source of traffic
+				Meta: &test_model.ResourceMeta{
+					Mesh: "demo",
+					Name: "backend",
+				},
+				Spec: mesh_proto.Dataplane{
+					Networking: &mesh_proto.Dataplane_Networking{
+						Inbound: []*mesh_proto.Dataplane_Networking_Inbound{
+							{Tags: map[string]string{"service": "backend", "region": "eu"}, Interface: "192.168.0.1:8080:18080"},
+							{Tags: map[string]string{"service": "frontend", "region": "eu"}, Interface: "192.168.0.1:7070:17070"},
+						},
+						Outbound: []*mesh_proto.Dataplane_Networking_Outbound{
+							{Service: "redis", Interface: ":10001"},
+							{Service: "elastic", Interface: ":10002"},
+						},
+					},
+				},
+			}
+			redisV1 := &mesh_core.DataplaneResource{ // dataplane that must become a target
+				Meta: &test_model.ResourceMeta{
+					Mesh: "demo",
+					Name: "redis-v1",
+				},
+				Spec: mesh_proto.Dataplane{
+					Networking: &mesh_proto.Dataplane_Networking{
+						Inbound: []*mesh_proto.Dataplane_Networking_Inbound{
+							{Tags: map[string]string{"service": "redis", "version": "v1"}, Interface: "192.168.0.2:6379:16379"},
+						},
+					},
+				},
+			}
+			redisV2 := &mesh_core.DataplaneResource{ // dataplane that must be ingored (due to `mesh: default`)
+				Meta: &test_model.ResourceMeta{
+					Mesh: "default", // other mesh
+					Name: "redis-v2",
+				},
+				Spec: mesh_proto.Dataplane{
+					Networking: &mesh_proto.Dataplane_Networking{
+						Inbound: []*mesh_proto.Dataplane_Networking_Inbound{
+							{Tags: map[string]string{"service": "redis", "version": "v2"}, Interface: "192.168.0.3:6379:26379"},
+						},
+					},
+				},
+			}
+			redisV3 := &mesh_core.DataplaneResource{ // dataplane that must be ingored (due to `version: v3`)
+				Meta: &test_model.ResourceMeta{
+					Mesh: "demo",
+					Name: "redis-v3",
+				},
+				Spec: mesh_proto.Dataplane{
+					Networking: &mesh_proto.Dataplane_Networking{
+						Inbound: []*mesh_proto.Dataplane_Networking_Inbound{
+							{Tags: map[string]string{"service": "redis", "version": "v3"}, Interface: "192.168.0.4:6379:36379"},
+						},
+					},
+				},
+			}
+			elasticEU := &mesh_core.DataplaneResource{ // dataplane that must be ingored (due to `region: eu`)
+				Meta: &test_model.ResourceMeta{
+					Mesh: "demo",
+					Name: "elastic-eu",
+				},
+				Spec: mesh_proto.Dataplane{
+					Networking: &mesh_proto.Dataplane_Networking{
+						Inbound: []*mesh_proto.Dataplane_Networking_Inbound{
+							{Tags: map[string]string{"service": "elastic", "region": "eu"}, Interface: "192.168.0.5:9200:49200"},
+						},
+					},
+				},
+			}
+			elasticUS := &mesh_core.DataplaneResource{ // dataplane that must become a target
+				Meta: &test_model.ResourceMeta{
+					Mesh: "demo",
+					Name: "elastic-us",
+				},
+				Spec: mesh_proto.Dataplane{
+					Networking: &mesh_proto.Dataplane_Networking{
+						Inbound: []*mesh_proto.Dataplane_Networking_Inbound{
+							{Tags: map[string]string{"service": "elastic", "region": "us"}, Interface: "192.168.0.6:9200:59200"},
+						},
+					},
+				},
+			}
+			destinations := core_xds.DestinationMap{
+				"redis": []mesh_proto.TagSelector{
+					{"service": "redis", "version": "v1"},
+					{"service": "redis", "version": "v2"},
+				},
+				"elastic": []mesh_proto.TagSelector{
+					{"service": "elastic", "region": "us"},
+					{"service": "elastic", "region": "au"},
+				},
+			}
+			for _, resource := range []core_model.Resource{mesh, backend, redisV1, redisV3, elasticEU, elasticUS, otherMesh, redisV2} {
+				// when
+				err := rm.Create(ctx, resource, core_store.CreateBy(core_model.MetaToResourceKey(resource.GetMeta())))
+				// then
+				Expect(err).ToNot(HaveOccurred())
+			}
+
+			// when
+			targets, err := GetOutboundTargets(ctx, backend, destinations, rm)
+
+			// then
+			Expect(err).ToNot(HaveOccurred())
+			// and
+			Expect(targets).To(HaveLen(2))
+			// and
+			Expect(targets).To(HaveKeyWithValue("redis", []core_xds.Endpoint{
+				{Target: "192.168.0.2", Port: 6379, Tags: map[string]string{"service": "redis", "version": "v1"}},
+			}))
+			Expect(targets).To(HaveKeyWithValue("elastic", []core_xds.Endpoint{
+				{Target: "192.168.0.6", Port: 9200, Tags: map[string]string{"service": "elastic", "region": "us"}},
+			}))
+		})
+	})
+
+	Describe("BuildEndpointMap()", func() {
+		type testCase struct {
+			destinations core_xds.DestinationMap
+			dataplanes   []*mesh_core.DataplaneResource
+			expected     core_xds.EndpointMap
+		}
+		DescribeTable("should include only those dataplanes that match given selectors",
+			func(given testCase) {
+				// when
+				endpoints := BuildEndpointMap(given.destinations, given.dataplanes)
+				// then
+				Expect(endpoints).To(Equal(given.expected))
+			},
+			Entry("no destinations", testCase{
+				destinations: core_xds.DestinationMap{},
+				dataplanes:   []*mesh_core.DataplaneResource{},
+				expected:     nil,
+			}),
+			Entry("no dataplanes", testCase{
+				destinations: core_xds.DestinationMap{
+					"redis": []mesh_proto.TagSelector{{"service": "redis"}},
+				},
+				dataplanes: []*mesh_core.DataplaneResource{},
+				expected:   core_xds.EndpointMap{},
+			}),
+			Entry("no dataplanes for that service", testCase{
+				destinations: core_xds.DestinationMap{
+					"redis": []mesh_proto.TagSelector{{"service": "redis"}},
+				},
+				dataplanes: []*mesh_core.DataplaneResource{
+					{
+						Spec: mesh_proto.Dataplane{
+							Networking: &mesh_proto.Dataplane_Networking{
+								Inbound: []*mesh_proto.Dataplane_Networking_Inbound{
+									{Interface: "192.168.0.1:9200:19200", Tags: map[string]string{"service": "elastic"}},
+								},
+							},
+						},
+					},
+				},
+				expected: core_xds.EndpointMap{},
+			}),
+			Entry("no dataplanes with matching tags", testCase{
+				destinations: core_xds.DestinationMap{
+					"redis": []mesh_proto.TagSelector{{"service": "redis", "version": "v1"}},
+				},
+				dataplanes: []*mesh_core.DataplaneResource{
+					{
+						Spec: mesh_proto.Dataplane{
+							Networking: &mesh_proto.Dataplane_Networking{
+								Inbound: []*mesh_proto.Dataplane_Networking_Inbound{
+									{Interface: "192.168.0.1:6379:16379", Tags: map[string]string{"service": "redis", "version": "v2"}},
+								},
+							},
+						},
+					},
+				},
+				expected: core_xds.EndpointMap{},
+			}),
+			Entry("dataplane with invalid inbound interface", testCase{
+				destinations: core_xds.DestinationMap{
+					"redis": []mesh_proto.TagSelector{{"service": "redis"}},
+				},
+				dataplanes: []*mesh_core.DataplaneResource{
+					{
+						Spec: mesh_proto.Dataplane{
+							Networking: &mesh_proto.Dataplane_Networking{
+								Inbound: []*mesh_proto.Dataplane_Networking_Inbound{
+									{Interface: "192.168.0.1:6379:16379", Tags: map[string]string{"service": "redis", "version": "v1"}},
+								},
+							},
+						},
+					},
+					{
+						Spec: mesh_proto.Dataplane{
+							Networking: &mesh_proto.Dataplane_Networking{
+								Inbound: []*mesh_proto.Dataplane_Networking_Inbound{
+									{Interface: "invalid value", Tags: map[string]string{"service": "redis", "version": "v2"}},
+								},
+							},
+						},
+					},
+					{
+						Spec: mesh_proto.Dataplane{
+							Networking: &mesh_proto.Dataplane_Networking{
+								Inbound: []*mesh_proto.Dataplane_Networking_Inbound{
+									{Interface: "192.168.0.3:6379:36379", Tags: map[string]string{"service": "redis", "version": "v3"}},
+								},
+							},
+						},
+					},
+				},
+				expected: core_xds.EndpointMap{
+					"redis": []core_xds.Endpoint{
+						{Target: "192.168.0.1", Port: 6379, Tags: map[string]string{"service": "redis", "version": "v1"}},
+						{Target: "192.168.0.3", Port: 6379, Tags: map[string]string{"service": "redis", "version": "v3"}},
+					},
+				},
+			}),
+			Entry("destination with multiple selectors", testCase{
+				destinations: core_xds.DestinationMap{
+					"redis": []mesh_proto.TagSelector{
+						{"service": "redis", "region": "eu"},
+						{"service": "redis", "region": "us"},
+					},
+				},
+				dataplanes: []*mesh_core.DataplaneResource{
+					{
+						Spec: mesh_proto.Dataplane{
+							Networking: &mesh_proto.Dataplane_Networking{
+								Inbound: []*mesh_proto.Dataplane_Networking_Inbound{
+									{Interface: "192.168.0.1:6379:16379", Tags: map[string]string{"service": "redis", "region": "us"}},
+								},
+							},
+						},
+					},
+				},
+				expected: core_xds.EndpointMap{
+					"redis": []core_xds.Endpoint{
+						{Target: "192.168.0.1", Port: 6379, Tags: map[string]string{"service": "redis", "region": "us"}},
+					},
+				},
+			}),
+			Entry("destination with multiple matching selectors", testCase{
+				destinations: core_xds.DestinationMap{
+					"redis": []mesh_proto.TagSelector{
+						{"service": "redis"},
+						{"service": "redis", "region": "us"},
+					},
+				},
+				dataplanes: []*mesh_core.DataplaneResource{
+					{
+						Spec: mesh_proto.Dataplane{
+							Networking: &mesh_proto.Dataplane_Networking{
+								Inbound: []*mesh_proto.Dataplane_Networking_Inbound{
+									{Interface: "192.168.0.1:6379:16379", Tags: map[string]string{"service": "redis", "region": "us"}},
+								},
+							},
+						},
+					},
+				},
+				expected: core_xds.EndpointMap{
+					"redis": []core_xds.Endpoint{
+						{Target: "192.168.0.1", Port: 6379, Tags: map[string]string{"service": "redis", "region": "us"}},
+					},
+				},
+			}),
+			Entry("multiple destinations", testCase{
+				destinations: core_xds.DestinationMap{
+					"redis": []mesh_proto.TagSelector{
+						{"service": "redis"},
+						{"service": "redis", "version": "v1"},
+					},
+					"elastic": []mesh_proto.TagSelector{
+						{"service": "elastic"},
+						{"service": "elastic", "region": "eu"},
+					},
+				},
+				dataplanes: []*mesh_core.DataplaneResource{
+					{
+						Spec: mesh_proto.Dataplane{
+							Networking: &mesh_proto.Dataplane_Networking{
+								Inbound: []*mesh_proto.Dataplane_Networking_Inbound{
+									{Interface: "192.168.0.1:6379:16379", Tags: map[string]string{"service": "redis", "version": "v1"}},
+								},
+							},
+						},
+					},
+					{
+						Spec: mesh_proto.Dataplane{
+							Networking: &mesh_proto.Dataplane_Networking{
+								Inbound: []*mesh_proto.Dataplane_Networking_Inbound{
+									{Interface: "192.168.0.2:9200:19200", Tags: map[string]string{"service": "elastic", "region": "us"}},
+								},
+							},
+						},
+					},
+				},
+				expected: core_xds.EndpointMap{
+					"redis": []core_xds.Endpoint{
+						{Target: "192.168.0.1", Port: 6379, Tags: map[string]string{"service": "redis", "version": "v1"}},
+					},
+					"elastic": []core_xds.Endpoint{
+						{Target: "192.168.0.2", Port: 9200, Tags: map[string]string{"service": "elastic", "region": "us"}},
+					},
+				},
+			}),
+			Entry("multiple destinations implemented by a single dataplane", testCase{
+				destinations: core_xds.DestinationMap{
+					"redis": []mesh_proto.TagSelector{
+						{"service": "redis"},
+						{"service": "redis", "version": "v1"},
+					},
+					"elastic": []mesh_proto.TagSelector{
+						{"service": "elastic"},
+						{"service": "elastic", "region": "eu"},
+					},
+				},
+				dataplanes: []*mesh_core.DataplaneResource{
+					{
+						Spec: mesh_proto.Dataplane{
+							Networking: &mesh_proto.Dataplane_Networking{
+								Inbound: []*mesh_proto.Dataplane_Networking_Inbound{
+									{Interface: "192.168.0.1:6379:16379", Tags: map[string]string{"service": "redis", "version": "v1"}},
+									{Interface: "192.168.0.2:9200:19200", Tags: map[string]string{"service": "elastic", "region": "us"}},
+								},
+							},
+						},
+					},
+				},
+				expected: core_xds.EndpointMap{
+					"redis": []core_xds.Endpoint{
+						{Target: "192.168.0.1", Port: 6379, Tags: map[string]string{"service": "redis", "version": "v1"}},
+					},
+					"elastic": []core_xds.Endpoint{
+						{Target: "192.168.0.2", Port: 9200, Tags: map[string]string{"service": "elastic", "region": "us"}},
+					},
+				},
+			}),
+		)
+	})
+})

--- a/pkg/xds/topology/router.go
+++ b/pkg/xds/topology/router.go
@@ -1,0 +1,171 @@
+package topology
+
+import (
+	"context"
+	"sort"
+
+	mesh_proto "github.com/Kong/kuma/api/mesh/v1alpha1"
+	mesh_core "github.com/Kong/kuma/pkg/core/resources/apis/mesh"
+	core_manager "github.com/Kong/kuma/pkg/core/resources/manager"
+	core_store "github.com/Kong/kuma/pkg/core/resources/store"
+	core_xds "github.com/Kong/kuma/pkg/core/xds"
+)
+
+type pseudoMeta struct {
+	Name string
+}
+
+func (m *pseudoMeta) GetMesh() string {
+	return ""
+}
+func (m *pseudoMeta) GetNamespace() string {
+	return ""
+}
+func (m *pseudoMeta) GetName() string {
+	return m.Name
+}
+func (m *pseudoMeta) GetVersion() string {
+	return ""
+}
+
+// GetRoutes picks a single the most specific route for each outbound interface of a given Dataplane.
+func GetRoutes(ctx context.Context, dataplane *mesh_core.DataplaneResource, manager core_manager.ResourceManager) (core_xds.RouteMap, error) {
+	if len(dataplane.Spec.Networking.GetOutbound()) == 0 {
+		return nil, nil
+	}
+	routes := &mesh_core.TrafficRouteResourceList{}
+	if err := manager.List(ctx, routes, core_store.ListByMesh(dataplane.Meta.GetMesh())); err != nil {
+		return nil, err
+	}
+	return BuildRouteMap(dataplane, routes.Items), nil
+}
+
+// BuildRouteMap picks a single the most specific route for each outbound interface of a given Dataplane.
+func BuildRouteMap(dataplane *mesh_core.DataplaneResource, routes []*mesh_core.TrafficRouteResource) core_xds.RouteMap {
+	sort.Stable(TrafficRoutesByNamespacedName(routes)) // sort to avoid flakiness
+
+	// First, select only those TrafficRoutes that have a `source` selector matching a given Dataplane.
+	// If a TrafficRoute has multiple matching `source` selectors, we need to choose the most specific one.
+	// Technically, we give a rank to every matching selector. The more specific selector is, the higher rank it gets.
+
+	type candidateBySource struct {
+		route          *mesh_core.TrafficRouteResource
+		bestSourceRank mesh_proto.TagSelectorRank
+	}
+
+	candidatesBySource := []candidateBySource{}
+	for _, route := range routes {
+		candidate := candidateBySource{route: route}
+		matches := false
+		for _, source := range route.Spec.Sources {
+			sourceSelector := mesh_proto.TagSelector(source.Match)
+			if dataplane.Spec.Matches(sourceSelector) {
+				sourceRank := sourceSelector.Rank()
+				if !matches || sourceRank.CompareTo(candidate.bestSourceRank) > 0 {
+					// TODO(yskopets): use CreationDate to resolve a conflict between 2 equal ranks
+					candidate.bestSourceRank = sourceRank
+				}
+				matches = true
+			}
+		}
+		if matches {
+			candidatesBySource = append(candidatesBySource, candidate)
+		}
+	}
+
+	// Then, for each outbound interface consider all TrafficRoutes that match it by a `destination` selector.
+	// If a TrafficRoute has multiple matching `destination` selectors, we need to choose the most specific one.
+	//
+	// It's possible that there will be multiple TrafficRoutes that match a given outbound interface.
+	// To choose between them, we need to compute an aggregate rank of the most specific selector by `source`
+	// with the most specific selector by `destination`.
+
+	type candidateByDestination struct {
+		candidateBySource
+		bestAggregateRank mesh_proto.TagSelectorRank
+	}
+
+	candidatesByDestination := map[core_xds.ServiceName]candidateByDestination{}
+	for _, oface := range dataplane.Spec.Networking.GetOutbound() {
+		if _, ok := candidatesByDestination[oface.Service]; ok {
+			// apparently, multiple outbound interfaces of a given Dataplane refer to the same service
+			continue
+		}
+		outboundTags := mesh_proto.SingleValueTagSet{mesh_proto.ServiceTag: oface.Service}
+		for _, candidateBySource := range candidatesBySource {
+			for _, destination := range candidateBySource.route.Spec.Destinations {
+				destinationSelector := mesh_proto.TagSelector(destination.Match)
+				if destinationSelector.Matches(outboundTags) {
+					aggregateRank := destinationSelector.Rank().CombinedWith(candidateBySource.bestSourceRank)
+
+					candidateByDestination, exists := candidatesByDestination[oface.Service]
+
+					if !exists || aggregateRank.CompareTo(candidateByDestination.bestAggregateRank) > 0 {
+						// TODO(yskopets): use CreationDate to resolve a conflict between 2 equal ranks
+						candidateByDestination.candidateBySource = candidateBySource
+						candidateByDestination.bestAggregateRank = aggregateRank
+
+						candidatesByDestination[oface.Service] = candidateByDestination
+					}
+				}
+			}
+		}
+	}
+
+	routeMap := core_xds.RouteMap{}
+	for _, oface := range dataplane.Spec.Networking.GetOutbound() {
+		candidate, exists := candidatesByDestination[oface.Service]
+		if exists {
+			routeMap[oface.Service] = candidate.route
+		} else {
+			// to avoid scattering defaulting logic everywhere, let's create a pseudo TrafficRoute
+			routeMap[oface.Service] = &mesh_core.TrafficRouteResource{
+				Meta: &pseudoMeta{
+					Name: "(implicit default route)",
+				},
+				Spec: mesh_proto.TrafficRoute{
+					Sources: []*mesh_proto.Selector{{
+						Match: mesh_proto.MatchService(mesh_proto.MatchAllTag),
+					}},
+					Destinations: []*mesh_proto.Selector{{
+						Match: mesh_proto.MatchService(oface.Service),
+					}},
+					Conf: []*mesh_proto.TrafficRoute_WeightedDestination{{
+						Weight:      100,
+						Destination: mesh_proto.MatchService(oface.Service),
+					}},
+				},
+			}
+		}
+	}
+	return routeMap
+}
+
+// BuildDestinationMap creates a map of selectors to match other dataplanes reachable from a given one
+// via given routes.
+func BuildDestinationMap(dataplane *mesh_core.DataplaneResource, routes core_xds.RouteMap) core_xds.DestinationMap {
+	destinations := core_xds.DestinationMap{}
+	for _, oface := range dataplane.Spec.Networking.GetOutbound() {
+		route, ok := routes[oface.Service]
+		if ok {
+			for _, destination := range route.Spec.Conf {
+				service, ok := destination.Destination[mesh_proto.ServiceTag]
+				if ok {
+					destinations[service] = append(destinations[service], mesh_proto.MatchTags(destination.Destination))
+				}
+			}
+		} else {
+			destinations[oface.Service] = append(destinations[oface.Service], mesh_proto.MatchService(oface.Service))
+		}
+	}
+	return destinations
+}
+
+type TrafficRoutesByNamespacedName []*mesh_core.TrafficRouteResource
+
+func (a TrafficRoutesByNamespacedName) Len() int      { return len(a) }
+func (a TrafficRoutesByNamespacedName) Swap(i, j int) { a[i], a[j] = a[j], a[i] }
+func (a TrafficRoutesByNamespacedName) Less(i, j int) bool {
+	return a[i].Meta.GetNamespace() < a[j].Meta.GetNamespace() ||
+		(a[i].Meta.GetNamespace() == a[j].Meta.GetNamespace() && a[i].Meta.GetName() < a[j].Meta.GetName())
+}

--- a/pkg/xds/topology/router.go
+++ b/pkg/xds/topology/router.go
@@ -125,7 +125,7 @@ func BuildRouteMap(dataplane *mesh_core.DataplaneResource, routes []*mesh_core.T
 				},
 				Spec: mesh_proto.TrafficRoute{
 					Sources: []*mesh_proto.Selector{{
-						Match: mesh_proto.MatchService(mesh_proto.MatchAllTag),
+						Match: mesh_proto.MatchAnyService(),
 					}},
 					Destinations: []*mesh_proto.Selector{{
 						Match: mesh_proto.MatchService(oface.Service),

--- a/pkg/xds/topology/router.go
+++ b/pkg/xds/topology/router.go
@@ -150,9 +150,12 @@ func BuildDestinationMap(dataplane *mesh_core.DataplaneResource, routes core_xds
 		if ok {
 			for _, destination := range route.Spec.Conf {
 				service, ok := destination.Destination[mesh_proto.ServiceTag]
-				if ok {
-					destinations[service] = append(destinations[service], mesh_proto.MatchTags(destination.Destination))
+				if !ok {
+					// ignore destinations without a `service` tag
+					// TODO(yskopets): consider adding a metric for this
+					continue
 				}
+				destinations[service] = append(destinations[service], mesh_proto.MatchTags(destination.Destination))
 			}
 		} else {
 			destinations[oface.Service] = append(destinations[oface.Service], mesh_proto.MatchService(oface.Service))

--- a/pkg/xds/topology/router_helper_test.go
+++ b/pkg/xds/topology/router_helper_test.go
@@ -1,0 +1,3 @@
+package topology
+
+type PseudoMeta = pseudoMeta

--- a/pkg/xds/topology/router_test.go
+++ b/pkg/xds/topology/router_test.go
@@ -1,0 +1,781 @@
+package topology_test
+
+import (
+	"context"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/ginkgo/extensions/table"
+	. "github.com/onsi/gomega"
+
+	. "github.com/Kong/kuma/pkg/xds/topology"
+
+	mesh_proto "github.com/Kong/kuma/api/mesh/v1alpha1"
+	mesh_core "github.com/Kong/kuma/pkg/core/resources/apis/mesh"
+	core_manager "github.com/Kong/kuma/pkg/core/resources/manager"
+	core_model "github.com/Kong/kuma/pkg/core/resources/model"
+	core_store "github.com/Kong/kuma/pkg/core/resources/store"
+	core_xds "github.com/Kong/kuma/pkg/core/xds"
+	memory_resources "github.com/Kong/kuma/pkg/plugins/resources/memory"
+	test_model "github.com/Kong/kuma/pkg/test/resources/model"
+)
+
+var _ = Describe("TrafficRoute", func() {
+
+	var ctx context.Context
+	var rm core_manager.ResourceManager
+
+	BeforeEach(func() {
+		ctx = context.Background()
+		rm = core_manager.NewResourceManager(memory_resources.NewStore())
+	})
+
+	Describe("GetRoutes()", func() {
+
+		It("should pick the best matching Route for each outbound interface", func() {
+			// given
+			mesh := &mesh_core.MeshResource{ // mesh that is relevant to this test case
+				Meta: &test_model.ResourceMeta{
+					Mesh: "demo",
+					Name: "demo",
+				},
+			}
+			otherMesh := &mesh_core.MeshResource{ // mesh that is irrelevant to this test case
+				Meta: &test_model.ResourceMeta{
+					Mesh: "default",
+					Name: "default",
+				},
+			}
+			backend := &mesh_core.DataplaneResource{ // dataplane that is a source of traffic
+				Meta: &test_model.ResourceMeta{
+					Mesh: "demo",
+					Name: "backend",
+				},
+				Spec: mesh_proto.Dataplane{
+					Networking: &mesh_proto.Dataplane_Networking{
+						Inbound: []*mesh_proto.Dataplane_Networking_Inbound{
+							{Tags: map[string]string{"service": "backend", "region": "eu"}, Interface: "192.168.0.1:8080:18080"},
+							{Tags: map[string]string{"service": "frontend", "region": "eu"}, Interface: "192.168.0.1:7070:17070"},
+						},
+						Outbound: []*mesh_proto.Dataplane_Networking_Outbound{
+							{Service: "redis", Interface: ":10001"},
+							{Service: "elastic", Interface: ":10002"},
+						},
+					},
+				},
+			}
+			routeRedis := &mesh_core.TrafficRouteResource{ // traffic route for `redis` service
+				Meta: &test_model.ResourceMeta{
+					Mesh: "demo",
+					Name: "route-to-redis",
+				},
+				Spec: mesh_proto.TrafficRoute{
+					Sources: []*mesh_proto.Selector{
+						{Match: mesh_proto.TagSelector{"service": "frontend"}},
+						{Match: mesh_proto.TagSelector{"service": "backend"}},
+					},
+					Destinations: []*mesh_proto.Selector{
+						{Match: mesh_proto.TagSelector{"service": "redis"}},
+					},
+					Conf: []*mesh_proto.TrafficRoute_WeightedDestination{
+						{Weight: 10, Destination: mesh_proto.TagSelector{"service": "redis", "version": "v1"}},
+						{Weight: 90, Destination: mesh_proto.TagSelector{"service": "redis", "version": "v2"}},
+					},
+				},
+			}
+			routeElastic := &mesh_core.TrafficRouteResource{ // traffic route for `elastic` service
+				Meta: &test_model.ResourceMeta{
+					Mesh: "demo",
+					Name: "route-to-elastic",
+				},
+				Spec: mesh_proto.TrafficRoute{
+					Sources: []*mesh_proto.Selector{
+						{Match: mesh_proto.TagSelector{"service": "*"}},
+					},
+					Destinations: []*mesh_proto.Selector{
+						{Match: mesh_proto.TagSelector{"service": "elastic"}},
+					},
+					Conf: []*mesh_proto.TrafficRoute_WeightedDestination{
+						{Weight: 30, Destination: mesh_proto.TagSelector{"service": "elastic", "region": "us"}},
+						{Weight: 70, Destination: mesh_proto.TagSelector{"service": "elastic", "region": "eu"}},
+					},
+				},
+			}
+			routeBlackhole := &mesh_core.TrafficRouteResource{ // traffic route that must be ignored (due to `mesh: default`)
+				Meta: &test_model.ResourceMeta{
+					Mesh: "default", // other mesh
+					Name: "route-to-blackhole",
+				},
+				Spec: mesh_proto.TrafficRoute{
+					Sources: []*mesh_proto.Selector{
+						{Match: mesh_proto.TagSelector{"service": "*"}},
+					},
+					Destinations: []*mesh_proto.Selector{
+						{Match: mesh_proto.TagSelector{"service": "*"}},
+					},
+					Conf: []*mesh_proto.TrafficRoute_WeightedDestination{
+						{Weight: 100, Destination: mesh_proto.TagSelector{"service": "blackhole"}},
+					},
+				},
+			}
+			for _, resource := range []core_model.Resource{mesh, backend, routeRedis, routeElastic, otherMesh, routeBlackhole} {
+				// when
+				err := rm.Create(ctx, resource, core_store.CreateBy(core_model.MetaToResourceKey(resource.GetMeta())))
+				// then
+				Expect(err).ToNot(HaveOccurred())
+			}
+
+			// when
+			routes, err := GetRoutes(ctx, backend, rm)
+
+			// then
+			Expect(err).ToNot(HaveOccurred())
+			// and
+			Expect(routes).To(HaveLen(2))
+			// and
+			Expect(routes).To(HaveKey("redis"))
+			Expect(routes["redis"].Meta.GetName()).To(Equal(routeRedis.Meta.GetName()))
+			Expect(routes["redis"].Spec).To(Equal(routeRedis.Spec))
+			// and
+			Expect(routes).To(HaveKey("elastic"))
+			Expect(routes["elastic"].Meta.GetName()).To(Equal(routeElastic.Meta.GetName()))
+			Expect(routes["elastic"].Spec).To(Equal(routeElastic.Spec))
+		})
+	})
+
+	Describe("BuildRouteMap()", func() {
+		sameMeta := func(meta1, meta2 core_model.ResourceMeta) bool {
+			return meta1.GetMesh() == meta2.GetMesh() &&
+				meta1.GetName() == meta2.GetName() &&
+				meta1.GetNamespace() == meta2.GetNamespace() &&
+				meta1.GetVersion() == meta2.GetVersion()
+		}
+		type testCase struct {
+			dataplane *mesh_core.DataplaneResource
+			routes    []*mesh_core.TrafficRouteResource
+			expected  core_xds.RouteMap
+		}
+		DescribeTable("should correctly pick a single the most specific route for each outbound interface",
+			func(given testCase) {
+				// setup
+				expectedRoutes := core_xds.RouteMap{}
+				for service, expectedRoute := range given.expected {
+					for _, route := range given.routes {
+						if sameMeta(expectedRoute.GetMeta(), route.GetMeta()) {
+							expectedRoutes[service] = route
+							break
+						}
+					}
+					if _, ok := expectedRoutes[service]; !ok {
+						expectedRoutes[service] = expectedRoute
+					}
+				}
+				// when
+				routes := BuildRouteMap(given.dataplane, given.routes)
+				// expect
+				Expect(routes).Should(Equal(expectedRoutes))
+			},
+			Entry("Dataplane without outbound interfaces and no routes", testCase{
+				dataplane: &mesh_core.DataplaneResource{},
+				routes:    nil,
+				expected:  nil,
+			}),
+			Entry("Dataplane without outbound interfaces", testCase{
+				dataplane: &mesh_core.DataplaneResource{},
+				routes: []*mesh_core.TrafficRouteResource{
+					{
+						Spec: mesh_proto.TrafficRoute{
+							Sources: []*mesh_proto.Selector{
+								{Match: mesh_proto.TagSelector{"service": "*"}},
+							},
+							Destinations: []*mesh_proto.Selector{
+								{Match: mesh_proto.TagSelector{"service": "*"}},
+							},
+							Conf: []*mesh_proto.TrafficRoute_WeightedDestination{
+								{
+									Weight:      100,
+									Destination: mesh_proto.TagSelector{"service": "blackhole"},
+								},
+							},
+						},
+					},
+				},
+				expected: core_xds.RouteMap{},
+			}),
+			Entry("if an outbound interface has no matching TrafficRoute, an implicit default route should be used", testCase{
+				dataplane: &mesh_core.DataplaneResource{
+					Spec: mesh_proto.Dataplane{
+						Networking: &mesh_proto.Dataplane_Networking{
+							Inbound: []*mesh_proto.Dataplane_Networking_Inbound{
+								{Tags: map[string]string{"service": "backend"}},
+							},
+							Outbound: []*mesh_proto.Dataplane_Networking_Outbound{
+								{Service: "redis"},
+								{Service: "elastic"},
+							},
+						},
+					},
+				},
+				routes: nil,
+				expected: core_xds.RouteMap{
+					"redis": &mesh_core.TrafficRouteResource{
+						Meta: &PseudoMeta{
+							Name: "(implicit default route)",
+						},
+						Spec: mesh_proto.TrafficRoute{
+							Sources: []*mesh_proto.Selector{{
+								Match: mesh_proto.TagSelector{"service": "*"},
+							}},
+							Destinations: []*mesh_proto.Selector{{
+								Match: mesh_proto.TagSelector{"service": "redis"},
+							}},
+							Conf: []*mesh_proto.TrafficRoute_WeightedDestination{{
+								Weight:      100,
+								Destination: mesh_proto.TagSelector{"service": "redis"},
+							}},
+						},
+					},
+					"elastic": &mesh_core.TrafficRouteResource{
+						Meta: &PseudoMeta{
+							Name: "(implicit default route)",
+						},
+						Spec: mesh_proto.TrafficRoute{
+							Sources: []*mesh_proto.Selector{{
+								Match: mesh_proto.TagSelector{"service": "*"},
+							}},
+							Destinations: []*mesh_proto.Selector{{
+								Match: mesh_proto.TagSelector{"service": "elastic"},
+							}},
+							Conf: []*mesh_proto.TrafficRoute_WeightedDestination{{
+								Weight:      100,
+								Destination: mesh_proto.TagSelector{"service": "elastic"},
+							}},
+						},
+					},
+				},
+			}),
+			Entry("implicit default route should only be used if there is matching TrafficRoute for a given outbound interface", testCase{
+				dataplane: &mesh_core.DataplaneResource{
+					Spec: mesh_proto.Dataplane{
+						Networking: &mesh_proto.Dataplane_Networking{
+							Inbound: []*mesh_proto.Dataplane_Networking_Inbound{
+								{Tags: map[string]string{"service": "backend"}},
+							},
+							Outbound: []*mesh_proto.Dataplane_Networking_Outbound{
+								{Service: "redis"},
+								{Service: "elastic"},
+							},
+						},
+					},
+				},
+				routes: []*mesh_core.TrafficRouteResource{
+					{
+						Meta: &test_model.ResourceMeta{
+							Name:      "everything-to-elastic-v1",
+							Namespace: "some",
+						},
+						Spec: mesh_proto.TrafficRoute{
+							Sources: []*mesh_proto.Selector{
+								{Match: mesh_proto.TagSelector{"service": "*"}},
+							},
+							Destinations: []*mesh_proto.Selector{
+								{Match: mesh_proto.TagSelector{"service": "elastic"}},
+							},
+							Conf: []*mesh_proto.TrafficRoute_WeightedDestination{
+								{
+									Weight:      200,
+									Destination: mesh_proto.TagSelector{"service": "elastic", "version": "v1"},
+								},
+							},
+						},
+					},
+				},
+				expected: core_xds.RouteMap{
+					"redis": &mesh_core.TrafficRouteResource{
+						Meta: &PseudoMeta{
+							Name: "(implicit default route)",
+						},
+						Spec: mesh_proto.TrafficRoute{
+							Sources: []*mesh_proto.Selector{{
+								Match: mesh_proto.TagSelector{"service": "*"},
+							}},
+							Destinations: []*mesh_proto.Selector{{
+								Match: mesh_proto.TagSelector{"service": "redis"},
+							}},
+							Conf: []*mesh_proto.TrafficRoute_WeightedDestination{{
+								Weight:      100,
+								Destination: mesh_proto.TagSelector{"service": "redis"},
+							}},
+						},
+					},
+					"elastic": &mesh_core.TrafficRouteResource{
+						Meta: &test_model.ResourceMeta{
+							Name:      "everything-to-elastic-v1",
+							Namespace: "some",
+						},
+					},
+				},
+			}),
+			Entry("TrafficRoutes should be ordered by namespace to consistently pick between two equally specific routes", testCase{
+				dataplane: &mesh_core.DataplaneResource{
+					Spec: mesh_proto.Dataplane{
+						Networking: &mesh_proto.Dataplane_Networking{
+							Inbound: []*mesh_proto.Dataplane_Networking_Inbound{
+								{Tags: map[string]string{"service": "backend"}},
+							},
+							Outbound: []*mesh_proto.Dataplane_Networking_Outbound{
+								{Service: "redis"},
+							},
+						},
+					},
+				},
+				routes: []*mesh_core.TrafficRouteResource{
+					{
+						Meta: &test_model.ResourceMeta{
+							Name:      "everything-to-blackhole", // although name `everything-to-blackhole` precedes `everything-to-hollygrail` lexicographically, namespace value is considered first
+							Namespace: "order-2",
+						},
+						Spec: mesh_proto.TrafficRoute{
+							Sources: []*mesh_proto.Selector{
+								{Match: mesh_proto.TagSelector{"service": "*"}},
+							},
+							Destinations: []*mesh_proto.Selector{
+								{Match: mesh_proto.TagSelector{"service": "*"}},
+							},
+							Conf: []*mesh_proto.TrafficRoute_WeightedDestination{
+								{
+									Weight:      100,
+									Destination: mesh_proto.TagSelector{"service": "blackhole"},
+								},
+							},
+						},
+					},
+					{
+						Meta: &test_model.ResourceMeta{
+							Name:      "everything-to-hollygrail",
+							Namespace: "order-1",
+						},
+						Spec: mesh_proto.TrafficRoute{
+							Sources: []*mesh_proto.Selector{
+								{Match: mesh_proto.TagSelector{"service": "*"}},
+							},
+							Destinations: []*mesh_proto.Selector{
+								{Match: mesh_proto.TagSelector{"service": "*"}},
+							},
+							Conf: []*mesh_proto.TrafficRoute_WeightedDestination{
+								{
+									Weight:      100,
+									Destination: mesh_proto.TagSelector{"service": "hollygrail"},
+								},
+							},
+						},
+					},
+				},
+				expected: core_xds.RouteMap{
+					"redis": &mesh_core.TrafficRouteResource{
+						Meta: &test_model.ResourceMeta{
+							Name:      "everything-to-hollygrail",
+							Namespace: "order-1",
+						},
+					},
+				},
+			}),
+			Entry("TrafficRoutes should be ordered by name to consistently pick between two equally specific routes", testCase{
+				dataplane: &mesh_core.DataplaneResource{
+					Spec: mesh_proto.Dataplane{
+						Networking: &mesh_proto.Dataplane_Networking{
+							Inbound: []*mesh_proto.Dataplane_Networking_Inbound{
+								{Tags: map[string]string{"service": "backend"}},
+							},
+							Outbound: []*mesh_proto.Dataplane_Networking_Outbound{
+								{Service: "redis"},
+							},
+						},
+					},
+				},
+				routes: []*mesh_core.TrafficRouteResource{
+					{
+						Meta: &test_model.ResourceMeta{
+							Name:      "everything-to-hollygrail",
+							Namespace: "default",
+						},
+						Spec: mesh_proto.TrafficRoute{
+							Sources: []*mesh_proto.Selector{
+								{Match: mesh_proto.TagSelector{"service": "*"}},
+							},
+							Destinations: []*mesh_proto.Selector{
+								{Match: mesh_proto.TagSelector{"service": "*"}},
+							},
+							Conf: []*mesh_proto.TrafficRoute_WeightedDestination{
+								{
+									Weight:      100,
+									Destination: mesh_proto.TagSelector{"service": "hollygrail"},
+								},
+							},
+						},
+					},
+					{
+						Meta: &test_model.ResourceMeta{
+							Name:      "everything-to-blackhole",
+							Namespace: "default",
+						},
+						Spec: mesh_proto.TrafficRoute{
+							Sources: []*mesh_proto.Selector{
+								{Match: mesh_proto.TagSelector{"service": "*"}},
+							},
+							Destinations: []*mesh_proto.Selector{
+								{Match: mesh_proto.TagSelector{"service": "*"}},
+							},
+							Conf: []*mesh_proto.TrafficRoute_WeightedDestination{
+								{
+									Weight:      100,
+									Destination: mesh_proto.TagSelector{"service": "blackhole"},
+								},
+							},
+						},
+					},
+				},
+				expected: core_xds.RouteMap{
+					"redis": &mesh_core.TrafficRouteResource{
+						Meta: &test_model.ResourceMeta{
+							Name:      "everything-to-blackhole",
+							Namespace: "default",
+						},
+					},
+				},
+			}),
+			Entry("TrafficRoute with a `source` selector by 2 tags should win over a TrafficRoute with a `source` selector by 1 tag", testCase{
+				dataplane: &mesh_core.DataplaneResource{
+					Spec: mesh_proto.Dataplane{
+						Networking: &mesh_proto.Dataplane_Networking{
+							Inbound: []*mesh_proto.Dataplane_Networking_Inbound{
+								{Tags: map[string]string{"service": "backend", "region": "eu"}},
+							},
+							Outbound: []*mesh_proto.Dataplane_Networking_Outbound{
+								{Service: "redis"},
+							},
+						},
+					},
+				},
+				routes: []*mesh_core.TrafficRouteResource{
+					{
+						Meta: &test_model.ResourceMeta{
+							Name: "less-specific",
+						},
+						Spec: mesh_proto.TrafficRoute{
+							Sources: []*mesh_proto.Selector{
+								{Match: mesh_proto.TagSelector{"service": "backend"}},
+							},
+							Destinations: []*mesh_proto.Selector{
+								{Match: mesh_proto.TagSelector{"service": "*"}},
+							},
+							Conf: []*mesh_proto.TrafficRoute_WeightedDestination{
+								{
+									Weight:      100,
+									Destination: mesh_proto.TagSelector{"service": "redis", "version": "v1"},
+								},
+							},
+						},
+					},
+					{
+						Meta: &test_model.ResourceMeta{
+							Name: "more-specific",
+						},
+						Spec: mesh_proto.TrafficRoute{
+							Sources: []*mesh_proto.Selector{
+								{Match: mesh_proto.TagSelector{"service": "backend", "region": "eu"}},
+							},
+							Destinations: []*mesh_proto.Selector{
+								{Match: mesh_proto.TagSelector{"service": "*"}},
+							},
+							Conf: []*mesh_proto.TrafficRoute_WeightedDestination{
+								{
+									Weight:      100,
+									Destination: mesh_proto.TagSelector{"service": "redis", "version": "v2"},
+								},
+							},
+						},
+					},
+				},
+				expected: core_xds.RouteMap{
+					"redis": &mesh_core.TrafficRouteResource{
+						Meta: &test_model.ResourceMeta{
+							Name: "more-specific",
+						},
+					},
+				},
+			}),
+			Entry("TrafficRoute with a `source` selector by an exact value should win over a TrafficRoute with a `source` selector by a wildcard value", testCase{
+				dataplane: &mesh_core.DataplaneResource{
+					Spec: mesh_proto.Dataplane{
+						Networking: &mesh_proto.Dataplane_Networking{
+							Inbound: []*mesh_proto.Dataplane_Networking_Inbound{
+								{Tags: map[string]string{"service": "backend", "region": "eu"}},
+							},
+							Outbound: []*mesh_proto.Dataplane_Networking_Outbound{
+								{Service: "redis"},
+							},
+						},
+					},
+				},
+				routes: []*mesh_core.TrafficRouteResource{
+					{
+						Meta: &test_model.ResourceMeta{
+							Name: "less-specific",
+						},
+						Spec: mesh_proto.TrafficRoute{
+							Sources: []*mesh_proto.Selector{
+								{Match: mesh_proto.TagSelector{"service": "*"}},
+							},
+							Destinations: []*mesh_proto.Selector{
+								{Match: mesh_proto.TagSelector{"service": "*"}},
+							},
+							Conf: []*mesh_proto.TrafficRoute_WeightedDestination{
+								{
+									Weight:      100,
+									Destination: mesh_proto.TagSelector{"service": "redis", "version": "v1"},
+								},
+							},
+						},
+					},
+					{
+						Meta: &test_model.ResourceMeta{
+							Name: "more-specific",
+						},
+						Spec: mesh_proto.TrafficRoute{
+							Sources: []*mesh_proto.Selector{
+								{Match: mesh_proto.TagSelector{"service": "backend"}},
+							},
+							Destinations: []*mesh_proto.Selector{
+								{Match: mesh_proto.TagSelector{"service": "*"}},
+							},
+							Conf: []*mesh_proto.TrafficRoute_WeightedDestination{
+								{
+									Weight:      100,
+									Destination: mesh_proto.TagSelector{"service": "redis", "version": "v2"},
+								},
+							},
+						},
+					},
+				},
+				expected: core_xds.RouteMap{
+					"redis": &mesh_core.TrafficRouteResource{
+						Meta: &test_model.ResourceMeta{
+							Name: "more-specific",
+						},
+					},
+				},
+			}),
+			Entry("TrafficRoute with a `destination` selector by an exact value should win over a TrafficRoute with a `destination` selector by a wildcard value", testCase{
+				dataplane: &mesh_core.DataplaneResource{
+					Spec: mesh_proto.Dataplane{
+						Networking: &mesh_proto.Dataplane_Networking{
+							Inbound: []*mesh_proto.Dataplane_Networking_Inbound{
+								{Tags: map[string]string{"service": "backend", "region": "eu"}},
+							},
+							Outbound: []*mesh_proto.Dataplane_Networking_Outbound{
+								{Service: "redis"},
+							},
+						},
+					},
+				},
+				routes: []*mesh_core.TrafficRouteResource{
+					{
+						Meta: &test_model.ResourceMeta{
+							Name: "less-specific",
+						},
+						Spec: mesh_proto.TrafficRoute{
+							Sources: []*mesh_proto.Selector{
+								{Match: mesh_proto.TagSelector{"service": "*"}},
+							},
+							Destinations: []*mesh_proto.Selector{
+								{Match: mesh_proto.TagSelector{"service": "*"}},
+							},
+							Conf: []*mesh_proto.TrafficRoute_WeightedDestination{
+								{
+									Weight:      100,
+									Destination: mesh_proto.TagSelector{"service": "redis", "version": "v1"},
+								},
+							},
+						},
+					},
+					{
+						Meta: &test_model.ResourceMeta{
+							Name: "more-specific",
+						},
+						Spec: mesh_proto.TrafficRoute{
+							Sources: []*mesh_proto.Selector{
+								{Match: mesh_proto.TagSelector{"service": "*"}},
+							},
+							Destinations: []*mesh_proto.Selector{
+								{Match: mesh_proto.TagSelector{"service": "redis"}},
+							},
+							Conf: []*mesh_proto.TrafficRoute_WeightedDestination{
+								{
+									Weight:      100,
+									Destination: mesh_proto.TagSelector{"service": "redis", "version": "v2"},
+								},
+							},
+						},
+					},
+				},
+				expected: core_xds.RouteMap{
+					"redis": &mesh_core.TrafficRouteResource{
+						Meta: &test_model.ResourceMeta{
+							Name: "more-specific",
+						},
+					},
+				},
+			}),
+			Entry("in case if TrafficRoutes have equal aggregate ranks, most specific one should be selected based on ordering by name", testCase{
+				dataplane: &mesh_core.DataplaneResource{
+					Spec: mesh_proto.Dataplane{
+						Networking: &mesh_proto.Dataplane_Networking{
+							Inbound: []*mesh_proto.Dataplane_Networking_Inbound{
+								{Tags: map[string]string{"service": "backend", "region": "eu"}},
+							},
+							Outbound: []*mesh_proto.Dataplane_Networking_Outbound{
+								{Service: "redis"},
+							},
+						},
+					},
+				},
+				routes: []*mesh_core.TrafficRouteResource{
+					{
+						Meta: &test_model.ResourceMeta{
+							Name: "equally-specific-2",
+						},
+						Spec: mesh_proto.TrafficRoute{
+							Sources: []*mesh_proto.Selector{
+								{Match: mesh_proto.TagSelector{"service": "*"}},
+							},
+							Destinations: []*mesh_proto.Selector{
+								{Match: mesh_proto.TagSelector{"service": "redis"}},
+							},
+							Conf: []*mesh_proto.TrafficRoute_WeightedDestination{
+								{
+									Weight:      100,
+									Destination: mesh_proto.TagSelector{"service": "redis", "version": "v2"},
+								},
+							},
+						},
+					},
+					{
+						Meta: &test_model.ResourceMeta{
+							Name: "equally-specific-1",
+						},
+						Spec: mesh_proto.TrafficRoute{
+							Sources: []*mesh_proto.Selector{
+								{Match: mesh_proto.TagSelector{"service": "backend"}},
+							},
+							Destinations: []*mesh_proto.Selector{
+								{Match: mesh_proto.TagSelector{"service": "*"}},
+							},
+							Conf: []*mesh_proto.TrafficRoute_WeightedDestination{
+								{
+									Weight:      100,
+									Destination: mesh_proto.TagSelector{"service": "redis", "version": "v1"},
+								},
+							},
+						},
+					},
+				},
+				expected: core_xds.RouteMap{
+					"redis": &mesh_core.TrafficRouteResource{
+						Meta: &test_model.ResourceMeta{
+							Name: "equally-specific-1",
+						},
+					},
+				},
+			}),
+		)
+	})
+
+	Describe("BuildDestinationMap()", func() {
+		type testCase struct {
+			dataplane *mesh_core.DataplaneResource
+			routes    core_xds.RouteMap
+			expected  core_xds.DestinationMap
+		}
+		DescribeTable("should correctly combine outbound interfaces with configuration of TrafficRoutes",
+			func(given testCase) {
+				// when
+				destinations := BuildDestinationMap(given.dataplane, given.routes)
+				// expect
+				Expect(destinations).Should(Equal(given.expected))
+			},
+			Entry("Dataplane without outbound interfaces", testCase{
+				dataplane: &mesh_core.DataplaneResource{},
+				routes:    nil,
+				expected:  core_xds.DestinationMap{},
+			}),
+			Entry("Dataplane with outbound interfaces but no TrafficRoutes", testCase{
+				dataplane: &mesh_core.DataplaneResource{
+					Spec: mesh_proto.Dataplane{
+						Networking: &mesh_proto.Dataplane_Networking{
+							Outbound: []*mesh_proto.Dataplane_Networking_Outbound{
+								{Service: "redis", Interface: ":10001"},
+								{Service: "elastic", Interface: ":10002"},
+							},
+						},
+					},
+				},
+				routes: nil,
+				expected: core_xds.DestinationMap{
+					"redis": []mesh_proto.TagSelector{
+						{"service": "redis"},
+					},
+					"elastic": []mesh_proto.TagSelector{
+						{"service": "elastic"},
+					},
+				},
+			}),
+			Entry("Dataplane with outbound interfaces and TrafficRoutes", testCase{
+				dataplane: &mesh_core.DataplaneResource{
+					Spec: mesh_proto.Dataplane{
+						Networking: &mesh_proto.Dataplane_Networking{
+							Outbound: []*mesh_proto.Dataplane_Networking_Outbound{
+								{Service: "redis", Interface: ":10001"},
+								{Service: "elastic", Interface: ":10002"},
+							},
+						},
+					},
+				},
+				routes: core_xds.RouteMap{
+					"redis": &mesh_core.TrafficRouteResource{
+						Spec: mesh_proto.TrafficRoute{
+							Conf: []*mesh_proto.TrafficRoute_WeightedDestination{
+								{
+									Weight:      10,
+									Destination: mesh_proto.TagSelector{"service": "redis", "role": "master"},
+								},
+								{
+									Weight:      90,
+									Destination: mesh_proto.TagSelector{"service": "redis", "role": "replica"},
+								},
+							},
+						},
+					},
+					"elastic": &mesh_core.TrafficRouteResource{
+						Spec: mesh_proto.TrafficRoute{
+							Conf: []*mesh_proto.TrafficRoute_WeightedDestination{
+								{
+									Weight:      100,
+									Destination: mesh_proto.TagSelector{"service": "google"},
+								},
+							},
+						},
+					},
+				},
+				expected: core_xds.DestinationMap{
+					"redis": []mesh_proto.TagSelector{
+						{"service": "redis", "role": "master"},
+						{"service": "redis", "role": "replica"},
+					},
+					"google": []mesh_proto.TagSelector{
+						{"service": "google"},
+					},
+				},
+			}),
+		)
+	})
+})

--- a/pkg/xds/topology/topology_suite_test.go
+++ b/pkg/xds/topology/topology_suite_test.go
@@ -1,0 +1,13 @@
+package topology_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+func TestTopology(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Topology Suite")
+}


### PR DESCRIPTION
### Summary

* pick a single the most specific `TrafficRoute` for every outbound interface of a `Dataplane`
   * match by an exact value is more specific than match by `*`
     * e.g., `service: backend` wins over `service: *`
   * match by `N+1` tags is more specific than match by `N` tags
     * e.g., `service: backend, version: v1` wins over `service: backend`
   * if 2 selectors have the same number of tags, the one that has more exact values is more specific
     * e.g., `service: backend, version: v1` wins over `service: backend, version: *`
   * to compare a combination of `source` and `destination` selectors we sum up their numbers of exact and wildcard matching tags
     * e.g.,
        * given `TrafficRoute 1`:
           ```yaml
           sources:
           - match:
                service: web
                version: '*'
           destinations:
           - match:
                service: backend         
           ``` 
        * and `TrafficRoute 2`:
           ```yaml
           sources:
           - match:
                service: web
                version: '*'
           destinations:
           - match:
                service: '*'         
           ``` 
         * `TrafficRoute 1` is more specific since it has 3 tags but only 1 wildcard vs 3 tags and 2 wildcards in case of  `TrafficRoute 2`
   * when resolving a tie we consider lexicographical order of `Namespace` and `Name` of involved `TrafficRoutes`
     * e.g.,  in case of tie, 
        * `TrafficRoute` from the namespace `demo` wins over  a rule from the namespace `test` 
        * when in the same namespace, `TrafficRoute` named `Alice` wins over `TrafficRoute` named `Bob`

     

