### PR TITLE
GUI server config

### DIFF
--- a/app/kuma-ui/pkg/server/server.go
+++ b/app/kuma-ui/pkg/server/server.go
@@ -71,6 +71,7 @@ func (g *Server) configHandler(writer http.ResponseWriter, request *http.Request
 		writer.WriteHeader(500)
 		return
 	}
+	writer.Header().Add("content-type", "application/json")
 	if _, err := writer.Write(bytes); err != nil {
 		log.Error(err, "could not write the response")
 	}

--- a/app/kuma-ui/pkg/server/server_test.go
+++ b/app/kuma-ui/pkg/server/server_test.go
@@ -114,6 +114,9 @@ var _ = Describe("GUI Server", func() {
 		Expect(resp.Body.Close()).To(Succeed())
 		Expect(err).ToNot(HaveOccurred())
 
+		// and
+		Expect(resp.Header.Get("content-type")).To(Equal("application/json"))
+
 		// when
 		cfg := types.GuiConfig{}
 		Expect(json.Unmarshal(received, &cfg)).To(Succeed())

--- a/app/kuma-ui/pkg/server/server_test.go
+++ b/app/kuma-ui/pkg/server/server_test.go
@@ -1,8 +1,10 @@
 package server_test
 
 import (
+	"encoding/json"
 	"fmt"
 	"github.com/Kong/kuma/app/kuma-ui/pkg/server"
+	"github.com/Kong/kuma/app/kuma-ui/pkg/server/types"
 	gui_server "github.com/Kong/kuma/pkg/config/gui-server"
 	"github.com/Kong/kuma/pkg/test"
 	. "github.com/onsi/ginkgo"
@@ -19,6 +21,11 @@ var _ = Describe("GUI Server", func() {
 	var stop chan struct{}
 	var baseUrl string
 
+	guiConfig := types.GuiConfig{
+		ApiUrl:      "http://kuma.internal:5681",
+		Environment: "kubernetes",
+	}
+
 	BeforeEach(func() {
 		port, err := test.GetFreePort()
 		Expect(err).ToNot(HaveOccurred())
@@ -27,6 +34,10 @@ var _ = Describe("GUI Server", func() {
 		srv := server.Server{
 			Config: &gui_server.GuiServerConfig{
 				Port: uint32(port),
+				GuiConfig: &gui_server.GuiConfig{
+					ApiUrl:      "http://kuma.internal:5681",
+					Environment: "kubernetes",
+				},
 			},
 		}
 		stop = make(chan struct{})
@@ -88,4 +99,27 @@ var _ = Describe("GUI Server", func() {
 			expectedFile: "data.js",
 		}),
 	)
+
+	It("should serve the gui config", func() {
+		// when
+		resp, err := http.Get(fmt.Sprintf("%s/config", baseUrl))
+
+		// then
+		Expect(err).ToNot(HaveOccurred())
+
+		// when
+		received, err := ioutil.ReadAll(resp.Body)
+
+		// then
+		Expect(resp.Body.Close()).To(Succeed())
+		Expect(err).ToNot(HaveOccurred())
+
+		// when
+		cfg := types.GuiConfig{}
+		Expect(json.Unmarshal(received, &cfg)).To(Succeed())
+
+		// then
+		Expect(cfg).To(Equal(guiConfig))
+	})
+
 })

--- a/app/kuma-ui/pkg/server/types/gui_config.go
+++ b/app/kuma-ui/pkg/server/types/gui_config.go
@@ -1,0 +1,6 @@
+package types
+
+type GuiConfig struct {
+	ApiUrl      string `json:"apiUrl"`
+	Environment string `json:"environment"`
+}

--- a/pkg/config/gui-server/config.go
+++ b/pkg/config/gui-server/config.go
@@ -9,6 +9,8 @@ import (
 type GuiServerConfig struct {
 	// Port on which the server is exposed
 	Port uint32 `yaml:"port" envconfig:"kuma_gui_server_port"`
+	// Config of the GUI itself
+	GuiConfig *GuiConfig
 }
 
 func (g *GuiServerConfig) Validate() error {
@@ -22,6 +24,13 @@ var _ config.Config = &GuiServerConfig{}
 
 func DefaultGuiServerConfig() *GuiServerConfig {
 	return &GuiServerConfig{
-		Port: 5683,
+		Port:      5683,
+		GuiConfig: &GuiConfig{},
 	}
+}
+
+// Not yet exposed via YAML and env vars on purpose. All of those are autoconfigured
+type GuiConfig struct {
+	ApiUrl      string
+	Environment string
 }

--- a/pkg/core/bootstrap/autoconfig.go
+++ b/pkg/core/bootstrap/autoconfig.go
@@ -3,6 +3,7 @@ package bootstrap
 import (
 	"fmt"
 	"github.com/Kong/kuma/pkg/config/api-server/catalogue"
+	gui_server "github.com/Kong/kuma/pkg/config/gui-server"
 	token_server "github.com/Kong/kuma/pkg/config/token-server"
 	"io/ioutil"
 	"os"
@@ -20,6 +21,7 @@ var autoconfigureLog = core.Log.WithName("bootstrap").WithName("auto-configure")
 func autoconfigure(cfg *kuma_cp.Config) error {
 	autoconfigureDataplaneTokenServer(cfg.DataplaneTokenServer)
 	autoconfigureCatalogue(cfg)
+	autoconfigureGui(cfg)
 	return autoconfigureSds(cfg)
 }
 
@@ -68,6 +70,13 @@ func autoconfigureSds(cfg *kuma_cp.Config) error {
 func autoconfigureDataplaneTokenServer(cfg *token_server.DataplaneTokenServerConfig) {
 	if cfg.Public.Enabled && cfg.Public.Port == 0 {
 		cfg.Public.Port = cfg.Local.Port
+	}
+}
+
+func autoconfigureGui(cfg *kuma_cp.Config) {
+	cfg.GuiServer.GuiConfig = &gui_server.GuiConfig{
+		ApiUrl:      fmt.Sprintf("http://%s:%d", cfg.General.AdvertisedHostname, cfg.ApiServer.Port),
+		Environment: cfg.Environment,
 	}
 }
 

--- a/pkg/core/bootstrap/autoconfig_test.go
+++ b/pkg/core/bootstrap/autoconfig_test.go
@@ -3,6 +3,8 @@ package bootstrap
 import (
 	"github.com/Kong/kuma/pkg/config/api-server/catalogue"
 	kuma_cp "github.com/Kong/kuma/pkg/config/app/kuma-cp"
+	"github.com/Kong/kuma/pkg/config/core"
+	gui_server "github.com/Kong/kuma/pkg/config/gui-server"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/ginkgo/extensions/table"
 	. "github.com/onsi/gomega"
@@ -104,4 +106,24 @@ var _ = Describe("Auto configuration", func() {
 			},
 		}),
 	)
+
+	It("should autoconfigure gui config", func() {
+		// given
+		cfg := kuma_cp.DefaultConfig()
+		cfg.Environment = core.KubernetesEnvironment
+		cfg.General.AdvertisedHostname = "kuma.internal"
+		cfg.ApiServer.Port = 1234
+
+		// when
+		err := autoconfigure(&cfg)
+
+		// then
+		Expect(err).ToNot(HaveOccurred())
+
+		// and
+		Expect(*cfg.GuiServer.GuiConfig).To(Equal(gui_server.GuiConfig{
+			ApiUrl:      "http://kuma.internal:1234",
+			Environment: "kubernetes",
+		}))
+	})
 })


### PR DESCRIPTION
### Summary

The problem is that even if we expose the GUI on some port, the API is on a different one. We need to deliver configuration about API coordinates. To do this, we can expose `/config` endpoint with configuration.

I used similar pattern to Catalog for now, which is keep it as Kuma Config, but don't expose env vars/yaml. Autoconfig everything.

Once we get more options for frontend, we can put it in the `GuiConfig` and use standard way to configure Kuma CP to configure embedded frontend.

Also I exposed the environment variable, to display if kuma is running on k8s or not on the GUI.