### PR TITLE
kuma-cp: generate `tcp_proxy` configuration that routes to a list of weighted clusters according to TrafficRoute

### DIFF
--- a/api/mesh/v1alpha1/dataplane_helpers.go
+++ b/api/mesh/v1alpha1/dataplane_helpers.go
@@ -3,6 +3,7 @@ package v1alpha1
 import (
 	"fmt"
 	"net"
+	"reflect"
 	"regexp"
 	"sort"
 	"strconv"
@@ -217,6 +218,10 @@ func (s TagSelector) Rank() (r TagSelectorRank) {
 		}
 	}
 	return
+}
+
+func (s TagSelector) Equal(other TagSelector) bool {
+	return len(s) == 0 && len(other) == 0 || len(s) == len(other) && reflect.DeepEqual(s, other)
 }
 
 func MatchAll() TagSelector {

--- a/pkg/core/xds/types.go
+++ b/pkg/core/xds/types.go
@@ -44,6 +44,9 @@ type Endpoint struct {
 	Tags   map[string]string
 }
 
+// EndpointList is a list of Endpoints with convenience methods.
+type EndpointList []Endpoint
+
 // EndpointMap holds routing-related information about a set of endpoints grouped by service name.
 type EndpointMap map[ServiceName][]Endpoint
 
@@ -65,6 +68,16 @@ func (s TagSelectorSet) Add(new mesh_proto.TagSelector) TagSelectorSet {
 		}
 	}
 	return append(s, new)
+}
+
+func (l EndpointList) Filter(selector mesh_proto.TagSelector) EndpointList {
+	var endpoints EndpointList
+	for _, endpoint := range l {
+		if selector.Matches(endpoint.Tags) {
+			endpoints = append(endpoints, endpoint)
+		}
+	}
+	return endpoints
 }
 
 func BuildProxyId(mesh, name string, more ...string) (*ProxyId, error) {

--- a/pkg/core/xds/types_test.go
+++ b/pkg/core/xds/types_test.go
@@ -147,4 +147,83 @@ var _ = Describe("xDS", func() {
 			})
 		})
 	})
+
+	Describe("EndpointList", func() {
+		Describe("Filter()", func() {
+			type testCase struct {
+				endpoints core_xds.EndpointList
+				filter    mesh_proto.TagSelector
+				expected  core_xds.EndpointList
+			}
+			DescribeTable("should filter out endpoints that don't match a given filter",
+				func(given testCase) {
+					// expect
+					Expect(given.endpoints.Filter(given.filter)).To(Equal(given.expected))
+				},
+				Entry("`nil` filter", testCase{
+					endpoints: core_xds.EndpointList{{
+						Target: "192.168.0.1",
+						Port:   8080,
+						Tags: map[string]string{
+							"service": "backend",
+						},
+					}},
+					filter: nil,
+					expected: core_xds.EndpointList{{
+						Target: "192.168.0.1",
+						Port:   8080,
+						Tags: map[string]string{
+							"service": "backend",
+						},
+					}},
+				}),
+				Entry("empty filter", testCase{
+					endpoints: core_xds.EndpointList{{
+						Target: "192.168.0.1",
+						Port:   8080,
+						Tags: map[string]string{
+							"service": "backend",
+						},
+					}},
+					filter: mesh_proto.TagSelector{},
+					expected: core_xds.EndpointList{{
+						Target: "192.168.0.1",
+						Port:   8080,
+						Tags: map[string]string{
+							"service": "backend",
+						},
+					}},
+				}),
+				Entry("empty filter", testCase{
+					endpoints: core_xds.EndpointList{{
+						Target: "192.168.0.1",
+						Port:   8080,
+						Tags: map[string]string{
+							"service": "backend",
+							"version": "v1",
+						},
+					}, {
+						Target: "192.168.0.2",
+						Port:   8080,
+						Tags: map[string]string{
+							"service": "backend",
+							"version": "v2",
+						},
+					}},
+					filter: mesh_proto.TagSelector{
+						"service": "backend",
+						"version": "v2",
+					},
+					expected: core_xds.EndpointList{{
+						Target: "192.168.0.2",
+						Port:   8080,
+						Tags: map[string]string{
+							"service": "backend",
+							"version": "v2",
+						},
+					}},
+				}),
+			)
+		})
+	})
 })

--- a/pkg/core/xds/types_test.go
+++ b/pkg/core/xds/types_test.go
@@ -5,6 +5,7 @@ import (
 	. "github.com/onsi/ginkgo/extensions/table"
 	. "github.com/onsi/gomega"
 
+	mesh_proto "github.com/Kong/kuma/api/mesh/v1alpha1"
 	core_xds "github.com/Kong/kuma/pkg/core/xds"
 	envoy_core "github.com/envoyproxy/go-control-plane/envoy/api/v2/core"
 )
@@ -110,6 +111,40 @@ var _ = Describe("xDS", func() {
 			Expect(key.Namespace).To(Equal("pilot"))
 			Expect(key.Mesh).To(Equal("default"))
 			Expect(key.Name).To(Equal("demo"))
+		})
+	})
+
+	Describe("TagSelectorSet", func() {
+		Describe("Add()", func() {
+			It("should be possible to add the first element to the set", func() {
+				// given
+				var set core_xds.TagSelectorSet
+				// when
+				actual := set.Add(mesh_proto.TagSelector{"service": "redis"})
+				// then
+				Expect(actual).To(HaveLen(1))
+				Expect(actual).To(ConsistOf(mesh_proto.TagSelector{"service": "redis"}))
+			})
+
+			It("should be possible to add the second element to the set", func() {
+				// given
+				set := core_xds.TagSelectorSet{mesh_proto.TagSelector{"service": "redis"}}
+				// when
+				actual := set.Add(mesh_proto.TagSelector{"service": "elastic"})
+				// then
+				Expect(actual).To(HaveLen(2))
+				Expect(actual).To(ConsistOf(mesh_proto.TagSelector{"service": "redis"}, mesh_proto.TagSelector{"service": "elastic"}))
+			})
+
+			It("should not be possible to add the second identical element", func() {
+				// given
+				set := core_xds.TagSelectorSet{mesh_proto.TagSelector{"service": "redis"}}
+				// when
+				actual := set.Add(mesh_proto.TagSelector{"service": "redis"})
+				// then
+				Expect(actual).To(HaveLen(1))
+				Expect(actual).To(ConsistOf(mesh_proto.TagSelector{"service": "redis"}))
+			})
 		})
 	})
 })

--- a/pkg/core/xds/types_test.go
+++ b/pkg/core/xds/types_test.go
@@ -194,7 +194,74 @@ var _ = Describe("xDS", func() {
 						},
 					}},
 				}),
-				Entry("empty filter", testCase{
+				Entry("wildcard filter", testCase{
+					endpoints: core_xds.EndpointList{{
+						Target: "192.168.0.1",
+						Port:   8080,
+						Tags: map[string]string{
+							"service": "backend",
+						},
+					}},
+					filter: mesh_proto.TagSelector{
+						"service": "*",
+					},
+					expected: core_xds.EndpointList{{
+						Target: "192.168.0.1",
+						Port:   8080,
+						Tags: map[string]string{
+							"service": "backend",
+						},
+					}},
+				}),
+				Entry("filter by tag that is missing", testCase{
+					endpoints: core_xds.EndpointList{{
+						Target: "192.168.0.1",
+						Port:   8080,
+						Tags: map[string]string{
+							"service": "backend",
+						},
+					}},
+					filter: mesh_proto.TagSelector{
+						"region": "us",
+					},
+					expected: nil,
+				}),
+				Entry("filter by 1 common tag", testCase{
+					endpoints: core_xds.EndpointList{{
+						Target: "192.168.0.1",
+						Port:   8080,
+						Tags: map[string]string{
+							"service": "backend",
+							"version": "v1",
+						},
+					}, {
+						Target: "192.168.0.2",
+						Port:   8080,
+						Tags: map[string]string{
+							"service": "backend",
+							"version": "v2",
+						},
+					}},
+					filter: mesh_proto.TagSelector{
+						"service": "backend",
+					},
+					expected: core_xds.EndpointList{{
+						Target: "192.168.0.1",
+						Port:   8080,
+						Tags: map[string]string{
+							"service": "backend",
+							"version": "v1",
+						},
+					}, {
+						Target: "192.168.0.2",
+						Port:   8080,
+						Tags: map[string]string{
+							"service": "backend",
+							"version": "v2",
+						},
+					}},
+				}),
+				Entry("filter by 1 common tag and 1 unique tag", testCase{
 					endpoints: core_xds.EndpointList{{
 						Target: "192.168.0.1",
 						Port:   8080,

--- a/pkg/xds/generator/outbound_proxy_generator_test.go
+++ b/pkg/xds/generator/outbound_proxy_generator_test.go
@@ -73,10 +73,26 @@ var _ = Describe("OutboundProxyGenerator", func() {
 					"db": &mesh_core.TrafficRouteResource{
 						Spec: mesh_proto.TrafficRoute{
 							Conf: []*mesh_proto.TrafficRoute_WeightedDestination{{
-								Weight:      100,
-								Destination: mesh_proto.MatchService("db"),
+								Weight:      10,
+								Destination: mesh_proto.TagSelector{"service": "db", "role": "master"},
+							}, {
+								Weight:      90,
+								Destination: mesh_proto.TagSelector{"service": "db", "role": "replica"},
+							}, {
+								Weight:      0, // should be excluded from Envoy configuration
+								Destination: mesh_proto.TagSelector{"service": "db", "role": "canary"},
 							}},
 						},
+					},
+				},
+				OutboundSelectors: model.DestinationMap{
+					"backend": model.TagSelectorSet{
+						{"service": "backend"},
+					},
+					"db": model.TagSelectorSet{
+						{"service": "db", "role": "master"},
+						{"service": "db", "role": "replica"},
+						{"service": "db", "role": "canary"},
 					},
 				},
 				OutboundTargets: model.EndpointMap{

--- a/pkg/xds/generator/outbound_proxy_generator_test.go
+++ b/pkg/xds/generator/outbound_proxy_generator_test.go
@@ -61,6 +61,24 @@ var _ = Describe("OutboundProxyGenerator", func() {
 					},
 					Spec: dataplane,
 				},
+				TrafficRoutes: model.RouteMap{
+					"backend": &mesh_core.TrafficRouteResource{
+						Spec: mesh_proto.TrafficRoute{
+							Conf: []*mesh_proto.TrafficRoute_WeightedDestination{{
+								Weight:      100,
+								Destination: mesh_proto.MatchService("backend"),
+							}},
+						},
+					},
+					"db": &mesh_core.TrafficRouteResource{
+						Spec: mesh_proto.TrafficRoute{
+							Conf: []*mesh_proto.TrafficRoute_WeightedDestination{{
+								Weight:      100,
+								Destination: mesh_proto.MatchService("db"),
+							}},
+						},
+					},
+				},
 				OutboundTargets: model.EndpointMap{
 					"backend": []model.Endpoint{
 						{Target: "192.168.0.1", Port: 8081, Tags: map[string]string{"service": "backend", "region": "us"}},

--- a/pkg/xds/generator/outbound_proxy_generator_test.go
+++ b/pkg/xds/generator/outbound_proxy_generator_test.go
@@ -9,6 +9,7 @@ import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/ginkgo/extensions/table"
 	. "github.com/onsi/gomega"
+	gtypes "github.com/onsi/gomega/types"
 
 	mesh_proto "github.com/Kong/kuma/api/mesh/v1alpha1"
 	mesh_core "github.com/Kong/kuma/pkg/core/resources/apis/mesh"
@@ -208,4 +209,146 @@ var _ = Describe("OutboundProxyGenerator", func() {
 			expected: "08.envoy.golden.yaml",
 		}),
 	)
+
+	Describe("fail when a user-defined configuration (Dataplane, TrafficRoute, etc) is not valid", func() {
+
+		type testCase struct {
+			ctx                xds_context.Context
+			dataplane          string
+			chaos              func(*model.Proxy)
+			expectedErrMatcher gtypes.GomegaMatcher
+		}
+
+		noExtraChaos := func(*model.Proxy) {}
+
+		DescribeTable("Generate Envoy xDS resources",
+			func(given testCase) {
+				// setup
+				gen := &generator.OutboundProxyGenerator{}
+
+				dataplane := mesh_proto.Dataplane{}
+				Expect(util_proto.FromYAML([]byte(given.dataplane), &dataplane)).To(Succeed())
+
+				proxy := &model.Proxy{
+					Id: model.ProxyId{Name: "side-car", Namespace: "default", Mesh: "default"},
+					Dataplane: &mesh_core.DataplaneResource{
+						Meta: &test_model.ResourceMeta{
+							Version: "1",
+						},
+						Spec: dataplane,
+					},
+					TrafficRoutes: model.RouteMap{
+						"backend": &mesh_core.TrafficRouteResource{
+							Spec: mesh_proto.TrafficRoute{
+								Conf: []*mesh_proto.TrafficRoute_WeightedDestination{{
+									Weight:      100,
+									Destination: mesh_proto.MatchService("backend"),
+								}},
+							},
+						},
+						"db": &mesh_core.TrafficRouteResource{
+							Spec: mesh_proto.TrafficRoute{
+								Conf: []*mesh_proto.TrafficRoute_WeightedDestination{{
+									Weight:      10,
+									Destination: mesh_proto.TagSelector{"service": "db", "role": "master"},
+								}, {
+									Weight:      90,
+									Destination: mesh_proto.TagSelector{"service": "db", "role": "replica"},
+								}, {
+									Weight:      0, // should be excluded from Envoy configuration
+									Destination: mesh_proto.TagSelector{"service": "db", "role": "canary"},
+								}},
+							},
+						},
+					},
+					OutboundSelectors: model.DestinationMap{
+						"backend": model.TagSelectorSet{
+							{"service": "backend"},
+						},
+						"db": model.TagSelectorSet{
+							{"service": "db", "role": "master"},
+							{"service": "db", "role": "replica"},
+							{"service": "db", "role": "canary"},
+						},
+					},
+					OutboundTargets: model.EndpointMap{
+						"backend": []model.Endpoint{
+							{Target: "192.168.0.1", Port: 8081, Tags: map[string]string{"service": "backend", "region": "us"}},
+							{Target: "192.168.0.2", Port: 8082},
+						},
+						"db": []model.Endpoint{
+							{Target: "192.168.0.3", Port: 5432, Tags: map[string]string{"service": "db", "role": "master"}},
+						},
+					},
+					Logs:     logs.NewMatchedLogs(),
+					Metadata: &model.DataplaneMetadata{},
+				}
+
+				By("introducing an error into configuration")
+				given.chaos(proxy)
+
+				// when
+				rs, err := gen.Generate(given.ctx, proxy)
+
+				// then
+				Expect(err).To(HaveOccurred())
+				// and
+				Expect(err.Error()).To(given.expectedErrMatcher)
+				// and
+				Expect(rs).To(BeNil())
+			},
+			Entry("dataplane with an invalid outbound interface", testCase{
+				ctx: plainCtx,
+				dataplane: `
+                networking:
+                  outbound:
+                  - interface: 127:not-a-port
+                    service: backend
+`,
+				chaos:              noExtraChaos,
+				expectedErrMatcher: HavePrefix(`dataplane.networking.outbound[0].interface: value is not valid: "127:not-a-port"`),
+			}),
+			Entry("dataplane with an outbound interface that has no route", testCase{
+				ctx: plainCtx,
+				dataplane: `
+                networking:
+                  outbound:
+                  - interface: :18080
+                    service: backend
+`,
+				chaos: func(proxy *model.Proxy) {
+					// simulate missing route
+					proxy.TrafficRoutes = nil
+				},
+				expectedErrMatcher: Equal(`dataplane.networking.outbound[0]{service="backend"}: has no TrafficRoute`),
+			}),
+			Entry("dataplane with an outbound interface that has a route without destination", testCase{
+				ctx: plainCtx,
+				dataplane: `
+                networking:
+                  outbound:
+                  - interface: :18080
+                    service: backend
+`,
+				chaos: func(proxy *model.Proxy) {
+					// simulate missing route
+					proxy.TrafficRoutes = model.RouteMap{
+						"backend": &mesh_core.TrafficRouteResource{
+							Meta: &test_model.ResourceMeta{
+								Name: "route-without-destination",
+							},
+							Spec: mesh_proto.TrafficRoute{
+								Sources:      []*mesh_proto.Selector{{Match: mesh_proto.MatchAnyService()}},
+								Destinations: []*mesh_proto.Selector{{Match: mesh_proto.MatchAnyService()}},
+								Conf: []*mesh_proto.TrafficRoute_WeightedDestination{{
+									Weight: 100, Destination: map[string]string{"not-a-service": "value"},
+								}},
+							},
+						},
+					}
+				},
+				expectedErrMatcher: Equal(`trafficroute{name="route-without-destination"}.conf[0].destination: mandatory tag "service" is missing: map[not-a-service:value]`),
+			}),
+		)
+	})
 })

--- a/pkg/xds/generator/proxy_template.go
+++ b/pkg/xds/generator/proxy_template.go
@@ -151,10 +151,15 @@ func (_ OutboundProxyGenerator) Generate(ctx xds_context.Context, proxy *model.P
 	resources := make([]*Resource, 0, len(ofaces))
 	names := make(map[string]bool)
 	sourceService := proxy.Dataplane.Spec.GetIdentifyingService()
-	for _, oface := range ofaces {
+	for i, oface := range ofaces {
 		endpoint, err := kuma_mesh.ParseOutboundInterface(oface.Interface)
 		if err != nil {
 			return nil, err
+		}
+
+		route := proxy.TrafficRoutes[oface.Service]
+		if route == nil {
+			return nil, errors.Errorf("outbound interface [%d]{service=%q} has no TrafficRoute", i, oface.Service)
 		}
 
 		serviceTag := kuma_mesh.ServiceTagValue(oface.Service)

--- a/pkg/xds/generator/proxy_template_profile_source_test.go
+++ b/pkg/xds/generator/proxy_template_profile_source_test.go
@@ -57,6 +57,16 @@ var _ = Describe("ProxyTemplateProfileSource", func() {
 					},
 					Spec: dataplane,
 				},
+				TrafficRoutes: model.RouteMap{
+					"db": &mesh_core.TrafficRouteResource{
+						Spec: mesh_proto.TrafficRoute{
+							Conf: []*mesh_proto.TrafficRoute_WeightedDestination{{
+								Weight:      100,
+								Destination: mesh_proto.MatchService("db"),
+							}},
+						},
+					},
+				},
 				OutboundTargets: model.EndpointMap{
 					"db": []model.Endpoint{
 						{Target: "192.168.0.3", Port: 5432, Tags: map[string]string{"service": "db", "role": "master"}},

--- a/pkg/xds/generator/resource_generator.go
+++ b/pkg/xds/generator/resource_generator.go
@@ -1,6 +1,7 @@
 package generator
 
 import (
+	"github.com/golang/protobuf/proto"
 	"github.com/golang/protobuf/ptypes"
 
 	model "github.com/Kong/kuma/pkg/core/xds"
@@ -50,4 +51,50 @@ func (rs ResourceList) ToDeltaDiscoveryResponse() *envoy.DeltaDiscoveryResponse 
 		})
 	}
 	return resp
+}
+
+type ResourceSet struct {
+	// we want to keep resources in the order they were added
+	resources []*Resource
+	// we want to prevent duplicates
+	typeToNamesIndex map[string]map[string]bool
+}
+
+func (s *ResourceSet) Contains(name string, resource ResourcePayload) bool {
+	names, ok := s.typeToNamesIndex[s.typeName(resource)]
+	if !ok {
+		return false
+	}
+	_, ok = names[name]
+	return ok
+}
+
+func (s *ResourceSet) Add(resources ...*Resource) *ResourceSet {
+	for _, resource := range resources {
+		if s.Contains(resource.Name, resource.Resource) {
+			continue
+		}
+		s.resources = append(s.resources, resource)
+		s.index(resource)
+	}
+	return s
+}
+
+func (s *ResourceSet) typeName(resource ResourcePayload) string {
+	return proto.MessageName(resource)
+}
+
+func (s *ResourceSet) index(resource *Resource) {
+	if s.typeToNamesIndex == nil {
+		s.typeToNamesIndex = map[string]map[string]bool{}
+	}
+	typeName := s.typeName(resource.Resource)
+	if s.typeToNamesIndex[typeName] == nil {
+		s.typeToNamesIndex[typeName] = map[string]bool{}
+	}
+	s.typeToNamesIndex[typeName][resource.Name] = true
+}
+
+func (s *ResourceSet) List() []*Resource {
+	return s.resources
 }

--- a/pkg/xds/generator/resource_generator_test.go
+++ b/pkg/xds/generator/resource_generator_test.go
@@ -1,0 +1,122 @@
+package generator_test
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	. "github.com/Kong/kuma/pkg/xds/generator"
+
+	envoy "github.com/envoyproxy/go-control-plane/envoy/api/v2"
+)
+
+var _ = Describe("ResourceSet", func() {
+
+	It("empty set should return empty list", func() {
+		// when
+		resources := &ResourceSet{}
+		// then
+		Expect(resources.List()).To(BeNil())
+	})
+
+	It("set of 1 element should return a list of 1 element", func() {
+		// given
+		resource := &Resource{
+			Name:    "backend",
+			Version: "v1",
+			Resource: &envoy.Cluster{
+				Name: "backend",
+			},
+		}
+		// when
+		resources := &ResourceSet{}
+		// and
+		resources.Add(resource)
+
+		// then
+		Expect(resources.List()).To(ConsistOf(resource))
+	})
+
+	It("set of 2 elements should return a list of 2 elements", func() {
+		// given
+		resource1 := &Resource{
+			Name:    "backend",
+			Version: "v1",
+			Resource: &envoy.Cluster{
+				Name: "backend",
+			},
+		}
+		resource2 := &Resource{
+			Name:    "outbound:127.0.0.1:8080",
+			Version: "v2",
+			Resource: &envoy.Listener{
+				Name: "outbound:127.0.0.1:8080",
+			},
+		}
+
+		// when
+		resources := &ResourceSet{}
+		// and
+		resources.Add(resource1)
+		// and
+		resources.Add(resource2)
+
+		// then
+		Expect(resources.List()).To(ConsistOf(resource1, resource2))
+	})
+
+	It("should not be possible to add 2 resources with same name and type", func() {
+		// given
+		resource1 := &Resource{
+			Name:    "backend",
+			Version: "v1",
+			Resource: &envoy.Cluster{
+				Name: "backend",
+			},
+		}
+		resource2 := &Resource{
+			Name:    "backend",
+			Version: "v2",
+			Resource: &envoy.Cluster{
+				Name: "backend",
+			},
+		}
+
+		// when
+		resources := &ResourceSet{}
+		// and
+		resources.Add(resource1)
+		// and
+		resources.Add(resource2)
+
+		// then
+		Expect(resources.List()).To(ConsistOf(resource1))
+	})
+
+	It("should be possible to add 2 resources with same name but different types", func() {
+		// given
+		resource1 := &Resource{
+			Name:    "backend",
+			Version: "v1",
+			Resource: &envoy.Cluster{
+				Name: "backend",
+			},
+		}
+		resource2 := &Resource{
+			Name:    "backend",
+			Version: "v2",
+			Resource: &envoy.Listener{
+				Name: "backend",
+			},
+		}
+
+		// when
+		resources := &ResourceSet{}
+		// and
+		resources.Add(resource1)
+		// and
+		resources.Add(resource2)
+
+		// then
+		Expect(resources.List()).To(ConsistOf(resource1, resource2))
+	})
+})

--- a/pkg/xds/generator/testdata/outbound-proxy/03.envoy.golden.yaml
+++ b/pkg/xds/generator/testdata/outbound-proxy/03.envoy.golden.yaml
@@ -24,11 +24,6 @@ resources:
             envoy.lb:
               region: us
               service: backend
-      - endpoint:
-          address:
-            socketAddress:
-              address: 192.168.0.2
-              portValue: 8082
 - name: outbound:127.0.0.1:18080
   resource:
     '@type': type.googleapis.com/envoy.api.v2.Listener

--- a/pkg/xds/generator/testdata/outbound-proxy/04.envoy.golden.yaml
+++ b/pkg/xds/generator/testdata/outbound-proxy/04.envoy.golden.yaml
@@ -52,11 +52,6 @@ resources:
             envoy.lb:
               region: us
               service: backend
-      - endpoint:
-          address:
-            socketAddress:
-              address: 192.168.0.2
-              portValue: 8082
 - name: outbound:127.0.0.1:18080
   resource:
     '@type': type.googleapis.com/envoy.api.v2.Listener

--- a/pkg/xds/generator/testdata/outbound-proxy/05.envoy.golden.yaml
+++ b/pkg/xds/generator/testdata/outbound-proxy/05.envoy.golden.yaml
@@ -24,11 +24,6 @@ resources:
             envoy.lb:
               region: us
               service: backend
-      - endpoint:
-          address:
-            socketAddress:
-              address: 192.168.0.2
-              portValue: 8082
 - name: outbound:127.0.0.1:18080
   resource:
     '@type': type.googleapis.com/envoy.api.v2.Listener

--- a/pkg/xds/generator/testdata/outbound-proxy/06.envoy.golden.yaml
+++ b/pkg/xds/generator/testdata/outbound-proxy/06.envoy.golden.yaml
@@ -52,11 +52,6 @@ resources:
             envoy.lb:
               region: us
               service: backend
-      - endpoint:
-          address:
-            socketAddress:
-              address: 192.168.0.2
-              portValue: 8082
 - name: outbound:127.0.0.1:18080
   resource:
     '@type': type.googleapis.com/envoy.api.v2.Listener

--- a/pkg/xds/generator/testdata/outbound-proxy/07.envoy.golden.yaml
+++ b/pkg/xds/generator/testdata/outbound-proxy/07.envoy.golden.yaml
@@ -24,11 +24,6 @@ resources:
             envoy.lb:
               region: us
               service: backend
-      - endpoint:
-          address:
-            socketAddress:
-              address: 192.168.0.2
-              portValue: 8082
 - name: outbound:127.0.0.1:18080
   resource:
     '@type': type.googleapis.com/envoy.api.v2.Listener
@@ -44,19 +39,19 @@ resources:
           cluster: backend
           statPrefix: backend
     name: outbound:127.0.0.1:18080
-- name: db
+- name: db{role=master}
   resource:
     '@type': type.googleapis.com/envoy.api.v2.Cluster
     connectTimeout: 5s
     edsClusterConfig:
       edsConfig:
         ads: {}
-    name: db
+    name: db{role=master}
     type: EDS
-- name: db
+- name: db{role=master}
   resource:
     '@type': type.googleapis.com/envoy.api.v2.ClusterLoadAssignment
-    clusterName: db
+    clusterName: db{role=master}
     endpoints:
     - lbEndpoints:
       - endpoint:
@@ -69,6 +64,21 @@ resources:
             envoy.lb:
               role: master
               service: db
+- name: db{role=replica}
+  resource:
+    '@type': type.googleapis.com/envoy.api.v2.Cluster
+    connectTimeout: 5s
+    edsClusterConfig:
+      edsConfig:
+        ads: {}
+    name: db{role=replica}
+    type: EDS
+- name: db{role=replica}
+  resource:
+    '@type': type.googleapis.com/envoy.api.v2.ClusterLoadAssignment
+    clusterName: db{role=replica}
+    endpoints:
+    - {}
 - name: outbound:127.0.0.1:54321
   resource:
     '@type': type.googleapis.com/envoy.api.v2.Listener
@@ -81,6 +91,11 @@ resources:
       - name: envoy.tcp_proxy
         typedConfig:
           '@type': type.googleapis.com/envoy.config.filter.network.tcp_proxy.v2.TcpProxy
-          cluster: db
           statPrefix: db
+          weightedClusters:
+            clusters:
+            - name: db{role=master}
+              weight: 10
+            - name: db{role=replica}
+              weight: 90
     name: outbound:127.0.0.1:54321

--- a/pkg/xds/generator/testdata/outbound-proxy/08.envoy.golden.yaml
+++ b/pkg/xds/generator/testdata/outbound-proxy/08.envoy.golden.yaml
@@ -52,11 +52,6 @@ resources:
             envoy.lb:
               region: us
               service: backend
-      - endpoint:
-          address:
-            socketAddress:
-              address: 192.168.0.2
-              portValue: 8082
 - name: outbound:127.0.0.1:18080
   resource:
     '@type': type.googleapis.com/envoy.api.v2.Listener
@@ -74,14 +69,14 @@ resources:
           cluster: backend
           statPrefix: backend
     name: outbound:127.0.0.1:18080
-- name: db
+- name: db{role=master}
   resource:
     '@type': type.googleapis.com/envoy.api.v2.Cluster
     connectTimeout: 5s
     edsClusterConfig:
       edsConfig:
         ads: {}
-    name: db
+    name: db{role=master}
     tlsContext:
       commonTlsContext:
         tlsCertificateSdsSecretConfigs:
@@ -111,10 +106,10 @@ resources:
                   statPrefix: sds_mesh_ca
                   targetUri: kuma-system:5677
     type: EDS
-- name: db
+- name: db{role=master}
   resource:
     '@type': type.googleapis.com/envoy.api.v2.ClusterLoadAssignment
-    clusterName: db
+    clusterName: db{role=master}
     endpoints:
     - lbEndpoints:
       - endpoint:
@@ -127,6 +122,49 @@ resources:
             envoy.lb:
               role: master
               service: db
+- name: db{role=replica}
+  resource:
+    '@type': type.googleapis.com/envoy.api.v2.Cluster
+    connectTimeout: 5s
+    edsClusterConfig:
+      edsConfig:
+        ads: {}
+    name: db{role=replica}
+    tlsContext:
+      commonTlsContext:
+        tlsCertificateSdsSecretConfigs:
+        - name: identity_cert
+          sdsConfig:
+            apiConfigSource:
+              apiType: GRPC
+              grpcServices:
+              - googleGrpc:
+                  channelCredentials:
+                    sslCredentials:
+                      rootCerts:
+                        inlineBytes: MTIzNDU=
+                  statPrefix: sds_identity_cert
+                  targetUri: kuma-system:5677
+        validationContextSdsSecretConfig:
+          name: mesh_ca
+          sdsConfig:
+            apiConfigSource:
+              apiType: GRPC
+              grpcServices:
+              - googleGrpc:
+                  channelCredentials:
+                    sslCredentials:
+                      rootCerts:
+                        inlineBytes: MTIzNDU=
+                  statPrefix: sds_mesh_ca
+                  targetUri: kuma-system:5677
+    type: EDS
+- name: db{role=replica}
+  resource:
+    '@type': type.googleapis.com/envoy.api.v2.ClusterLoadAssignment
+    clusterName: db{role=replica}
+    endpoints:
+    - {}
 - name: outbound:127.0.0.1:54321
   resource:
     '@type': type.googleapis.com/envoy.api.v2.Listener
@@ -141,6 +179,11 @@ resources:
       - name: envoy.tcp_proxy
         typedConfig:
           '@type': type.googleapis.com/envoy.config.filter.network.tcp_proxy.v2.TcpProxy
-          cluster: db
           statPrefix: db
+          weightedClusters:
+            clusters:
+            - name: db{role=master}
+              weight: 10
+            - name: db{role=replica}
+              weight: 90
     name: outbound:127.0.0.1:54321

--- a/pkg/xds/server/components.go
+++ b/pkg/xds/server/components.go
@@ -143,6 +143,7 @@ func DefaultDataplaneSyncTracker(rt core_runtime.Runtime, reconciler SnapshotRec
 					Dataplane:          dataplane,
 					TrafficPermissions: matchedPermissions,
 					TrafficRoutes:      routes,
+					OutboundSelectors:  destinations,
 					OutboundTargets:    outbound,
 					Logs:               matchedLogs,
 					Metadata:           metadataTracker.Metadata(streamId),

--- a/pkg/xds/topology/router.go
+++ b/pkg/xds/topology/router.go
@@ -155,10 +155,10 @@ func BuildDestinationMap(dataplane *mesh_core.DataplaneResource, routes core_xds
 					// TODO(yskopets): consider adding a metric for this
 					continue
 				}
-				destinations[service] = append(destinations[service], mesh_proto.MatchTags(destination.Destination))
+				destinations[service] = destinations[service].Add(mesh_proto.MatchTags(destination.Destination))
 			}
 		} else {
-			destinations[oface.Service] = append(destinations[oface.Service], mesh_proto.MatchService(oface.Service))
+			destinations[oface.Service] = destinations[oface.Service].Add(mesh_proto.MatchService(oface.Service))
 		}
 	}
 	return destinations


### PR DESCRIPTION
### Summary

* generate `tcp_proxy` configuration that routes to a list of weighted clusters according to `TrafficRoute`
  * generate a separate `Cluster` for each unique subset referenced by `TrafficRoute`
  * if an outgoing listener has more than 1 destination `Cluster`, configured `weighted clusters`
  * if a destination has 0 weights in Kuma, don't include into Envoy config (Envoy doesn't support 0 weight)