### PR TITLE
Demo/add multiple versions of backend

### DIFF
--- a/examples/kubernetes/kuma-demo/kuma-demo-aio.yaml
+++ b/examples/kubernetes/kuma-demo/kuma-demo-aio.yaml
@@ -146,7 +146,7 @@ spec:
 apiVersion: v1
 kind: Service
 metadata:
-  name: kuma-demo-backend
+  name: kuma-demo-backend-v1
   namespace: kuma-demo
 spec:
   selector:
@@ -158,20 +158,63 @@ spec:
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: kuma-demo-backend
+  name: kuma-demo-backend-v1
   namespace: kuma-demo
 spec:
   replicas: 1
   selector:
     matchLabels:
       app: kuma-demo-backend
+      version: v1
   template:
     metadata:
       labels:
         app: kuma-demo-backend
+        version: v1
     spec:
       containers:
-      - image: kvn0218/kuma-demo-be:lts
+      - image: kvn0218/kuma-demo-be:v1
+        name: kuma-be
+        env:
+        - name: ES_HOST
+          value: http://elasticsearch:80
+        - name: REDIS_HOST
+          value: "redis-master"
+        imagePullPolicy: IfNotPresent
+        ports:
+        - containerPort: 3001
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: kuma-demo-backend-v2
+  namespace: kuma-demo
+spec:
+  selector:
+    app: kuma-demo-backend
+  ports:
+  - name: api
+    port: 3001
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: kuma-demo-backend-v2
+  namespace: kuma-demo
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: kuma-demo-backend
+      version: v2
+  template:
+    metadata:
+      labels:
+        app: kuma-demo-backend
+        version: v2
+    spec:
+      containers:
+      - image: kvn0218/kuma-demo-be:v2
         name: kuma-be
         env:
         - name: ES_HOST
@@ -208,7 +251,6 @@ data:
         }
         upstream backend {
             server kuma-demo-backend:3001;
-
             keepalive_timeout 0s;
         }
         server {

--- a/examples/kubernetes/kuma-demo/kuma-demo-aio.yaml
+++ b/examples/kubernetes/kuma-demo/kuma-demo-aio.yaml
@@ -146,7 +146,7 @@ spec:
 apiVersion: v1
 kind: Service
 metadata:
-  name: kuma-demo-backend-v1
+  name: kuma-demo-backend
   namespace: kuma-demo
 spec:
   selector:
@@ -183,18 +183,6 @@ spec:
         imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 3001
----
-apiVersion: v1
-kind: Service
-metadata:
-  name: kuma-demo-backend-v2
-  namespace: kuma-demo
-spec:
-  selector:
-    app: kuma-demo-backend
-  ports:
-  - name: api
-    port: 3001
 ---
 apiVersion: apps/v1
 kind: Deployment

--- a/examples/kubernetes/kuma-demo/kuma-demo-aio.yaml
+++ b/examples/kubernetes/kuma-demo/kuma-demo-aio.yaml
@@ -158,6 +158,35 @@ spec:
 apiVersion: apps/v1
 kind: Deployment
 metadata:
+  name: kuma-demo-backend-v0
+  namespace: kuma-demo
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: kuma-demo-backend
+      version: v0
+  template:
+    metadata:
+      labels:
+        app: kuma-demo-backend
+        version: v0
+    spec:
+      containers:
+      - image: kvn0218/kuma-demo-be:v1
+        name: kuma-be
+        env:
+        - name: ES_HOST
+          value: http://elasticsearch:80
+        - name: REDIS_HOST
+          value: "redis-master"
+        imagePullPolicy: IfNotPresent
+        ports:
+        - containerPort: 3001
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
   name: kuma-demo-backend-v1
   namespace: kuma-demo
 spec:


### PR DESCRIPTION
### Summary

* add multiple versions of `backend`
* add `version` label for use in `TrafficRoute` 
* update configuration to include 3 versions of `backend`: `v0`, `v1` and `v2`

Here is an example `TrafficRoute` to split traffic between multiple versions:

```yaml
apiVersion: kuma.io/v1alpha1
kind: TrafficRoute
metadata:
  name: frontend-to-backend
  namespace: kuma-demo
mesh: default
spec:
  sources:
  - match:
      service: kuma-demo-frontend.kuma-demo.svc:80
  destinations:
  - match:
      service: kuma-demo-backend.kuma-demo.svc:3001
  conf:
  - weight: 60
    destination:
      service: kuma-demo-backend.kuma-demo.svc:3001
      version: v0
  - weight: 30
    destination:
      service: kuma-demo-backend.kuma-demo.svc:3001
      version: v1
  - weight: 10
    destination:
      service: kuma-demo-backend.kuma-demo.svc:3001
      version: v2
```
