### PR TITLE
feat(kuma-cp) expose config

### DIFF
--- a/app/kuma-cp/cmd/run.go
+++ b/app/kuma-cp/cmd/run.go
@@ -48,12 +48,12 @@ func newRunCmdWithOpts(opts runCmdOpts) *cobra.Command {
 				runLog.Error(err, "unable to set up Control Plane runtime")
 				return err
 			}
-			cfgBytes, err := config.ConfigForDisplayYaml(&cfg)
+			cfgBytes, err := config.ConfigForDisplayJSON(&cfg)
 			if err != nil {
 				runLog.Error(err, "unable to prepare config for display")
 				return err
 			}
-			runLog.Info(fmt.Sprintf("Current config: \n%s", string(cfgBytes)))
+			runLog.Info(fmt.Sprintf("Current config %s", cfgBytes))
 			if err := sds_server.SetupServer(rt); err != nil {
 				runLog.Error(err, "unable to set up SDS server")
 				return err

--- a/app/kuma-cp/cmd/run.go
+++ b/app/kuma-cp/cmd/run.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"fmt"
 	ui_server "github.com/Kong/kuma/app/kuma-ui/pkg/server"
 	api_server "github.com/Kong/kuma/pkg/api-server"
 	"github.com/Kong/kuma/pkg/config"
@@ -47,6 +48,12 @@ func newRunCmdWithOpts(opts runCmdOpts) *cobra.Command {
 				runLog.Error(err, "unable to set up Control Plane runtime")
 				return err
 			}
+			cfgBytes, err := config.ConfigForDisplayYaml(&cfg)
+			if err != nil {
+				runLog.Error(err, "unable to prepare config for display")
+				return err
+			}
+			runLog.Info(fmt.Sprintf("Current config: \n%s", string(cfgBytes)))
 			if err := sds_server.SetupServer(rt); err != nil {
 				runLog.Error(err, "unable to set up SDS server")
 				return err

--- a/app/kuma-cp/cmd/run.go
+++ b/app/kuma-cp/cmd/run.go
@@ -48,9 +48,14 @@ func newRunCmdWithOpts(opts runCmdOpts) *cobra.Command {
 				runLog.Error(err, "unable to set up Control Plane runtime")
 				return err
 			}
-			cfgBytes, err := config.ConfigForDisplayJSON(&cfg)
+			cfgForDisplay, err := config.ConfigForDisplay(&cfg)
 			if err != nil {
 				runLog.Error(err, "unable to prepare config for display")
+				return err
+			}
+			cfgBytes, err := config.ToJson(cfgForDisplay)
+			if err != nil {
+				runLog.Error(err, "unable to convert config to json")
 				return err
 			}
 			runLog.Info(fmt.Sprintf("Current config %s", cfgBytes))

--- a/pkg/api-server/config_ws.go
+++ b/pkg/api-server/config_ws.go
@@ -6,14 +6,18 @@ import (
 )
 
 func configWs(cfg config.Config) (*restful.WebService, error) {
-	cfgForDisplay, err := config.ConfigForDisplayJSON(cfg)
+	cfgForDisplay, err := config.ConfigForDisplay(cfg)
+	if err != nil {
+		return nil, err
+	}
+	json, err := config.ToJson(cfgForDisplay)
 	if err != nil {
 		return nil, err
 	}
 	ws := new(restful.WebService).Path("/config")
 	ws.Route(ws.GET("").To(func(req *restful.Request, resp *restful.Response) {
 		resp.AddHeader("content-type", "application/json")
-		if _, err := resp.Write(cfgForDisplay); err != nil {
+		if _, err := resp.Write(json); err != nil {
 			log.Error(err, "Could not write the index response")
 		}
 	}))

--- a/pkg/api-server/config_ws.go
+++ b/pkg/api-server/config_ws.go
@@ -1,0 +1,22 @@
+package api_server
+
+import (
+	"github.com/Kong/kuma/pkg/config"
+	kuma_cp "github.com/Kong/kuma/pkg/config/app/kuma-cp"
+	"github.com/emicklei/go-restful"
+)
+
+func configWs(cfg *kuma_cp.Config) (*restful.WebService, error) {
+	cfgForDisplay, err := config.ConfigForDisplayJson(cfg)
+	if err != nil {
+		return nil, err
+	}
+	ws := new(restful.WebService).Path("/config")
+	ws.Route(ws.GET("").To(func(req *restful.Request, resp *restful.Response) {
+		resp.AddHeader("content-type", "application/json")
+		if _, err := resp.Write(cfgForDisplay); err != nil {
+			log.Error(err, "Could not write the index response")
+		}
+	}))
+	return ws, nil
+}

--- a/pkg/api-server/config_ws.go
+++ b/pkg/api-server/config_ws.go
@@ -2,12 +2,11 @@ package api_server
 
 import (
 	"github.com/Kong/kuma/pkg/config"
-	kuma_cp "github.com/Kong/kuma/pkg/config/app/kuma-cp"
 	"github.com/emicklei/go-restful"
 )
 
-func configWs(cfg *kuma_cp.Config) (*restful.WebService, error) {
-	cfgForDisplay, err := config.ConfigForDisplayJson(cfg)
+func configWs(cfg config.Config) (*restful.WebService, error) {
+	cfgForDisplay, err := config.ConfigForDisplayJSON(cfg)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/api-server/config_ws_test.go
+++ b/pkg/api-server/config_ws_test.go
@@ -46,7 +46,7 @@ var _ = Describe("Config WS", func() {
 		// when
 		expectedConfig := kuma_cp.DefaultConfig()
 		expectedConfig.ApiServer = cfg
-		cfgJson, err := config.ConfigForDisplayJson(&expectedConfig)
+		cfgJson, err := config.ConfigForDisplayJSON(&expectedConfig)
 		Expect(err).ToNot(HaveOccurred())
 
 		// then

--- a/pkg/api-server/config_ws_test.go
+++ b/pkg/api-server/config_ws_test.go
@@ -132,6 +132,6 @@ var _ = Describe("Config WS", func() {
           }
         }
 		`, port)
-		Expect(json).To(MatchJSON(body))
+		Expect(body).To(MatchJSON(json))
 	})
 })

--- a/pkg/api-server/config_ws_test.go
+++ b/pkg/api-server/config_ws_test.go
@@ -1,0 +1,55 @@
+package api_server_test
+
+import (
+	"fmt"
+	"github.com/Kong/kuma/pkg/config"
+	api_server_config "github.com/Kong/kuma/pkg/config/api-server"
+	kuma_cp "github.com/Kong/kuma/pkg/config/app/kuma-cp"
+	"github.com/Kong/kuma/pkg/plugins/resources/memory"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"io/ioutil"
+	"net/http"
+)
+
+var _ = Describe("Config WS", func() {
+
+	It("should return the config", func() {
+		// given
+		cfg := api_server_config.DefaultApiServerConfig()
+
+		// setup
+		resourceStore := memory.NewStore()
+		apiServer := createTestApiServer(resourceStore, cfg)
+
+		stop := make(chan struct{})
+		go func() {
+			defer GinkgoRecover()
+			err := apiServer.Start(stop)
+			Expect(err).ToNot(HaveOccurred())
+		}()
+
+		// wait for the server
+		Eventually(func() error {
+			_, err := http.Get(fmt.Sprintf("http://localhost%s/config", apiServer.Address()))
+			return err
+		}, "3s").ShouldNot(HaveOccurred())
+
+		// when
+		resp, err := http.Get(fmt.Sprintf("http://localhost%s/config", apiServer.Address()))
+		Expect(err).ToNot(HaveOccurred())
+
+		// then
+		body, err := ioutil.ReadAll(resp.Body)
+		Expect(err).ToNot(HaveOccurred())
+
+		// when
+		expectedConfig := kuma_cp.DefaultConfig()
+		expectedConfig.ApiServer = cfg
+		cfgJson, err := config.ConfigForDisplayJson(&expectedConfig)
+		Expect(err).ToNot(HaveOccurred())
+
+		// then
+		Expect(cfgJson).To(MatchJSON(body))
+	})
+})

--- a/pkg/api-server/resource_api_client_test.go
+++ b/pkg/api-server/resource_api_client_test.go
@@ -108,7 +108,7 @@ func createTestApiServer(store store.ResourceStore, config *config_api_server.Ap
 	resources := manager.NewResourceManager(store)
 	cfg := kuma_cp.DefaultConfig()
 	cfg.ApiServer = config
-	apiServer, err := api_server.NewApiServer(resources, defs, cfg)
+	apiServer, err := api_server.NewApiServer(resources, defs, cfg.ApiServer, &cfg)
 	Expect(err).ToNot(HaveOccurred())
 	return apiServer
 }

--- a/pkg/api-server/resource_api_client_test.go
+++ b/pkg/api-server/resource_api_client_test.go
@@ -7,6 +7,7 @@ import (
 	api_server "github.com/Kong/kuma/pkg/api-server"
 	"github.com/Kong/kuma/pkg/api-server/definitions"
 	config_api_server "github.com/Kong/kuma/pkg/config/api-server"
+	kuma_cp "github.com/Kong/kuma/pkg/config/app/kuma-cp"
 	"github.com/Kong/kuma/pkg/core/resources/manager"
 	"github.com/Kong/kuma/pkg/core/resources/store"
 	"github.com/Kong/kuma/pkg/test"
@@ -105,5 +106,9 @@ func createTestApiServer(store store.ResourceStore, config *config_api_server.Ap
 	config.Port = port
 	defs := append(definitions.All, SampleTrafficRouteWsDefinition)
 	resources := manager.NewResourceManager(store)
-	return api_server.NewApiServer(resources, defs, config)
+	cfg := kuma_cp.DefaultConfig()
+	cfg.ApiServer = config
+	apiServer, err := api_server.NewApiServer(resources, defs, cfg)
+	Expect(err).ToNot(HaveOccurred())
+	return apiServer
 }

--- a/pkg/config/api-server/config.go
+++ b/pkg/config/api-server/config.go
@@ -16,7 +16,7 @@ type ApiServerConfig struct {
 	// If true, then API Server will operate in read only mode (serving GET requests)
 	ReadOnly bool `yaml:"readOnly" envconfig:"kuma_api_server_read_only"`
 	// API Catalog
-	Catalog *catalog.CatalogConfig
+	Catalog *catalog.CatalogConfig `yaml:"-"`
 	// Allowed domains for Cross-Origin Resource Sharing. The value can be either domain or regexp
 	CorsAllowedDomains []string `yaml:"corsAllowedDomains" envconfig:"kuma_api_server_cors_allowed_domains"`
 }

--- a/pkg/config/api-server/config.go
+++ b/pkg/config/api-server/config.go
@@ -21,6 +21,9 @@ type ApiServerConfig struct {
 	CorsAllowedDomains []string `yaml:"corsAllowedDomains" envconfig:"kuma_api_server_cors_allowed_domains"`
 }
 
+func (a *ApiServerConfig) Sanitize() {
+}
+
 func (a *ApiServerConfig) Validate() error {
 	if a.Port < 0 {
 		return errors.New("Port cannot be negative")

--- a/pkg/config/app/kuma-cp/config.go
+++ b/pkg/config/app/kuma-cp/config.go
@@ -28,6 +28,9 @@ type Defaults struct {
 	Mesh string `yaml:"mesh"`
 }
 
+func (d *Defaults) Sanitize() {
+}
+
 func (d *Defaults) MeshProto() v1alpha1.Mesh {
 	mesh, err := d.parseMesh()
 	util_error.MustNot(err)
@@ -79,6 +82,20 @@ type Config struct {
 	Reports *Reports `yaml:"reports"`
 	// GUI Server Config
 	GuiServer *gui_server.GuiServerConfig `yaml:"guiServer"`
+}
+
+func (c *Config) Sanitize() {
+	c.General.Sanitize()
+	c.Store.Sanitize()
+	c.Discovery.Sanitize()
+	c.BootstrapServer.Sanitize()
+	c.XdsServer.Sanitize()
+	c.SdsServer.Sanitize()
+	c.DataplaneTokenServer.Sanitize()
+	c.ApiServer.Sanitize()
+	c.Runtime.Sanitize()
+	c.Defaults.Sanitize()
+	c.GuiServer.Sanitize()
 }
 
 func DefaultConfig() Config {
@@ -152,6 +169,9 @@ type GeneralConfig struct {
 }
 
 var _ config.Config = &GeneralConfig{}
+
+func (g *GeneralConfig) Sanitize() {
+}
 
 func (g *GeneralConfig) Validate() error {
 	return nil

--- a/pkg/config/app/kuma-dp/config.go
+++ b/pkg/config/app/kuma-dp/config.go
@@ -39,6 +39,12 @@ type Config struct {
 	DataplaneRuntime DataplaneRuntime `yaml:"dataplaneRuntime,omitempty"`
 }
 
+func (c *Config) Sanitize() {
+	c.ControlPlane.Sanitize()
+	c.Dataplane.Sanitize()
+	c.DataplaneRuntime.Sanitize()
+}
+
 // ControlPlane defines coordinates of the Control Plane.
 type ControlPlane struct {
 	// ApiServer defines coordinates of the Control Plane API Server
@@ -89,6 +95,10 @@ func (c *Config) Validate() (errs error) {
 
 var _ config.Config = &ControlPlane{}
 
+func (c *ControlPlane) Sanitize() {
+	c.ApiServer.Sanitize()
+}
+
 func (c *ControlPlane) Validate() (errs error) {
 	if err := c.ApiServer.Validate(); err != nil {
 		errs = multierr.Append(errs, errors.Wrapf(err, ".ApiServer is not valid"))
@@ -97,6 +107,9 @@ func (c *ControlPlane) Validate() (errs error) {
 }
 
 var _ config.Config = &Dataplane{}
+
+func (d *Dataplane) Sanitize() {
+}
 
 func (d *Dataplane) Validate() (errs error) {
 	if d.Mesh == "" {
@@ -116,11 +129,19 @@ func (d *Dataplane) Validate() (errs error) {
 
 var _ config.Config = &DataplaneRuntime{}
 
+func (d *DataplaneRuntime) Sanitize() {
+}
+
 func (d *DataplaneRuntime) Validate() (errs error) {
 	if d.BinaryPath == "" {
 		errs = multierr.Append(errs, errors.Errorf(".BinaryPath must be non-empty"))
 	}
 	return
+}
+
+var _ config.Config = &ApiServer{}
+
+func (d *ApiServer) Sanitize() {
 }
 
 func (d *ApiServer) Validate() (errs error) {

--- a/pkg/config/app/kuma-injector/config.go
+++ b/pkg/config/app/kuma-injector/config.go
@@ -88,6 +88,9 @@ type WebHookServer struct {
 	CertDir string `yaml:"certDir,omitempty" envconfig:"kuma_injector_webhook_server_cert_dir"`
 }
 
+func (s *WebHookServer) Sanitize() {
+}
+
 // Injector defines configuration of a Kuma Sidecar Injector.
 type Injector struct {
 	// ControlPlane defines coordinates of the Kuma Control Plane.
@@ -190,6 +193,11 @@ type InitContainer struct {
 
 var _ config.Config = &Config{}
 
+func (c *Config) Sanitize() {
+	c.Injector.Sanitize()
+	c.WebHookServer.Sanitize()
+}
+
 func (c *Config) Validate() (errs error) {
 	if err := c.WebHookServer.Validate(); err != nil {
 		errs = multierr.Append(errs, errors.Wrapf(err, ".WebHookServer is not valid"))
@@ -217,6 +225,12 @@ func (s *WebHookServer) Validate() (errs error) {
 
 var _ config.Config = &Injector{}
 
+func (i *Injector) Sanitize() {
+	i.ControlPlane.Sanitize()
+	i.InitContainer.Sanitize()
+	i.SidecarContainer.Sanitize()
+}
+
 func (i *Injector) Validate() (errs error) {
 	if err := i.ControlPlane.Validate(); err != nil {
 		errs = multierr.Append(errs, errors.Wrapf(err, ".ControlPlane is not valid"))
@@ -232,6 +246,10 @@ func (i *Injector) Validate() (errs error) {
 
 var _ config.Config = &ControlPlane{}
 
+func (c *ControlPlane) Sanitize() {
+	c.ApiServer.Sanitize()
+}
+
 func (c *ControlPlane) Validate() (errs error) {
 	if err := c.ApiServer.Validate(); err != nil {
 		errs = multierr.Append(errs, errors.Wrapf(err, ".ApiServer is not valid"))
@@ -240,6 +258,9 @@ func (c *ControlPlane) Validate() (errs error) {
 }
 
 var _ config.Config = &ApiServer{}
+
+func (s *ApiServer) Sanitize() {
+}
 
 func (s *ApiServer) Validate() (errs error) {
 	if s.URL == "" {
@@ -254,6 +275,12 @@ func (s *ApiServer) Validate() (errs error) {
 }
 
 var _ config.Config = &SidecarContainer{}
+
+func (c *SidecarContainer) Sanitize() {
+	c.Resources.Sanitize()
+	c.LivenessProbe.Sanitize()
+	c.ReadinessProbe.Sanitize()
+}
 
 func (c *SidecarContainer) Validate() (errs error) {
 	if c.Image == "" {
@@ -282,6 +309,9 @@ func (c *SidecarContainer) Validate() (errs error) {
 
 var _ config.Config = &InitContainer{}
 
+func (c *InitContainer) Sanitize() {
+}
+
 func (c *InitContainer) Validate() (errs error) {
 	if c.Image == "" {
 		errs = multierr.Append(errs, errors.Errorf(".Image must be non-empty"))
@@ -290,6 +320,9 @@ func (c *InitContainer) Validate() (errs error) {
 }
 
 var _ config.Config = &SidecarReadinessProbe{}
+
+func (c *SidecarReadinessProbe) Sanitize() {
+}
 
 func (c *SidecarReadinessProbe) Validate() (errs error) {
 	if c.InitialDelaySeconds < 1 {
@@ -312,6 +345,9 @@ func (c *SidecarReadinessProbe) Validate() (errs error) {
 
 var _ config.Config = &SidecarLivenessProbe{}
 
+func (c *SidecarLivenessProbe) Sanitize() {
+}
+
 func (c *SidecarLivenessProbe) Validate() (errs error) {
 	if c.InitialDelaySeconds < 1 {
 		errs = multierr.Append(errs, errors.Errorf(".InitialDelaySeconds must be >= 1"))
@@ -329,6 +365,14 @@ func (c *SidecarLivenessProbe) Validate() (errs error) {
 }
 
 var _ config.Config = &SidecarResources{}
+
+func (c *SidecarResources) Sanitize() {
+	c.Limits.Sanitize()
+	c.Requests.Sanitize()
+}
+
+func (c *SidecarResourceRequests) Sanitize() {
+}
 
 func (c *SidecarResources) Validate() (errs error) {
 	if err := c.Requests.Validate(); err != nil {
@@ -353,6 +397,9 @@ func (c *SidecarResourceRequests) Validate() (errs error) {
 }
 
 var _ config.Config = &SidecarResourceLimits{}
+
+func (c *SidecarResourceLimits) Sanitize() {
+}
 
 func (c *SidecarResourceLimits) Validate() (errs error) {
 	if _, err := kube_api.ParseQuantity(c.CPU); err != nil {

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -1,5 +1,8 @@
 package config
 
+const SanitizedValue = "*****"
+
 type Config interface {
+	Sanitize()
 	Validate() error
 }

--- a/pkg/config/core/discovery/config.go
+++ b/pkg/config/core/discovery/config.go
@@ -12,6 +12,10 @@ type DiscoveryConfig struct {
 	Universal *universal.UniversalDiscoveryConfig `yaml:"universal"`
 }
 
+func (d *DiscoveryConfig) Sanitize() {
+	d.Universal.Sanitize()
+}
+
 func (d *DiscoveryConfig) Validate() error {
 	return errors.Wrap(d.Universal.Validate(), "Discovery validation failed")
 }

--- a/pkg/config/core/resources/store/config.go
+++ b/pkg/config/core/resources/store/config.go
@@ -36,6 +36,11 @@ func DefaultStoreConfig() *StoreConfig {
 	}
 }
 
+func (s *StoreConfig) Sanitize() {
+	s.Kubernetes.Sanitize()
+	s.Postgres.Sanitize()
+}
+
 func (s *StoreConfig) Validate() error {
 	switch s.Type {
 	case PostgresStore:

--- a/pkg/config/display.go
+++ b/pkg/config/display.go
@@ -1,0 +1,49 @@
+package config
+
+import (
+	"encoding/json"
+	ghodss_yaml "github.com/ghodss/yaml"
+	"github.com/pkg/errors"
+	"gopkg.in/yaml.v2"
+	"reflect"
+)
+
+func ConfigForDisplay(cfg Config) (Config, error) {
+	// copy config so we don't override values, because nested structs in config are pointers
+	newCfg, err := copyConfig(cfg)
+	if err != nil {
+		return nil, err
+	}
+	// todo(jakubdyszkiewicz) hide secret values
+	return newCfg, nil
+}
+
+func ConfigForDisplayYaml(cfg Config) ([]byte, error) {
+	cfgForDisplay, err := ConfigForDisplay(cfg)
+	if err != nil {
+		return nil, errors.Wrap(err, "could not prepare config for display")
+	}
+	return yaml.Marshal(&cfgForDisplay)
+}
+
+func ConfigForDisplayJson(cfg Config) ([]byte, error) {
+	yamlBytes, err := ConfigForDisplayYaml(cfg)
+	if err != nil {
+		return nil, err
+	}
+	// there is no easy way to convert yaml to json using gopkg.in/yaml.v2
+	return ghodss_yaml.YAMLToJSON(yamlBytes)
+}
+
+func copyConfig(cfg Config) (Config, error) {
+	cfgBytes, err := json.Marshal(cfg)
+	if err != nil {
+		return nil, err
+	}
+
+	newCfg := reflect.New(reflect.TypeOf(cfg).Elem()).Interface().(Config)
+	if err := json.Unmarshal(cfgBytes, newCfg); err != nil {
+		return nil, err
+	}
+	return newCfg, nil
+}

--- a/pkg/config/display.go
+++ b/pkg/config/display.go
@@ -18,7 +18,7 @@ func ConfigForDisplay(cfg Config) (Config, error) {
 	return newCfg, nil
 }
 
-func ConfigForDisplayYaml(cfg Config) ([]byte, error) {
+func ConfigForDisplayYAML(cfg Config) ([]byte, error) {
 	cfgForDisplay, err := ConfigForDisplay(cfg)
 	if err != nil {
 		return nil, errors.Wrap(err, "could not prepare config for display")
@@ -26,8 +26,8 @@ func ConfigForDisplayYaml(cfg Config) ([]byte, error) {
 	return yaml.Marshal(&cfgForDisplay)
 }
 
-func ConfigForDisplayJson(cfg Config) ([]byte, error) {
-	yamlBytes, err := ConfigForDisplayYaml(cfg)
+func ConfigForDisplayJSON(cfg Config) ([]byte, error) {
+	yamlBytes, err := ConfigForDisplayYAML(cfg)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/config/display.go
+++ b/pkg/config/display.go
@@ -2,9 +2,6 @@ package config
 
 import (
 	"encoding/json"
-	ghodss_yaml "github.com/ghodss/yaml"
-	"github.com/pkg/errors"
-	"gopkg.in/yaml.v2"
 	"reflect"
 )
 
@@ -16,23 +13,6 @@ func ConfigForDisplay(cfg Config) (Config, error) {
 	}
 	newCfg.Sanitize()
 	return newCfg, nil
-}
-
-func ConfigForDisplayYAML(cfg Config) ([]byte, error) {
-	cfgForDisplay, err := ConfigForDisplay(cfg)
-	if err != nil {
-		return nil, errors.Wrap(err, "could not prepare config for display")
-	}
-	return yaml.Marshal(&cfgForDisplay)
-}
-
-func ConfigForDisplayJSON(cfg Config) ([]byte, error) {
-	yamlBytes, err := ConfigForDisplayYAML(cfg)
-	if err != nil {
-		return nil, err
-	}
-	// there is no easy way to convert yaml to json using gopkg.in/yaml.v2
-	return ghodss_yaml.YAMLToJSON(yamlBytes)
 }
 
 func copyConfig(cfg Config) (Config, error) {

--- a/pkg/config/display.go
+++ b/pkg/config/display.go
@@ -14,7 +14,7 @@ func ConfigForDisplay(cfg Config) (Config, error) {
 	if err != nil {
 		return nil, err
 	}
-	// todo(jakubdyszkiewicz) hide secret values
+	newCfg.Sanitize()
 	return newCfg, nil
 }
 

--- a/pkg/config/gui-server/config.go
+++ b/pkg/config/gui-server/config.go
@@ -13,6 +13,9 @@ type GuiServerConfig struct {
 	GuiConfig *GuiConfig `yaml:"-"`
 }
 
+func (g *GuiServerConfig) Sanitize() {
+}
+
 func (g *GuiServerConfig) Validate() error {
 	if g.Port > 65535 {
 		return errors.New("Port must be in the range [0, 65535]")

--- a/pkg/config/gui-server/config.go
+++ b/pkg/config/gui-server/config.go
@@ -10,7 +10,7 @@ type GuiServerConfig struct {
 	// Port on which the server is exposed
 	Port uint32 `yaml:"port" envconfig:"kuma_gui_server_port"`
 	// Config of the GUI itself
-	GuiConfig *GuiConfig
+	GuiConfig *GuiConfig `yaml:"-"`
 }
 
 func (g *GuiServerConfig) Validate() error {

--- a/pkg/config/loader.go
+++ b/pkg/config/loader.go
@@ -2,10 +2,10 @@ package config
 
 import (
 	"github.com/Kong/kuma/pkg/core"
-	//"github.com/ghodss/yaml"
 	"github.com/kelseyhightower/envconfig"
 	"github.com/pkg/errors"
-	"gopkg.in/yaml.v2" // todo(jakubdyszkiewicz) switch to "github.com/ghodss/yaml" when solved problems with loading xdsServer
+	// we use gopkg.in/yaml.v2 because it supports time.Duration
+	"gopkg.in/yaml.v2"
 	"io/ioutil"
 	"os"
 )

--- a/pkg/config/plugins/discovery/universal/config.go
+++ b/pkg/config/plugins/discovery/universal/config.go
@@ -13,6 +13,9 @@ type UniversalDiscoveryConfig struct {
 	PollingInterval time.Duration `yaml:"pollingInterval" envconfig:"kuma_discovery_universal_polling_interval"`
 }
 
+func (u UniversalDiscoveryConfig) Sanitize() {
+}
+
 func (u UniversalDiscoveryConfig) Validate() error {
 	return nil
 }

--- a/pkg/config/plugins/resources/k8s/config.go
+++ b/pkg/config/plugins/resources/k8s/config.go
@@ -20,6 +20,9 @@ type KubernetesStoreConfig struct {
 
 var _ config.Config = &KubernetesStoreConfig{}
 
+func (p *KubernetesStoreConfig) Sanitize() {
+}
+
 func (p *KubernetesStoreConfig) Validate() error {
 	if len(p.SystemNamespace) < 1 {
 		return errors.New("SystemNamespace should not be empty")

--- a/pkg/config/plugins/resources/postgres/config.go
+++ b/pkg/config/plugins/resources/postgres/config.go
@@ -24,6 +24,10 @@ type PostgresStoreConfig struct {
 	ConnectionTimeout int `yaml:"connectionTimeout" envconfig:"kuma_store_postgres_connection_timeout"`
 }
 
+func (p *PostgresStoreConfig) Sanitize() {
+	p.Password = config.SanitizedValue
+}
+
 func (p *PostgresStoreConfig) Validate() error {
 	if len(p.Host) < 1 {
 		return errors.New("Host should not be empty")

--- a/pkg/config/plugins/runtime/config.go
+++ b/pkg/config/plugins/runtime/config.go
@@ -19,6 +19,10 @@ type RuntimeConfig struct {
 	Kubernetes *k8s.KubernetesRuntimeConfig `yaml:"kubernetes"`
 }
 
+func (c *RuntimeConfig) Sanitize() {
+	c.Kubernetes.Sanitize()
+}
+
 func (c *RuntimeConfig) Validate(env core.EnvironmentType) error {
 	switch env {
 	case core.KubernetesEnvironment:

--- a/pkg/config/plugins/runtime/k8s/config.go
+++ b/pkg/config/plugins/runtime/k8s/config.go
@@ -35,6 +35,9 @@ type AdmissionServerConfig struct {
 
 var _ config.Config = &KubernetesRuntimeConfig{}
 
+func (c *KubernetesRuntimeConfig) Sanitize() {
+}
+
 func (c *KubernetesRuntimeConfig) Validate() error {
 	if err := c.AdmissionServer.Validate(); err != nil {
 		return errors.Wrap(err, "Admission Server validation failed")
@@ -43,6 +46,9 @@ func (c *KubernetesRuntimeConfig) Validate() error {
 }
 
 var _ config.Config = &AdmissionServerConfig{}
+
+func (c *AdmissionServerConfig) Sanitize() {
+}
 
 func (c *AdmissionServerConfig) Validate() error {
 	if 65535 < c.Port {

--- a/pkg/config/sds/config.go
+++ b/pkg/config/sds/config.go
@@ -24,6 +24,9 @@ type SdsServerConfig struct {
 
 var _ config.Config = &SdsServerConfig{}
 
+func (c *SdsServerConfig) Sanitize() {
+}
+
 func (c *SdsServerConfig) Validate() error {
 	if c.GrpcPort < 0 {
 		return errors.New("GrpcPort cannot be negative")

--- a/pkg/config/token-server/config.go
+++ b/pkg/config/token-server/config.go
@@ -25,6 +25,11 @@ type DataplaneTokenServerConfig struct {
 	Public *PublicDataplaneTokenServerConfig `yaml:"public"`
 }
 
+func (i *DataplaneTokenServerConfig) Sanitize() {
+	i.Public.Sanitize()
+	i.Local.Sanitize()
+}
+
 func (i *DataplaneTokenServerConfig) Validate() error {
 	if err := i.Local.Validate(); err != nil {
 		return errors.Wrap(err, "Local validation failed")
@@ -45,6 +50,9 @@ type LocalDataplaneTokenServerConfig struct {
 }
 
 var _ config.Config = &LocalDataplaneTokenServerConfig{}
+
+func (l *LocalDataplaneTokenServerConfig) Sanitize() {
+}
 
 func (l *LocalDataplaneTokenServerConfig) Validate() error {
 	if l.Port > 65535 {
@@ -86,6 +94,9 @@ func DefaultPublicDataplaneTokenServerConfig() *PublicDataplaneTokenServerConfig
 		TlsKeyFile:     "",
 		ClientCertsDir: "",
 	}
+}
+
+func (p *PublicDataplaneTokenServerConfig) Sanitize() {
 }
 
 func (p *PublicDataplaneTokenServerConfig) Validate() error {

--- a/pkg/config/util.go
+++ b/pkg/config/util.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	ghodss_yaml "github.com/ghodss/yaml"
 	"gopkg.in/yaml.v2"
 )
 
@@ -10,4 +11,13 @@ func FromYAML(content []byte, cfg Config) error {
 
 func ToYAML(cfg Config) ([]byte, error) {
 	return yaml.Marshal(cfg)
+}
+
+func ToJson(cfg Config) ([]byte, error) {
+	yamlBytes, err := ToYAML(cfg)
+	if err != nil {
+		return nil, err
+	}
+	// there is no easy way to convert yaml to json using gopkg.in/yaml.v2
+	return ghodss_yaml.YAMLToJSON(yamlBytes)
 }

--- a/pkg/config/xds/bootstrap/config.go
+++ b/pkg/config/xds/bootstrap/config.go
@@ -18,6 +18,10 @@ type BootstrapServerConfig struct {
 	Params *BootstrapParamsConfig `yaml:"params"`
 }
 
+func (b *BootstrapServerConfig) Sanitize() {
+	b.Params.Sanitize()
+}
+
 func (b *BootstrapServerConfig) Validate() error {
 	if b.Port > 65535 {
 		return errors.New("Port must be in the range [0, 65535]")
@@ -50,6 +54,9 @@ type BootstrapParamsConfig struct {
 	XdsPort uint32 `yaml:"xdsPort" envconfig:"kuma_bootstrap_server_params_xds_port"`
 	// Connection timeout to the XDS Server
 	XdsConnectTimeout time.Duration `yaml:"xdsConnectTimeout" envconfig:"kuma_bootstrap_server_params_xds_connect_timeout"`
+}
+
+func (b *BootstrapParamsConfig) Sanitize() {
 }
 
 func (b *BootstrapParamsConfig) Validate() error {

--- a/pkg/config/xds/config.go
+++ b/pkg/config/xds/config.go
@@ -23,6 +23,9 @@ type XdsServerConfig struct {
 	DataplaneStatusFlushInterval time.Duration `yaml:"dataplaneStatusFlushInterval" envconfig:"kuma_xds_server_dataplane_status_flush_interval"`
 }
 
+func (x *XdsServerConfig) Sanitize() {
+}
+
 func (x *XdsServerConfig) Validate() error {
 	if x.GrpcPort < 0 {
 		return errors.New("GrpcPort cannot be negative")


### PR DESCRIPTION
### Summary

Starting as draft, because of open questions.

1) **Library**
I tried to switch from `gopkg.in/yaml.v2` to `github.com/ghodss/yaml`. It required to change `yaml` to `json` annotations, but it turned out that `ghodss` does not support `time.Duration`, therefore you cannot put in config stuff like `xdsConnectTimeout: 1s`. I'd say this is a decrease in UX.

2) **Secret values**
For now, we only want to hide the Postgres password, but who knows what will come next. I see 2 ways to implement this.
    1. via annotation like `secret:"true"` next to `envconfig` and `yaml`. Then scan struct recursivly via reflection and replace it via placeholder. Extra tricky part, the value can be of many types.
    2. Just like validation, we can add `func HideSecretValues()` method on `Config`, call that for every subconfig and explicitly replace the values.

    I like the second option better. Although probably a bit more code, it is explicit and less magical.

3) **Pointers in config**
We have to replace secrets in config so we have to copy a config. It's a problem since subconfigs are pointers. We can "hack" it with marshal -> unmarshal, but I'd say it's better to get rid of pointers. It's kind of uncomfortable to think that any component can change the config at any given time of running app.