### PR TITLE
feat(kuma-cp) validate traffic permission

### DIFF
--- a/app/kumactl/cmd/config/config_control_planes_add_test.go
+++ b/app/kumactl/cmd/config/config_control_planes_add_test.go
@@ -126,9 +126,9 @@ var _ = Describe("kumactl config control-planes add", func() {
 			// when
 			err := rootCmd.Execute()
 			// then
-			Expect(err).To(MatchError(fmt.Sprintf(`could not connect to the Control Plane API Server: Get http://localhost:%d: context deadline exceeded`, port)))
+			Expect(err).To(MatchError(fmt.Sprintf(`could not connect to the Control Plane API Server: Get http://localhost:%d: net/http: request canceled (Client.Timeout exceeded while awaiting headers)`, port)))
 			// and
-			Expect(outbuf.String()).To(Equal(fmt.Sprintf(`Error: could not connect to the Control Plane API Server: Get http://localhost:%d: context deadline exceeded
+			Expect(outbuf.String()).To(Equal(fmt.Sprintf(`Error: could not connect to the Control Plane API Server: Get http://localhost:%d: net/http: request canceled (Client.Timeout exceeded while awaiting headers)
 `, port)))
 			// and
 			Expect(errbuf.Bytes()).To(BeEmpty())

--- a/app/kumactl/pkg/config/validate.go
+++ b/app/kumactl/pkg/config/validate.go
@@ -1,7 +1,6 @@
 package config
 
 import (
-	"context"
 	"encoding/json"
 	"github.com/Kong/kuma/pkg/api-server/types"
 	kumactl_config "github.com/Kong/kuma/pkg/config/app/kumactl/v1alpha1"
@@ -19,9 +18,10 @@ func ValidateCpCoordinates(cp *kumactl_config.ControlPlane) error {
 	if err != nil {
 		return errors.Wrap(err, "could not construct the request")
 	}
-	ctx, cancel := context.WithTimeout(context.Background(), DefaultApiServerTimeout)
-	defer cancel()
-	resp, err := http.DefaultClient.Do(req.WithContext(ctx))
+	client := http.Client{
+		Timeout: DefaultApiServerTimeout,
+	}
+	resp, err := client.Do(req)
 	if err != nil {
 		return errors.Wrap(err, "could not connect to the Control Plane API Server")
 	}

--- a/pkg/core/resources/apis/mesh/traffic_permission.go
+++ b/pkg/core/resources/apis/mesh/traffic_permission.go
@@ -39,9 +39,6 @@ func (t *TrafficPermissionResource) SetSpec(spec model.ResourceSpec) error {
 		return nil
 	}
 }
-func (t *TrafficPermissionResource) Validate() error {
-	return nil
-}
 
 var _ model.ResourceList = &TrafficPermissionResourceList{}
 

--- a/pkg/core/resources/apis/mesh/traffic_permission_validator.go
+++ b/pkg/core/resources/apis/mesh/traffic_permission_validator.go
@@ -1,0 +1,20 @@
+package mesh
+
+import (
+	"github.com/Kong/kuma/pkg/core/validators"
+)
+
+func (d *TrafficPermissionResource) Validate() error {
+	var err validators.ValidationError
+	err.Add(d.validateSources())
+	err.Add(d.validateDestinations())
+	return err.OrNil()
+}
+
+func (d *TrafficPermissionResource) validateSources() validators.ValidationError {
+	return ValidateSelectors(validators.RootedAt("sources"), d.Spec.Sources, OnlyServiceTagAllowed)
+}
+
+func (d *TrafficPermissionResource) validateDestinations() (err validators.ValidationError) {
+	return ValidateSelectors(validators.RootedAt("destinations"), d.Spec.Destinations, OnlyServiceTagAllowed)
+}

--- a/pkg/core/resources/apis/mesh/traffic_route_validator.go
+++ b/pkg/core/resources/apis/mesh/traffic_route_validator.go
@@ -1,9 +1,6 @@
 package mesh
 
 import (
-	"fmt"
-
-	mesh_proto "github.com/Kong/kuma/api/mesh/v1alpha1"
 	"github.com/Kong/kuma/pkg/core/validators"
 )
 
@@ -20,26 +17,7 @@ func (d *TrafficRouteResource) validateSources() validators.ValidationError {
 }
 
 func (d *TrafficRouteResource) validateDestinations() (err validators.ValidationError) {
-	return ValidateSelectors(validators.RootedAt("destinations"), d.Spec.Destinations, ValidateSelectorOpts{
-		SkipRequireAtLeastOneTag: true,
-		ExtraSelectorValidators: []SelectorValidatorFunc{
-			func(path validators.PathBuilder, selector map[string]string) (err validators.ValidationError) {
-				_, defined := selector[mesh_proto.ServiceTag]
-				if len(selector) != 1 || !defined {
-					err.AddViolationAt(path, fmt.Sprintf("must consist of exactly one tag %q", mesh_proto.ServiceTag))
-				}
-				return
-			},
-		},
-		ExtraTagKeyValidators: []TagKeyValidatorFunc{
-			func(path validators.PathBuilder, key string) (err validators.ValidationError) {
-				if key != mesh_proto.ServiceTag {
-					err.AddViolationAt(path.Key(key), fmt.Sprintf("tag %q is not allowed", key))
-				}
-				return
-			},
-		},
-	})
+	return ValidateSelectors(validators.RootedAt("destinations"), d.Spec.Destinations, OnlyServiceTagAllowed)
 }
 
 func (d *TrafficRouteResource) validateConf() (err validators.ValidationError) {

--- a/pkg/core/resources/apis/mesh/validators.go
+++ b/pkg/core/resources/apis/mesh/validators.go
@@ -58,6 +58,27 @@ func ValidateSelector(path validators.PathBuilder, selector map[string]string, o
 	return
 }
 
+var OnlyServiceTagAllowed = ValidateSelectorOpts{
+	SkipRequireAtLeastOneTag: true,
+	ExtraSelectorValidators: []SelectorValidatorFunc{
+		func(path validators.PathBuilder, selector map[string]string) (err validators.ValidationError) {
+			_, defined := selector[mesh_proto.ServiceTag]
+			if len(selector) != 1 || !defined {
+				err.AddViolationAt(path, fmt.Sprintf("must consist of exactly one tag %q", mesh_proto.ServiceTag))
+			}
+			return
+		},
+	},
+	ExtraTagKeyValidators: []TagKeyValidatorFunc{
+		func(path validators.PathBuilder, key string) (err validators.ValidationError) {
+			if key != mesh_proto.ServiceTag {
+				err.AddViolationAt(path.Key(key), fmt.Sprintf("tag %q is not allowed", key))
+			}
+			return
+		},
+	},
+}
+
 func Keys(tags map[string]string) []string {
 	// sort keys for consistency
 	var keys []string


### PR DESCRIPTION
### Summary

Validate traffic permission. Only service tag is allowed in both cases for now.

Once this is merged, I'll fix the TrafficLog to also use `OnlyServiceTagAllowed`