### PR TITLE
workshop: split demo app into frontend and backend

### DIFF
--- a/examples/kubernetes/kuma-demo/kuma-demo-aio.yaml
+++ b/examples/kubernetes/kuma-demo/kuma-demo-aio.yaml
@@ -146,15 +146,41 @@ spec:
 apiVersion: v1
 kind: Service
 metadata:
-  name: kuma-demo-api
+  name: kuma-demo-backend
   namespace: kuma-demo
 spec:
   selector:
-    app: kuma-demo-api
+    app: kuma-demo-backend
   ports:
   - name: api
     port: 3001
-    targetPort: 80
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: kuma-demo-backend
+  namespace: kuma-demo
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: kuma-demo-backend
+  template:
+    metadata:
+      labels:
+        app: kuma-demo-backend
+    spec:
+      containers:
+      - image: kvn0218/kuma-demo-be:lts
+        name: kuma-be
+        env:
+        - name: ES_HOST
+          value: http://elasticsearch:80
+        - name: REDIS_HOST
+          value: "redis-master"
+        imagePullPolicy: IfNotPresent
+        ports:
+        - containerPort: 3001
 ---
 apiVersion: v1
 kind: ConfigMap
@@ -181,7 +207,9 @@ data:
             server localhost:8080;
         }
         upstream backend {
-            server localhost:3001;
+            server kuma-demo-backend:3001;
+
+            keepalive_timeout 0s;
         }
         server {
             listen       80;
@@ -195,6 +223,18 @@ data:
         }
     }
 ---
+apiVersion: v1
+kind: Service
+metadata:
+  name: kuma-demo-frontend
+  namespace: kuma-demo
+spec:
+  selector:
+    app: kuma-demo-frontend
+  ports:
+  - name: http
+    port: 80
+---
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -204,11 +244,11 @@ spec:
   replicas: 1
   selector:
     matchLabels:
-      app: kuma-demo-api
+      app: kuma-demo-frontend
   template:
     metadata:
       labels:
-        app: kuma-demo-api
+        app: kuma-demo-frontend
     spec:
       containers:
       - image: nginx
@@ -219,21 +259,9 @@ spec:
         volumeMounts:
         - name: demo-app-config
           mountPath: /etc/nginx/
-      - image: kvn0218/kuma-demo-be:lts
-        name: kuma-be
-        env:
-        - name: ES_HOST
-          value: http://elasticsearch:80
-        - name: REDIS_HOST
-          value: "redis-master"
-        imagePullPolicy: IfNotPresent
-        ports:
-        - containerPort: 3001
       - name: kuma-fe
         image: kvn0218/kuma-demo-fe:kubecon
         imagePullPolicy: IfNotPresent
-        ports:
-        - containerPort: 8080
       volumes:
       - name: demo-app-config
         configMap:


### PR DESCRIPTION
### Summary

* split a single `demo-app` into 2 separate deployments: `frontend` and `backend`

