### PR TITLE
feat(kuma-cp) validate traffic log

### DIFF
--- a/pkg/core/resources/apis/mesh/traffic_log.go
+++ b/pkg/core/resources/apis/mesh/traffic_log.go
@@ -39,9 +39,6 @@ func (t *TrafficLogResource) SetSpec(spec model.ResourceSpec) error {
 		return nil
 	}
 }
-func (t *TrafficLogResource) Validate() error {
-	return nil
-}
 
 var _ model.ResourceList = &TrafficLogResourceList{}
 

--- a/pkg/core/resources/apis/mesh/traffic_log_validator.go
+++ b/pkg/core/resources/apis/mesh/traffic_log_validator.go
@@ -1,0 +1,42 @@
+package mesh
+
+import (
+	"fmt"
+
+	mesh_proto "github.com/Kong/kuma/api/mesh/v1alpha1"
+	"github.com/Kong/kuma/pkg/core/validators"
+)
+
+func (d *TrafficLogResource) Validate() error {
+	var err validators.ValidationError
+	err.Add(d.validateSources())
+	err.Add(d.validateDestinations())
+	return err.OrNil()
+}
+
+func (d *TrafficLogResource) validateSources() validators.ValidationError {
+	return ValidateSelectors(validators.RootedAt("sources"), d.Spec.Sources, ValidateSelectorOpts{})
+}
+
+func (d *TrafficLogResource) validateDestinations() (err validators.ValidationError) {
+	return ValidateSelectors(validators.RootedAt("destinations"), d.Spec.Destinations, ValidateSelectorOpts{
+		SkipRequireAtLeastOneTag: true,
+		ExtraSelectorValidators: []SelectorValidatorFunc{
+			func(path validators.PathBuilder, selector map[string]string) (err validators.ValidationError) {
+				_, defined := selector[mesh_proto.ServiceTag]
+				if len(selector) != 1 || !defined {
+					err.AddViolationAt(path, fmt.Sprintf("must consist of exactly one tag %q", mesh_proto.ServiceTag))
+				}
+				return
+			},
+		},
+		ExtraTagKeyValidators: []TagKeyValidatorFunc{
+			func(path validators.PathBuilder, key string) (err validators.ValidationError) {
+				if key != mesh_proto.ServiceTag {
+					err.AddViolationAt(path.Key(key), fmt.Sprintf("tag %q is not allowed", key))
+				}
+				return
+			},
+		},
+	})
+}

--- a/pkg/core/resources/apis/mesh/traffic_log_validator.go
+++ b/pkg/core/resources/apis/mesh/traffic_log_validator.go
@@ -1,9 +1,6 @@
 package mesh
 
 import (
-	"fmt"
-
-	mesh_proto "github.com/Kong/kuma/api/mesh/v1alpha1"
 	"github.com/Kong/kuma/pkg/core/validators"
 )
 
@@ -11,6 +8,7 @@ func (d *TrafficLogResource) Validate() error {
 	var err validators.ValidationError
 	err.Add(d.validateSources())
 	err.Add(d.validateDestinations())
+	// d.Spec.Conf and d.Spec.Conf.DefaultBackend can be empty, then default backend of the mesh is chosen.
 	return err.OrNil()
 }
 
@@ -19,24 +17,5 @@ func (d *TrafficLogResource) validateSources() validators.ValidationError {
 }
 
 func (d *TrafficLogResource) validateDestinations() (err validators.ValidationError) {
-	return ValidateSelectors(validators.RootedAt("destinations"), d.Spec.Destinations, ValidateSelectorOpts{
-		SkipRequireAtLeastOneTag: true,
-		ExtraSelectorValidators: []SelectorValidatorFunc{
-			func(path validators.PathBuilder, selector map[string]string) (err validators.ValidationError) {
-				_, defined := selector[mesh_proto.ServiceTag]
-				if len(selector) != 1 || !defined {
-					err.AddViolationAt(path, fmt.Sprintf("must consist of exactly one tag %q", mesh_proto.ServiceTag))
-				}
-				return
-			},
-		},
-		ExtraTagKeyValidators: []TagKeyValidatorFunc{
-			func(path validators.PathBuilder, key string) (err validators.ValidationError) {
-				if key != mesh_proto.ServiceTag {
-					err.AddViolationAt(path.Key(key), fmt.Sprintf("tag %q is not allowed", key))
-				}
-				return
-			},
-		},
-	})
+	return ValidateSelectors(validators.RootedAt("destinations"), d.Spec.Destinations, OnlyServiceTagAllowed)
 }

--- a/pkg/core/resources/apis/mesh/traffic_log_validator_test.go
+++ b/pkg/core/resources/apis/mesh/traffic_log_validator_test.go
@@ -1,0 +1,135 @@
+package mesh_test
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/ginkgo/extensions/table"
+	. "github.com/onsi/gomega"
+
+	. "github.com/Kong/kuma/pkg/core/resources/apis/mesh"
+
+	util_proto "github.com/Kong/kuma/pkg/util/proto"
+	"github.com/ghodss/yaml"
+)
+
+var _ = Describe("TrafficLog", func() {
+	Describe("Validate()", func() {
+		type testCase struct {
+			trafficLog string
+			expected   string
+		}
+		DescribeTable("should validate all fields and return as much individual erorrs as possible",
+			func(given testCase) {
+				// setup
+				trafficLog := TrafficLogResource{}
+
+				// when
+				err := util_proto.FromYAML([]byte(given.trafficLog), &trafficLog.Spec)
+				// then
+				Expect(err).ToNot(HaveOccurred())
+
+				// when
+				verr := trafficLog.Validate()
+				// and
+				actual, err := yaml.Marshal(verr)
+
+				// then
+				Expect(err).ToNot(HaveOccurred())
+				// and
+				Expect(actual).To(MatchYAML(given.expected))
+			},
+			Entry("empty spec", testCase{
+				trafficLog: ``,
+				expected: `
+                violations:
+                - field: sources
+                  message: must have at least one element
+                - field: destinations
+                  message: must have at least one element
+`,
+			}),
+			Entry("selectors without tags", testCase{
+				trafficLog: `
+                sources:
+                - match: {}
+                destinations:
+                - match: {}
+`,
+				expected: `
+                violations:
+                - field: sources[0].match
+                  message: must have at least one tag
+                - field: sources[0].match
+                  message: mandatory tag "service" is missing
+                - field: destinations[0].match
+                  message: must consist of exactly one tag "service"
+                - field: destinations[0].match
+                  message: mandatory tag "service" is missing
+`,
+			}),
+			Entry("selectors with empty tags values", testCase{
+				trafficLog: `
+                sources:
+                - match:
+                    service:
+                    region:
+                destinations:
+                - match:
+                    service:
+                    region:
+`,
+				expected: `
+                violations:
+                - field: sources[0].match["region"]
+                  message: tag value must be non-empty
+                - field: sources[0].match["service"]
+                  message: tag value must be non-empty
+                - field: destinations[0].match
+                  message: must consist of exactly one tag "service"
+                - field: destinations[0].match["region"]
+                  message: tag "region" is not allowed
+                - field: destinations[0].match["region"]
+                  message: tag value must be non-empty
+                - field: destinations[0].match["service"]
+                  message: tag value must be non-empty
+`,
+			}),
+			Entry("multiple selectors", testCase{
+				trafficLog: `
+                sources:
+                - match:
+                    service:
+                    region:
+                - match: {}
+                destinations:
+                - match:
+                    service:
+                    region:
+                - match: {}
+`,
+				expected: `
+                violations:
+                - field: sources[0].match["region"]
+                  message: tag value must be non-empty
+                - field: sources[0].match["service"]
+                  message: tag value must be non-empty
+                - field: sources[1].match
+                  message: must have at least one tag
+                - field: sources[1].match
+                  message: mandatory tag "service" is missing
+                - field: destinations[0].match
+                  message: must consist of exactly one tag "service"
+                - field: destinations[0].match["region"]
+                  message: tag "region" is not allowed
+                - field: destinations[0].match["region"]
+                  message: tag value must be non-empty
+                - field: destinations[0].match["service"]
+                  message: tag value must be non-empty
+                - field: destinations[1].match
+                  message: must consist of exactly one tag "service"
+                - field: destinations[1].match
+                  message: mandatory tag "service" is missing
+`,
+			}),
+		)
+	})
+})

--- a/pkg/core/resources/apis/mesh/traffic_log_validator_test.go
+++ b/pkg/core/resources/apis/mesh/traffic_log_validator_test.go
@@ -17,7 +17,7 @@ var _ = Describe("TrafficLog", func() {
 			trafficLog string
 			expected   string
 		}
-		DescribeTable("should validate all fields and return as much individual erorrs as possible",
+		DescribeTable("should validate all fields and return as much individual errors as possible",
 			func(given testCase) {
 				// setup
 				trafficLog := TrafficLogResource{}

--- a/pkg/core/resources/manager/manager_test.go
+++ b/pkg/core/resources/manager/manager_test.go
@@ -80,7 +80,25 @@ var _ = Describe("Resource Manager", func() {
 				Namespace: "default",
 				Name:      "tl-1",
 			}
-			err = resManager.Create(context.Background(), &mesh.TrafficLogResource{}, store.CreateBy(tlKey))
+			trafficLog := &mesh.TrafficLogResource{
+				Spec: mesh_proto.TrafficLog{
+					Sources: []*mesh_proto.Selector{
+						{
+							Match: map[string]string{
+								"service": "*",
+							},
+						},
+					},
+					Destinations: []*mesh_proto.Selector{
+						{
+							Match: map[string]string{
+								"service": "*",
+							},
+						},
+					},
+				},
+			}
+			err = resManager.Create(context.Background(), trafficLog, store.CreateBy(tlKey))
 			Expect(err).ToNot(HaveOccurred())
 
 			// when


### PR DESCRIPTION
### Summary

Traffic log validation.
Destination can only have service tag.
`conf` or `conf.backend` can be empty, because then we choose `defaultBackend` from the mesh.

Ideally we should also validate if the backend we are setting is specified in the mesh. Then we also need to think if we can remove the mesh if the backend is used in TrafficLog. This is dynamic validation (depends on some other resource) which we don't support yet. We can improve this in a separate PR.