### PR TITLE
feat(kumactl) generate certificate

### DIFF
--- a/app/kumactl/cmd/config/config_control_planes_add_test.go
+++ b/app/kumactl/cmd/config/config_control_planes_add_test.go
@@ -261,11 +261,11 @@ func setupCpIndexServer() (*httptest.Server, int) {
 
 func setupCpServer(fn func(http.ResponseWriter, *http.Request)) (*httptest.Server, int) {
 	mux := http.NewServeMux()
-	server := httptest.NewServer(mux)
 	mux.HandleFunc("/", func(writer http.ResponseWriter, req *http.Request) {
 		defer GinkgoRecover()
 		fn(writer, req)
 	})
+	server := httptest.NewServer(mux)
 	port, err := strconv.Atoi(strings.Split(server.Listener.Addr().String(), ":")[1])
 	Expect(err).ToNot(HaveOccurred())
 	return server, port

--- a/app/kumactl/cmd/generate/generate.go
+++ b/app/kumactl/cmd/generate/generate.go
@@ -13,5 +13,6 @@ func NewGenerateCmd(pctx *kumactl_cmd.RootContext) *cobra.Command {
 	}
 	// sub-commands
 	cmd.AddCommand(NewGenerateDataplaneTokenCmd(pctx))
+	cmd.AddCommand(NewGenerateCertificateCmd(pctx))
 	return cmd
 }

--- a/app/kumactl/cmd/generate/generate_certificate.go
+++ b/app/kumactl/cmd/generate/generate_certificate.go
@@ -1,0 +1,60 @@
+package generate
+
+import (
+	"fmt"
+	kumactl_cmd "github.com/Kong/kuma/app/kumactl/pkg/cmd"
+	cmd2 "github.com/Kong/kuma/pkg/cmd"
+	"github.com/Kong/kuma/pkg/tls"
+	"github.com/pkg/errors"
+	"github.com/spf13/cobra"
+	"io/ioutil"
+)
+
+var (
+	// overridable by unit tests
+	NewSelfSignedCert = tls.NewSelfSignedCert
+)
+
+type generateCertificateContext struct {
+	*kumactl_cmd.RootContext
+
+	args struct {
+		key      string
+		cert     string
+		certType string
+	}
+}
+
+func NewGenerateCertificateCmd(pctx *kumactl_cmd.RootContext) *cobra.Command {
+	ctx := &generateCertificateContext{RootContext: pctx}
+	cmd := &cobra.Command{
+		Use:   "certificate",
+		Short: "Generate certificate",
+		Long:  `Generate self signed key and certificate pair that can be used for example in Dataplane Token Server setup.`,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			if ctx.args.certType != "client" && ctx.args.certType != "server" {
+				return errors.New(`--type has to be either "client" or "server"`)
+			}
+			keyPair, err := NewSelfSignedCert("kuma", tls.CertType(ctx.args.certType))
+			if err != nil {
+				return errors.Wrap(err, "could not generate certificate")
+			}
+			if err := ioutil.WriteFile(ctx.args.key, keyPair.KeyPEM, 0664); err != nil {
+				return errors.Wrap(err, "could not write the key file")
+			}
+			if err := ioutil.WriteFile(ctx.args.cert, keyPair.CertPEM, 0664); err != nil {
+				return errors.Wrap(err, "could not write the cert file")
+			}
+			_, err = cmd.OutOrStdout().Write([]byte(fmt.Sprintf(`Certificates generated
+Key path: %s
+Cert path: %s
+`, ctx.args.key, ctx.args.cert)))
+			return err
+		},
+	}
+	cmd.Flags().StringVar(&ctx.args.key, "key", "key.pem", "path to the generated key")
+	cmd.Flags().StringVar(&ctx.args.cert, "cert", "cert.pem", "path to the generated certificate")
+	cmd.Flags().StringVar(&ctx.args.certType, "type", "", cmd2.UsageOptions("type of the certificate", "client", "server"))
+	_ = cmd.MarkFlagRequired("type")
+	return cmd
+}

--- a/app/kumactl/cmd/generate/generate_certificate_test.go
+++ b/app/kumactl/cmd/generate/generate_certificate_test.go
@@ -1,0 +1,74 @@
+package generate_test
+
+import (
+	"bytes"
+	"fmt"
+	"github.com/Kong/kuma/app/kumactl/cmd"
+	"github.com/Kong/kuma/app/kumactl/cmd/generate"
+	"github.com/Kong/kuma/pkg/tls"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"io/ioutil"
+)
+
+var _ = Describe("kumactl generate certificate", func() {
+
+	var backupNewSelfSignedCert func(string, tls.CertType, ...string) (tls.KeyPair, error)
+	BeforeEach(func() {
+		backupNewSelfSignedCert = generate.NewSelfSignedCert
+	})
+	AfterEach(func() {
+		generate.NewSelfSignedCert = backupNewSelfSignedCert
+	})
+
+	BeforeEach(func() {
+		generate.NewSelfSignedCert = func(string, tls.CertType, ...string) (tls.KeyPair, error) {
+			return tls.KeyPair{
+				CertPEM: []byte("CERT"),
+				KeyPEM:  []byte("KEY"),
+			}, nil
+		}
+	})
+
+	It("should generate certificate", func() {
+		// given
+		keyFile, err := ioutil.TempFile("", "")
+		Expect(err).ToNot(HaveOccurred())
+		certFile, err := ioutil.TempFile("", "")
+		Expect(err).ToNot(HaveOccurred())
+
+		stdout := &bytes.Buffer{}
+		stderr := &bytes.Buffer{}
+
+		rootCmd := cmd.DefaultRootCmd()
+		rootCmd.SetArgs([]string{"generate", "certificate",
+			"--key", keyFile.Name(),
+			"--cert", certFile.Name(),
+			"--type", "client",
+		})
+		rootCmd.SetOut(stdout)
+		rootCmd.SetErr(stderr)
+
+		// when
+		err = rootCmd.Execute()
+
+		// then
+		Expect(err).ToNot(HaveOccurred())
+
+		// and
+		keyBytes, err := ioutil.ReadAll(keyFile)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(string(keyBytes)).To(Equal("KEY"))
+
+		// and
+		certBytes, err := ioutil.ReadAll(certFile)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(string(certBytes)).To(Equal("CERT"))
+
+		// and
+		Expect(stdout.String()).To(Equal(fmt.Sprintf(`Certificates generated
+Key path: %s
+Cert path: %s
+`, keyFile.Name(), certFile.Name())))
+	})
+})

--- a/app/kumactl/cmd/generate/generate_certificate_test.go
+++ b/app/kumactl/cmd/generate/generate_certificate_test.go
@@ -9,9 +9,10 @@ import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	"io/ioutil"
+	"os"
 )
 
-var _ = Describe("kumactl generate certificate", func() {
+var _ = Describe("kumactl generate tls-certificate", func() {
 
 	var backupNewSelfSignedCert func(string, tls.CertType, ...string) (tls.KeyPair, error)
 	BeforeEach(func() {
@@ -21,54 +22,139 @@ var _ = Describe("kumactl generate certificate", func() {
 		generate.NewSelfSignedCert = backupNewSelfSignedCert
 	})
 
+	var keyFile *os.File
+	var certFile *os.File
+
+	var stdout *bytes.Buffer
+	var stderr *bytes.Buffer
+
 	BeforeEach(func() {
-		generate.NewSelfSignedCert = func(string, tls.CertType, ...string) (tls.KeyPair, error) {
-			return tls.KeyPair{
-				CertPEM: []byte("CERT"),
-				KeyPEM:  []byte("KEY"),
-			}, nil
-		}
+		key, err := ioutil.TempFile("", "")
+		Expect(err).ToNot(HaveOccurred())
+		keyFile = key
+
+		cert, err := ioutil.TempFile("", "")
+		Expect(err).ToNot(HaveOccurred())
+		certFile = cert
+
+		stdout = &bytes.Buffer{}
+		stderr = &bytes.Buffer{}
 	})
 
-	It("should generate certificate", func() {
-		// given
-		keyFile, err := ioutil.TempFile("", "")
-		Expect(err).ToNot(HaveOccurred())
-		certFile, err := ioutil.TempFile("", "")
-		Expect(err).ToNot(HaveOccurred())
-
-		stdout := &bytes.Buffer{}
-		stderr := &bytes.Buffer{}
-
-		rootCmd := cmd.DefaultRootCmd()
-		rootCmd.SetArgs([]string{"generate", "certificate",
-			"--key", keyFile.Name(),
-			"--cert", certFile.Name(),
-			"--type", "client",
+	Context("client certificate", func() {
+		BeforeEach(func() {
+			generate.NewSelfSignedCert = func(commonName string, certType tls.CertType, _ ...string) (tls.KeyPair, error) {
+				Expect(commonName).To(Equal("kuma"))
+				Expect(certType).To(Equal(tls.ClientCertType))
+				return tls.KeyPair{
+					CertPEM: []byte("CERT"),
+					KeyPEM:  []byte("KEY"),
+				}, nil
+			}
 		})
-		rootCmd.SetOut(stdout)
-		rootCmd.SetErr(stderr)
 
-		// when
-		err = rootCmd.Execute()
+		It("should generate client certificate", func() {
+			// given
+			rootCmd := cmd.DefaultRootCmd()
+			rootCmd.SetArgs([]string{"generate", "tls-certificate",
+				"--key-file", keyFile.Name(),
+				"--cert-file", certFile.Name(),
+				"--type", "client",
+			})
+			rootCmd.SetOut(stdout)
+			rootCmd.SetErr(stderr)
 
-		// then
-		Expect(err).ToNot(HaveOccurred())
+			// when
+			err := rootCmd.Execute()
 
-		// and
-		keyBytes, err := ioutil.ReadAll(keyFile)
-		Expect(err).ToNot(HaveOccurred())
-		Expect(string(keyBytes)).To(Equal("KEY"))
+			// then
+			Expect(err).ToNot(HaveOccurred())
 
-		// and
-		certBytes, err := ioutil.ReadAll(certFile)
-		Expect(err).ToNot(HaveOccurred())
-		Expect(string(certBytes)).To(Equal("CERT"))
+			// and
+			keyBytes, err := ioutil.ReadAll(keyFile)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(string(keyBytes)).To(Equal("KEY"))
 
-		// and
-		Expect(stdout.String()).To(Equal(fmt.Sprintf(`Certificates generated
-Key path: %s
-Cert path: %s
+			// and
+			certBytes, err := ioutil.ReadAll(certFile)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(string(certBytes)).To(Equal("CERT"))
+
+			// and
+			Expect(stdout.String()).To(Equal(fmt.Sprintf(`Certificates generated
+Key was saved in: %s
+Cert was saved in: %s
 `, keyFile.Name(), certFile.Name())))
+		})
+
+		It("should not allow to specify control plane hostname", func() {
+			// given
+			rootCmd := cmd.DefaultRootCmd()
+			rootCmd.SetArgs([]string{"generate", "tls-certificate",
+				"--key-file", keyFile.Name(),
+				"--cert-file", certFile.Name(),
+				"--type", "client",
+				"--control-plane-hostname", "kuma1.internal",
+			})
+			rootCmd.SetOut(stdout)
+			rootCmd.SetErr(stderr)
+
+			// when
+			err := rootCmd.Execute()
+
+			// then
+			Expect(err.Error()).To(Equal(`--control-plane-hostname cannot be used with "client" type`))
+		})
+	})
+
+	Context("server certificate", func() {
+		BeforeEach(func() {
+			generate.NewSelfSignedCert = func(commonName string, certType tls.CertType, hosts ...string) (tls.KeyPair, error) {
+				Expect(commonName).To(Equal("kuma"))
+				Expect(certType).To(Equal(tls.ServerCertType))
+				Expect(hosts).To(HaveLen(2))
+				Expect(hosts).To(ConsistOf("kuma1.internal", "kuma2.internal"))
+				return tls.KeyPair{
+					CertPEM: []byte("CERT"),
+					KeyPEM:  []byte("KEY"),
+				}, nil
+			}
+		})
+
+		It("should generate server certificate", func() {
+			// given
+			rootCmd := cmd.DefaultRootCmd()
+			rootCmd.SetArgs([]string{"generate", "tls-certificate",
+				"--key-file", keyFile.Name(),
+				"--cert-file", certFile.Name(),
+				"--type", "server",
+				"--control-plane-hostname", "kuma1.internal",
+				"--control-plane-hostname", "kuma2.internal",
+			})
+			rootCmd.SetOut(stdout)
+			rootCmd.SetErr(stderr)
+
+			// when
+			err := rootCmd.Execute()
+
+			// then
+			Expect(err).ToNot(HaveOccurred())
+
+			// and
+			keyBytes, err := ioutil.ReadAll(keyFile)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(string(keyBytes)).To(Equal("KEY"))
+
+			// and
+			certBytes, err := ioutil.ReadAll(certFile)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(string(certBytes)).To(Equal("CERT"))
+
+			// and
+			Expect(stdout.String()).To(Equal(fmt.Sprintf(`Certificates generated
+Key was saved in: %s
+Cert was saved in: %s
+`, keyFile.Name(), certFile.Name())))
+		})
 	})
 })

--- a/app/kumactl/cmd/install/install_control_plane.go
+++ b/app/kumactl/cmd/install/install_control_plane.go
@@ -69,7 +69,7 @@ func newInstallControlPlaneCmd(pctx *kumactl_cmd.RootContext) *cobra.Command {
 			if args.AdmissionServerTlsCert == "" && args.AdmissionServerTlsKey == "" {
 				fqdn := fmt.Sprintf("%s.%s.svc", args.ControlPlaneServiceName, args.Namespace)
 				// notice that Kubernetes doesn't requires DNS SAN in a X509 cert of a WebHook
-				admissionCert, err := NewSelfSignedCert(fqdn)
+				admissionCert, err := NewSelfSignedCert(fqdn, tls.ServerCertType)
 				if err != nil {
 					return errors.Wrapf(err, "Failed to generate TLS certificate for %q", fqdn)
 				}
@@ -82,7 +82,7 @@ func newInstallControlPlaneCmd(pctx *kumactl_cmd.RootContext) *cobra.Command {
 			if args.InjectorTlsCert == "" && args.InjectorTlsKey == "" {
 				fqdn := fmt.Sprintf("%s.%s.svc", args.InjectorServiceName, args.Namespace)
 				// notice that Kubernetes doesn't requires DNS SAN in a X509 cert of a WebHook
-				injectorCert, err := NewSelfSignedCert(fqdn)
+				injectorCert, err := NewSelfSignedCert(fqdn, tls.ServerCertType)
 				if err != nil {
 					return errors.Wrapf(err, "Failed to generate TLS certificate for %q", fqdn)
 				}
@@ -101,7 +101,7 @@ func newInstallControlPlaneCmd(pctx *kumactl_cmd.RootContext) *cobra.Command {
 					"localhost",
 				}
 				// notice that Envoy's SDS client (Google gRPC) does require DNS SAN in a X509 cert of an SDS server
-				sdsCert, err := NewSelfSignedCert(fqdn, hosts...)
+				sdsCert, err := NewSelfSignedCert(fqdn, tls.ServerCertType, hosts...)
 				if err != nil {
 					return errors.Wrapf(err, "Failed to generate TLS certificate for %q", fqdn)
 				}

--- a/app/kumactl/cmd/install/install_control_plane_test.go
+++ b/app/kumactl/cmd/install/install_control_plane_test.go
@@ -19,7 +19,7 @@ import (
 
 var _ = Describe("kumactl install control-plane", func() {
 
-	var backupNewSelfSignedCert func(string, ...string) (tls.KeyPair, error)
+	var backupNewSelfSignedCert func(string, tls.CertType, ...string) (tls.KeyPair, error)
 	BeforeEach(func() {
 		backupNewSelfSignedCert = install.NewSelfSignedCert
 	})
@@ -28,7 +28,7 @@ var _ = Describe("kumactl install control-plane", func() {
 	})
 
 	BeforeEach(func() {
-		install.NewSelfSignedCert = func(string, ...string) (tls.KeyPair, error) {
+		install.NewSelfSignedCert = func(string, tls.CertType, ...string) (tls.KeyPair, error) {
 			return tls.KeyPair{
 				CertPEM: []byte("CERT"),
 				KeyPEM:  []byte("KEY"),

--- a/docs/cmd/kumactl/HELP.md
+++ b/docs/cmd/kumactl/HELP.md
@@ -277,18 +277,18 @@ Usage:
 
 Examples:
 
-# Generate a TLS certificate for use by an HTTPS server, i.e. by the Dataplane Token server
-kumactl generate tls-certificate --type=server
+  # Generate a TLS certificate for use by an HTTPS server, i.e. by the Dataplane Token server
+  kumactl generate tls-certificate --type=server
 
-# Generate a TLS certificate for use by a client of an HTTPS server, i.e. by the 'kumactl generate dataplane-token' command
-kumactl generate tls-certificate --type=client
+  # Generate a TLS certificate for use by a client of an HTTPS server, i.e. by the 'kumactl generate dataplane-token' command
+  kumactl generate tls-certificate --type=client
 
 Flags:
-      --cert-file string                 path to a file with a generated TLS certificate (default "cert.pem")
-      --control-plane-hostname strings   DNS name of the control plane
-  -h, --help                             help for tls-certificate
-      --key-file string                  path to a file with a generated key (default "key.pem")
-      --type string                      type of the certificate: one of client|server
+      --cert-file string      path to a file with a generated TLS certificate (default "cert.pem")
+      --cp-hostname strings   DNS name of the control plane
+  -h, --help                  help for tls-certificate
+      --key-file string       path to a file with a generated private key (default "key.pem")
+      --type string           type of the certificate: one of client|server
 
 Global Flags:
       --config-file string   path to the configuration file to use

--- a/docs/cmd/kumactl/HELP.md
+++ b/docs/cmd/kumactl/HELP.md
@@ -267,6 +267,26 @@ Global Flags:
       --mesh string          mesh to use (default "default")
 ```
 
+### kumactl generate certificate
+
+```
+Generate self signed key and certificate pair that can be used for example in Dataplane Token Server setup.
+
+Usage:
+  kumactl generate certificate [flags]
+
+Flags:
+      --cert string   path to the generated certificate (default "cert.pem")
+  -h, --help          help for certificate
+      --key string    path to the generated key (default "key.pem")
+      --type string   type of the certificate: one of client|server
+
+Global Flags:
+      --config-file string   path to the configuration file to use
+      --log-level string     log level: one of off|info|debug (default "off")
+      --mesh string          mesh to use (default "default")
+```
+
 ### kumactl generate dp-token
 
 ```
@@ -276,6 +296,7 @@ Usage:
   kumactl generate [command]
 
 Available Commands:
+  certificate     Generate certificate
   dataplane-token Generate Dataplane Token
 
 Flags:

--- a/docs/cmd/kumactl/HELP.md
+++ b/docs/cmd/kumactl/HELP.md
@@ -267,19 +267,28 @@ Global Flags:
       --mesh string          mesh to use (default "default")
 ```
 
-### kumactl generate certificate
+### kumactl generate tls-certificate
 
 ```
 Generate self signed key and certificate pair that can be used for example in Dataplane Token Server setup.
 
 Usage:
-  kumactl generate certificate [flags]
+  kumactl generate tls-certificate [flags]
+
+Examples:
+
+# Generate a TLS certificate for use by an HTTPS server, i.e. by the Dataplane Token server
+kumactl generate tls-certificate --type=server
+
+# Generate a TLS certificate for use by a client of an HTTPS server, i.e. by the 'kumactl generate dataplane-token' command
+kumactl generate tls-certificate --type=client
 
 Flags:
-      --cert string   path to the generated certificate (default "cert.pem")
-  -h, --help          help for certificate
-      --key string    path to the generated key (default "key.pem")
-      --type string   type of the certificate: one of client|server
+      --cert-file string                 path to a file with a generated TLS certificate (default "cert.pem")
+      --control-plane-hostname strings   DNS name of the control plane
+  -h, --help                             help for tls-certificate
+      --key-file string                  path to a file with a generated key (default "key.pem")
+      --type string                      type of the certificate: one of client|server
 
 Global Flags:
       --config-file string   path to the configuration file to use
@@ -296,8 +305,8 @@ Usage:
   kumactl generate [command]
 
 Available Commands:
-  certificate     Generate certificate
   dataplane-token Generate Dataplane Token
+  tls-certificate Generate a TLS certificate
 
 Flags:
   -h, --help   help for generate

--- a/pkg/core/bootstrap/autoconfig.go
+++ b/pkg/core/bootstrap/autoconfig.go
@@ -50,7 +50,7 @@ func autoconfigureSds(cfg *kuma_cp.Config) error {
 				"localhost",
 			}
 			// notice that Envoy's SDS client (Google gRPC) does require DNS SAN in a X509 cert of an SDS server
-			sdsCert, err := tls.NewSelfSignedCert("kuma-sds", hosts...)
+			sdsCert, err := tls.NewSelfSignedCert("kuma-sds", tls.ServerCertType, hosts...)
 			if err != nil {
 				return errors.Wrap(err, "failed to auto-generate TLS certificate for SDS server")
 			}

--- a/tools/docs/kumactl/gen_help.sh
+++ b/tools/docs/kumactl/gen_help.sh
@@ -36,6 +36,7 @@ gen_help kumactl config control-planes switch
 gen_help kumactl install
 gen_help kumactl install control-plane
 gen_help kumactl install database-schema
+gen_help kumactl generate certificate
 gen_help kumactl generate dp-token
 gen_help kumactl get
 gen_help kumactl get meshes

--- a/tools/docs/kumactl/gen_help.sh
+++ b/tools/docs/kumactl/gen_help.sh
@@ -36,7 +36,7 @@ gen_help kumactl config control-planes switch
 gen_help kumactl install
 gen_help kumactl install control-plane
 gen_help kumactl install database-schema
-gen_help kumactl generate certificate
+gen_help kumactl generate tls-certificate
 gen_help kumactl generate dp-token
 gen_help kumactl get
 gen_help kumactl get meshes


### PR DESCRIPTION
### Summary

Generate certificate from `kumactl`.
Unfortunately, we cannot generate certificate for the server and client in the same way therefore we need to specify the purpose.