### PR TITLE
demo: rename Service objects to simplify TrafficPermission, TrafficRoute, TrafficLogging examples

### DIFF
--- a/examples/kubernetes/kuma-demo/README.md
+++ b/examples/kubernetes/kuma-demo/README.md
@@ -30,32 +30,40 @@ serviceaccount/elasticsearch created
 service/elasticsearch created
 replicationcontroller/es created
 deployment.apps/redis-master created
-service/redis-master created
-service/kuma-demo-api created
+service/redis created
+service/backend created
+deployment.apps/kuma-demo-backend-v0 created
+deployment.apps/kuma-demo-backend-v1 created
+deployment.apps/kuma-demo-backend-v2 created
+configmap/demo-app-config created
+service/frontend created
 deployment.apps/kuma-demo-app created
 ```
 
-This will deploy our demo marketplace application split across 3 pods. The first pod is an Elasticsearch service that stores all the items in our marketplace. The second pod is our Node/Vue application that allows you to visually query the Elastic and Redis endpoints. The last pod is a Redis service that stores reviews for each item.
+This will deploy our demo marketplace application split across multiple pods:
+1. The first pod is an Elasticsearch service that stores all the items in our marketplace
+2. The second pod is a Redis service that stores reviews for each item
+3. The third pod is a Node application that represents a backend
+4. The remaining pods represent multiple versions of our Node/Vue application that allows you to visually query the Elastic and Redis endpoints
 
 Check the pods are up and running by checking the `kuma-demo` namespace
 
 ```
 $ kubectl get pods -n kuma-demo
-NAME                            READY   STATUS    RESTARTS   AGE
-es-n8df7                        1/1     Running   0          13m
-kuma-demo-app-8fc49ddbf-gfjtb   2/2     Running   0          13m
-redis-master-6d4cf995c5-nsghm   1/1     Running   0          13m
+NAME                                    READY   STATUS    RESTARTS   AGE
+es-v6g88                                1/1     Running   0          32s
+kuma-demo-app-7bb5d85c8c-8kl2z          2/2     Running   0          30s
+kuma-demo-backend-v0-7dcb8dc8fd-rq798   1/1     Running   0          31s
+redis-master-5b5978b77f-pmhnz           1/1     Running   0          32s
 ```
 
 In the following steps, we will be using the pod name of the `kuma-demo-app-*************` pod. Please replace any `${KUMA_DEMO_APP_POD_NAME}` variables with your pod name.
 
 ### 4. Port-forward the sample application to access the front-end UI at http://localhost:8080
 
-<pre><code>$ kubectl port-forward <b>${KUMA_DEMO_APP_POD_NAME}</b> -n kuma-demo 8080 3001
-Forwarding from 127.0.0.1:8080 -> 8080
-Forwarding from [::1]:8080 -> 8080
-Forwarding from 127.0.0.1:3001 -> 3001
-Forwarding from [::1]:3001 -> 3001
+<pre><code>$ kubectl port-forward <b>${KUMA_DEMO_APP_POD_NAME}</b> -n kuma-demo 8080:80
+Forwarding from 127.0.0.1:8080 -> 80
+Forwarding from [::1]:8080 -> 80
 </code></pre>
 
 Now you can access the marketplace application through your web browser at http://localhost:8080.
@@ -66,28 +74,28 @@ The items on the front page are pulled from the Elasticsearch service. While the
 ### 5. Download the latest version of Kuma
 
 ```
-$ wget https://kong.bintray.com/kuma/kuma-0.2.2-darwin-amd64.tar.gz
---2019-10-13 05:53:46--  https://kong.bintray.com/kuma/kuma-0.2.2-darwin-amd64.tar.gz
+$ wget https://kong.bintray.com/kuma/kuma-0.3.0-rc2-darwin-amd64.tar.gz
+--2019-10-13 05:53:46--  https://kong.bintray.com/kuma/kuma-0.3.0-rc2-darwin-amd64.tar.gz
 Resolving kong.bintray.com (kong.bintray.com)... 52.88.33.18, 54.200.232.13
 Connecting to kong.bintray.com (kong.bintray.com)|52.88.33.18|:443... connected.
 HTTP request sent, awaiting response... 302
-Location: https://akamai.bintray.com/69/694567d6d0d64f5eb5a5841aea3b4c3d60c8f2a6e6c3ff79cd5d580edf22e12b?__gda__=exp=1570917947~hmac=68f26ab23b95f97acebfc4b33a1bc1e88aeca46a44b1bc349af851019c941d0a&response-content-disposition=attachment%3Bfilename%3D%22kuma-0.2.2-darwin-amd64.tar.gz%22&response-content-type=application%2Fgzip&requestInfo=U2FsdGVkX1_SREBFG76q54ykX416x4BKSbGVrX5A-GfV55I-FdyX_0L9WI3EaLJdsXfRQ4V2pY3vP9viaRvtUxQEjLKVz_AEytCDaz5VW3oTvdhio0sq10KPgW3Z3hFN&response-X-Checksum-Sha1=01c56caae58a6d14a1ad24545ee0b25421c6d48e&response-X-Checksum-Sha2=694567d6d0d64f5eb5a5841aea3b4c3d60c8f2a6e6c3ff79cd5d580edf22e12b [following]
---2019-10-13 05:53:47--  https://akamai.bintray.com/69/694567d6d0d64f5eb5a5841aea3b4c3d60c8f2a6e6c3ff79cd5d580edf22e12b?__gda__=exp=1570917947~hmac=68f26ab23b95f97acebfc4b33a1bc1e88aeca46a44b1bc349af851019c941d0a&response-content-disposition=attachment%3Bfilename%3D%22kuma-0.2.2-darwin-amd64.tar.gz%22&response-content-type=application%2Fgzip&requestInfo=U2FsdGVkX1_SREBFG76q54ykX416x4BKSbGVrX5A-GfV55I-FdyX_0L9WI3EaLJdsXfRQ4V2pY3vP9viaRvtUxQEjLKVz_AEytCDaz5VW3oTvdhio0sq10KPgW3Z3hFN&response-X-Checksum-Sha1=01c56caae58a6d14a1ad24545ee0b25421c6d48e&response-X-Checksum-Sha2=694567d6d0d64f5eb5a5841aea3b4c3d60c8f2a6e6c3ff79cd5d580edf22e12b
+Location: https://akamai.bintray.com/69/694567d6d0d64f5eb5a5841aea3b4c3d60c8f2a6e6c3ff79cd5d580edf22e12b?__gda__=exp=1570917947~hmac=68f26ab23b95f97acebfc4b33a1bc1e88aeca46a44b1bc349af851019c941d0a&response-content-disposition=attachment%3Bfilename%3D%22kuma-0.3.0-rc2-darwin-amd64.tar.gz%22&response-content-type=application%2Fgzip&requestInfo=U2FsdGVkX1_SREBFG76q54ykX416x4BKSbGVrX5A-GfV55I-FdyX_0L9WI3EaLJdsXfRQ4V2pY3vP9viaRvtUxQEjLKVz_AEytCDaz5VW3oTvdhio0sq10KPgW3Z3hFN&response-X-Checksum-Sha1=01c56caae58a6d14a1ad24545ee0b25421c6d48e&response-X-Checksum-Sha2=694567d6d0d64f5eb5a5841aea3b4c3d60c8f2a6e6c3ff79cd5d580edf22e12b [following]
+--2019-10-13 05:53:47--  https://akamai.bintray.com/69/694567d6d0d64f5eb5a5841aea3b4c3d60c8f2a6e6c3ff79cd5d580edf22e12b?__gda__=exp=1570917947~hmac=68f26ab23b95f97acebfc4b33a1bc1e88aeca46a44b1bc349af851019c941d0a&response-content-disposition=attachment%3Bfilename%3D%22kuma-0.3.0-rc2-darwin-amd64.tar.gz%22&response-content-type=application%2Fgzip&requestInfo=U2FsdGVkX1_SREBFG76q54ykX416x4BKSbGVrX5A-GfV55I-FdyX_0L9WI3EaLJdsXfRQ4V2pY3vP9viaRvtUxQEjLKVz_AEytCDaz5VW3oTvdhio0sq10KPgW3Z3hFN&response-X-Checksum-Sha1=01c56caae58a6d14a1ad24545ee0b25421c6d48e&response-X-Checksum-Sha2=694567d6d0d64f5eb5a5841aea3b4c3d60c8f2a6e6c3ff79cd5d580edf22e12b
 Resolving akamai.bintray.com (akamai.bintray.com)... 104.93.1.149
 Connecting to akamai.bintray.com (akamai.bintray.com)|104.93.1.149|:443... connected.
 HTTP request sent, awaiting response... 200 OK
 Length: 42892462 (41M) [application/gzip]
-Saving to: ‘kuma-0.2.2-darwin-amd64.tar.gz’
+Saving to: ‘kuma-0.3.0-rc2-darwin-amd64.tar.gz’
 
-kuma-0.2.2-darwin-amd64.tar.g 100%[===============================================>]  40.91M  2.61MB/s    in 20s
+kuma-0.3.0-rc2-darwin-amd64.tar.g 100%[===============================================>]  40.91M  2.61MB/s    in 20s
 
-2019-10-13 05:54:08 (2.09 MB/s) - ‘kuma-0.2.2-darwin-amd64.tar.gz’ saved [42892462/42892462]
+2019-10-13 05:54:08 (2.09 MB/s) - ‘kuma-0.3.0-rc2-darwin-amd64.tar.gz’ saved [42892462/42892462]
 ```
 
 ### 6. Unbundle the files to get the following components:
 
 ```
-$ tar xvzf kuma-0.2.2-darwin-amd64.tar.gz
+$ tar xvzf kuma-0.3.0-rc2-darwin-amd64.tar.gz
 x ./
 x ./conf/
 x ./conf/kuma-cp.conf
@@ -113,27 +121,30 @@ envoy   kuma-cp   kuma-dp   kuma-tcp-echo kumactl
 ```
 $ ./kumactl install control-plane | kubectl apply -f -
 namespace/kuma-system created
+secret/kuma-admission-server-tls-cert created
 secret/kuma-injector-tls-cert created
 secret/kuma-sds-tls-cert created
-secret/kuma-admission-server-tls-cert created
+configmap/kuma-control-plane-config created
 configmap/kuma-injector-config created
 serviceaccount/kuma-control-plane created
-customresourcedefinition.apiextensions.k8s.io/dataplaneinsights.kuma.io created
-customresourcedefinition.apiextensions.k8s.io/dataplanes.kuma.io created
-customresourcedefinition.apiextensions.k8s.io/meshes.kuma.io created
-customresourcedefinition.apiextensions.k8s.io/proxytemplates.kuma.io created
-customresourcedefinition.apiextensions.k8s.io/trafficlogs.kuma.io created
-customresourcedefinition.apiextensions.k8s.io/trafficpermissions.kuma.io created
-clusterrole.rbac.authorization.k8s.io/kuma:control-plane created
-clusterrolebinding.rbac.authorization.k8s.io/kuma:control-plane created
+customresourcedefinition.apiextensions.k8s.io/dataplaneinsights.kuma.io configured
+customresourcedefinition.apiextensions.k8s.io/dataplanes.kuma.io configured
+customresourcedefinition.apiextensions.k8s.io/meshes.kuma.io configured
+customresourcedefinition.apiextensions.k8s.io/proxytemplates.kuma.io configured
+customresourcedefinition.apiextensions.k8s.io/trafficlogs.kuma.io configured
+customresourcedefinition.apiextensions.k8s.io/trafficpermissions.kuma.io configured
+customresourcedefinition.apiextensions.k8s.io/trafficroutes.kuma.io configured
+clusterrole.rbac.authorization.k8s.io/kuma:control-plane unchanged
+clusterrolebinding.rbac.authorization.k8s.io/kuma:control-plane unchanged
 role.rbac.authorization.k8s.io/kuma:control-plane created
 rolebinding.rbac.authorization.k8s.io/kuma:control-plane created
 service/kuma-injector created
 service/kuma-control-plane created
 deployment.apps/kuma-control-plane created
 deployment.apps/kuma-injector created
-mutatingwebhookconfiguration.admissionregistration.k8s.io/kuma-admission-mutating-webhook-configuration created
-mutatingwebhookconfiguration.admissionregistration.k8s.io/kuma-injector-webhook-configuration created
+mutatingwebhookconfiguration.admissionregistration.k8s.io/kuma-admission-mutating-webhook-configuration configured
+mutatingwebhookconfiguration.admissionregistration.k8s.io/kuma-injector-webhook-configuration configured
+validatingwebhookconfiguration.admissionregistration.k8s.io/kuma-validating-webhook-configuration configured
 ```
 
 You can check the pods are up and running by checking the `kuma-system` namespace
@@ -151,28 +162,28 @@ In the following steps, we will be using the pod name of the `kuma-control-plane
 
 ```
 $ kubectl delete pods --all -n kuma-demo
-pod "es-n8df7" deleted
-pod "kuma-demo-app-8fc49ddbf-gfjtb" deleted
-pod "redis-master-6d4cf995c5-nsghm" deleted
+pod "es-v6g88" deleted
+pod "kuma-demo-app-7bb5d85c8c-8kl2z" deleted
+pod "kuma-demo-backend-v0-7dcb8dc8fd-rq798" deleted
+pod "redis-master-5b5978b77f-pmhnz" deleted
 ```
 
 And check the pods are up and running again with an additional container. The additional container is the Envoy sidecar proxy that Kuma is injecting into each pod.
 
 ```
 $ kubectl get pods -n kuma-demo
-NAME                            READY   STATUS    RESTARTS   AGE
-es-gsc8w                        2/2     Running   0          2m25s
-kuma-demo-app-8fc49ddbf-k5z5q   3/3     Running   0          2m25s
-redis-master-6d4cf995c5-jxjjm   2/2     Running   0          2m25s
+NAME                                    READY   STATUS    RESTARTS   AGE
+es-5snv2                                2/2     Running   0          37s
+kuma-demo-app-7bb5d85c8c-5sqxl          3/3     Running   0          37s
+kuma-demo-backend-v0-7dcb8dc8fd-7ttjm   2/2     Running   0          37s
+redis-master-5b5978b77f-hwjvd           2/2     Running   0          37s
 ```
 
 ### 10. Port-forward the sample application again to access the front-end UI at http://localhost:8080
 
-<pre><code>$ kubectl port-forward <b>${KUMA_DEMO_APP_POD_NAME}</b> -n kuma-demo 8080 3001
-Forwarding from 127.0.0.1:8080 -> 8080
-Forwarding from [::1]:8080 -> 8080
-Forwarding from 127.0.0.1:3001 -> 3001
-Forwarding from [::1]:3001 -> 3001
+<pre><code>$ kubectl port-forward <b>${KUMA_DEMO_APP_POD_NAME}</b> -n kuma-demo 8080:80
+Forwarding from 127.0.0.1:8080 -> 80
+Forwarding from [::1]:8080 -> 80
 </code></pre>
 
 Now you can access the marketplace application through your web browser at http://localhost:8080 with Envoy handling all the traffic between the services. Happy shopping!
@@ -198,18 +209,19 @@ switched active Control Plane to "minikube"
 
 ```
 $ ./kumactl inspect dataplanes
-MESH      NAME                            TAGS                                                                                                      STATUS   LAST CONNECTED AGO   LAST UPDATED AGO   TOTAL UPDATES   TOTAL ERRORS
-default   es-gsc8w                        component=elasticsearch service=elasticsearch.kuma-demo.svc:80                                            Online   9m5s                 9m4s               3               0
-default   redis-master-6d4cf995c5-jxjjm   app=redis pod-template-hash=6d4cf995c5 role=master service=redis-master.kuma-demo.svc:6379 tier=backend   Online   9m2s                 9m1s               3               0
-default   kuma-demo-app-8fc49ddbf-k5z5q   app=kuma-demo-api pod-template-hash=8fc49ddbf service=kuma-demo-api.kuma-demo.svc:3001                    Online   9m8s                 9m7s               3               0
+MESH      NAME                                    TAGS                                                                                               STATUS   LAST CONNECTED AGO   LAST UPDATED AGO   TOTAL UPDATES   TOTAL ERRORS
+default   redis-master-5b5978b77f-hwjvd           app=redis pod-template-hash=5b5978b77f role=master service=redis.kuma-demo.svc:6379 tier=backend   Online   2m7s                 2m3s               8               0
+default   es-5snv2                                component=elasticsearch service=elasticsearch.kuma-demo.svc:80                                     Online   1m49s                1m48s              3               0
+default   kuma-demo-app-7bb5d85c8c-5sqxl          app=kuma-demo-frontend pod-template-hash=7bb5d85c8c service=frontend.kuma-demo.svc:80              Online   1m49s                1m48s              3               0
+default   kuma-demo-backend-v0-7dcb8dc8fd-7ttjm   app=kuma-demo-backend pod-template-hash=7dcb8dc8fd service=backend.kuma-demo.svc:3001 version=v0   Online   1m47s                1m46s              3               0
 ```
 
 ### 14. You can also use `kumactl` to look at the mesh. As shown below, our default mesh does not have mTLS enabled.
 
 ```
 $ ./kumactl get meshes
-NAME      mTLS   DP ACCESS LOGS
-default   off    off
+NAME      mTLS
+default   off
 ```
 
 ### 15.  Let's enable mTLS.
@@ -233,8 +245,8 @@ Using `kumactl`, inspect the mesh again to see if mTLS is enabled:
 
 ```
 $ ./kumactl get meshes
-NAME      mTLS   DP ACCESS LOGS
-default   on     off
+NAME      mTLS
+default   on
 ```
 
 ### 16.  Now let's enable traffic-permission for all services so our application will work like it use to:
@@ -311,20 +323,24 @@ metadata:
   namespace: kuma-demo
   name: everything
 spec:
-  rules:
-  - sources:
-    - match:
-        service: '*'
-    destinations:
-    - match:
-        service: '*'
-    conf:
-      backend: logstash
+  sources:
+  - match:
+      service: '*'
+  destinations:
+  - match:
+      service: '*'
+  conf:
+    backend: logstash
 EOF
 ```
 Logs will be sent to https://kumademo.loggly.com/
 
 ### 19. Now let's take down our Redis service because someone is spamming fake reviews. We can easily accomplish that by changing our traffic-permissions:
+
+```
+$ kubectl delete trafficpermission -n kuma-demo --all
+```
+
 ```
 $ cat <<EOF | kubectl apply -f - 
 apiVersion: kuma.io/v1alpha1
@@ -332,14 +348,28 @@ kind: TrafficPermission
 mesh: default
 metadata:
   namespace: kuma-demo
-  name: everything
+  name: frontend-to-backend
 spec:
   sources:
   - match:
-      service: 'kuma-demo-api.kuma-demo.svc:3001'
+      service: frontend.kuma-demo.svc:80
   destinations:
   - match:
-      service: 'elasticsearch.kuma-demo.svc:80'
+      service: backend.kuma-demo.svc:3001
+---
+apiVersion: kuma.io/v1alpha1
+kind: TrafficPermission
+mesh: default
+metadata:
+  namespace: kuma-demo
+  name: backend-to-elasticsearch
+spec:
+  sources:
+  - match:
+      service: backend.kuma-demo.svc:3001
+  destinations:
+  - match:
+      service: elasticsearch.kuma-demo.svc:80
 EOF
 ```
 
@@ -353,13 +383,13 @@ kind: TrafficPermission
 mesh: default
 metadata:
   namespace: kuma-demo
-  name: everything
+  name: backend-to-redis
 spec:
   sources:
   - match:
-      service: '*'
+      service: backend.kuma-demo.svc:3001
   destinations:
   - match:
-      service: '*'
+      service: redis.kuma-demo.svc:6379
 EOF
 ```

--- a/examples/kubernetes/kuma-demo/kuma-demo-aio.yaml
+++ b/examples/kubernetes/kuma-demo/kuma-demo-aio.yaml
@@ -128,7 +128,7 @@ spec:
 apiVersion: v1
 kind: Service
 metadata:
-  name: redis-master
+  name: redis
   namespace: kuma-demo
   labels:
     app: redis
@@ -146,7 +146,7 @@ spec:
 apiVersion: v1
 kind: Service
 metadata:
-  name: kuma-demo-backend
+  name: backend
   namespace: kuma-demo
 spec:
   selector:
@@ -183,7 +183,7 @@ spec:
         - name: ES_SPECIAL_OFFER
           value: "false"
         - name: REDIS_HOST
-          value: "redis-master"
+          value: redis
         imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 3001
@@ -194,7 +194,7 @@ metadata:
   name: kuma-demo-backend-v1
   namespace: kuma-demo
 spec:
-  replicas: 1
+  replicas: 0
   selector:
     matchLabels:
       app: kuma-demo-backend
@@ -214,7 +214,7 @@ spec:
         - name: ES_HOST
           value: http://elasticsearch:80
         - name: REDIS_HOST
-          value: "redis-master"
+          value: redis
         imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 3001
@@ -225,7 +225,7 @@ metadata:
   name: kuma-demo-backend-v2
   namespace: kuma-demo
 spec:
-  replicas: 1
+  replicas: 0
   selector:
     matchLabels:
       app: kuma-demo-backend
@@ -247,7 +247,7 @@ spec:
         - name: ES_TOTAL_OFFER
           value: "2"
         - name: REDIS_HOST
-          value: "redis-master"
+          value: redis
         imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 3001
@@ -277,7 +277,7 @@ data:
             server localhost:8080;
         }
         upstream backend {
-            server kuma-demo-backend:3001;
+            server backend:3001;
             keepalive_timeout 0s;
         }
         server {
@@ -295,7 +295,7 @@ data:
 apiVersion: v1
 kind: Service
 metadata:
-  name: kuma-demo-frontend
+  name: frontend
   namespace: kuma-demo
 spec:
   selector:

--- a/examples/kubernetes/kuma-demo/kuma-demo.yaml
+++ b/examples/kubernetes/kuma-demo/kuma-demo.yaml
@@ -128,7 +128,7 @@ spec:
 apiVersion: v1
 kind: Service
 metadata:
-  name: redis-master
+  name: redis
   namespace: kuma-demo
   labels:
     app: redis
@@ -225,7 +225,7 @@ spec:
         - name: ES_HOST
           value: http://elasticsearch:80
         - name: REDIS_HOST
-          value: "redis-master"
+          value: redis
         imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 3001


### PR DESCRIPTION
### Summary

* rename `Service` objects to simplify `TrafficPermission`, `TrafficRoute`, `TrafficLogging` examples
