### PR TITLE
ci: add e2e tests for TrafficRoute

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -400,6 +400,12 @@ jobs:
     - run:
         name: Verify Envoy stats
         command: make verify/example/docker-compose
+    - run:
+        name: Verify traffic routing without mTLS
+        command: make verify/traffic-routing/docker-compose/without-mtls
+    - run:
+        name: Verify traffic routing with mTLS
+        command: make verify/traffic-routing/docker-compose/with-mtls
 
   example_minikube:
     executor: vm

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -435,7 +435,7 @@ jobs:
             name: Load Docker images into Minikube
             command: make load/example/minikube
     - run:
-        name: Deploy Kuma demo
+        name: Deploy example setup
         command: make deploy/example/minikube
     - run:
         name: Wait until Envoy listener gets configured
@@ -461,6 +461,18 @@ jobs:
     - run:
         name: Verify kumactl workflow
         command: make kumactl/example/minikube
+    - run:
+        name: Undeploy example setup
+        command: make undeploy/example/minikube
+    - run:
+        name: Deploy example setup for traffic routing
+        command: make deploy/traffic-routing/minikube
+    - run:
+        name: Verify traffic routing without mTLS
+        command: make verify/traffic-routing/minikube/without-mtls
+    - run:
+        name: Verify traffic routing with mTLS
+        command: make verify/traffic-routing/minikube/with-mtls
 
   release:
     executor: golang

--- a/Makefile.e2e.mk
+++ b/Makefile.e2e.mk
@@ -3,6 +3,7 @@
 		wait/example/docker-compose curl/example/docker-compose stats/example/docker-compose \
 		verify/example/docker-compose/inbound verify/example/docker-compose/outbound verify/example/docker-compose \
 		build/example/minikube load/example/minikube deploy/example/minikube wait/example/minikube apply/example/minikube/mtls wait/example/minikube/mtls curl/example/minikube stats/example/minikube \
+		deploy/example/traffic-routing/minikube \
 		verify/example/minikube/inbound verify/example/minikube/outbound verify/example/minikube \
 		verify/example/minikube/mtls/outbound verify/example/minikube/mtls
 
@@ -165,6 +166,15 @@ deploy/example/minikube: ## Minikube: Deploy example setup
 	kubectl wait --timeout=60s --for=condition=Ready -n kuma-demo pods -l app=demo-app
 	kubectl wait --timeout=60s --for=condition=Available -n kuma-demo deployment/demo-client
 	kubectl wait --timeout=60s --for=condition=Ready -n kuma-demo pods -l app=demo-client
+
+deploy/example/traffic-routing/minikube: ## Minikube: Deploy example setup for TrafficRoute
+	kubectl apply -f tools/e2e/examples/minikube/kuma-routing/
+	kubectl wait --timeout=60s --for=condition=Available -n kuma-example deployment/kuma-example-web
+	kubectl wait --timeout=60s --for=condition=Ready -n kuma-example pods -l app=kuma-example-web
+	kubectl wait --timeout=60s --for=condition=Available -n kuma-example deployment/kuma-example-backend-v1
+	kubectl wait --timeout=60s --for=condition=Ready -n kuma-example pods -l app=kuma-example-backend,version=v1
+	kubectl wait --timeout=60s --for=condition=Available -n kuma-example deployment/kuma-example-backend-v2
+	kubectl wait --timeout=60s --for=condition=Ready -n kuma-example pods -l app=kuma-example-backend,version=v2
 
 apply/example/minikube/mtls: ## Minikube: enable mTLS
 	kubectl apply -f tools/e2e/examples/minikube/policies/mtls.yaml

--- a/dev/examples/k8s/traffic-routes/web-to-backend.yaml
+++ b/dev/examples/k8s/traffic-routes/web-to-backend.yaml
@@ -7,20 +7,18 @@ mesh: default
 spec:
   sources:
   - match:
-      service: web
-      region: us-east-1
-      version: v10
+      service: kuma-example-web.kuma-example.svc:6060
+      env: prod
   destinations:
   - match:
         # NOTE: only `service` tag can be used here (in `universal` all TCP connections will have `127.0.0.1` as destination => it's not enough info to infer any other destination tags)
-      service: backend
+      service: kuma-example-backend.kuma-example.svc:7070
   conf:
   - weight: 90
     destination:
-      service: backend
-      region: us-east-1
-      version: v2
+      service: kuma-example-backend.kuma-example.svc:7070
+      version: v1
   - weight: 10
     destination:
-      service: backend
-      version: v3
+      service: kuma-example-backend.kuma-example.svc:7070
+      version: v2

--- a/tools/e2e/examples/docker-compose/README.md
+++ b/tools/e2e/examples/docker-compose/README.md
@@ -51,6 +51,18 @@ where
 * `envoy_cluster_upstream_rq_total{envoy_cluster_name="localhost_8080"}` is a number of `inbound` requests
 * `envoy_cluster_upstream_rq_total{envoy_cluster_name="pass_through"}` is a number of `outbound` requests
 
+### Verify traffic routing without mTLS
+
+```bash
+make verify/traffic-routing/docker-compose/without-mtls -C ../../../..
+```
+
+### Verify traffic routing with mTLS
+
+```bash
+make verify/traffic-routing/docker-compose/with-mtls -C ../../../..
+```
+
 ### Cleanup
 
 ```bash

--- a/tools/e2e/examples/docker-compose/backend.yaml
+++ b/tools/e2e/examples/docker-compose/backend.yaml
@@ -1,0 +1,32 @@
+#
+# HTTP server that serves static responses
+#
+static_resources:
+  listeners:
+  - name: main
+    address:
+      socket_address:
+        address: 127.0.0.1
+        port_value: 7070
+    filter_chains:
+    - filters:
+      - name: envoy.http_connection_manager
+        config:
+          stat_prefix: ingress_http
+          codec_type: auto
+          route_config:
+            name: local_route
+            virtual_hosts:
+            - name: local_service
+              domains:
+              - "*"
+              routes:
+              - match:
+                  prefix: "/"
+                direct_response: 
+                  status: 200
+                  body:
+                    filename: /tmp/response.json
+          http_filters:
+          - name: envoy.router
+            config: {}

--- a/tools/e2e/examples/docker-compose/docker-compose.yaml
+++ b/tools/e2e/examples/docker-compose/docker-compose.yaml
@@ -71,6 +71,24 @@ services:
     restart: on-failure
 
   #
+  # Container with `kumactl` to edit Kuma resources as part of e2e workflow.
+  #
+  kumactl:
+    # image name must be provided via environment variable KUMACTL_DOCKER_IMAGE
+    image: ${KUMACTL_DOCKER_IMAGE:-kuma/kumactl:latest}
+    volumes:
+    - ./policies:/kuma-example/policies
+    command:
+    - sh
+    - -c
+    - kumactl config control-planes add --name universal --address http://kuma-control-plane:5681 --overwrite && sleep 31536000
+    networks:
+      kuma-example: {}
+    depends_on:
+      - kuma-control-plane
+    restart: on-failure
+
+  #
   # Auxiliary service (container) for sharing Linux network namespace
   # between Example Application and Kuma Sidecar.
   #
@@ -263,7 +281,7 @@ services:
     - --show-error
     - --include
     - --fail
-    - http://kuma-example-backend:7070/version
+    - http://localhost:5000/version
     # the following setting instructs Docker Compose to add `kuma-example-web` container
     # to the network namespace of `kuma-example-web-namespace` container
     network_mode: service:kuma-example-web-namespace

--- a/tools/e2e/examples/docker-compose/docker-compose.yaml
+++ b/tools/e2e/examples/docker-compose/docker-compose.yaml
@@ -55,8 +55,11 @@ services:
     image: ${KUMACTL_DOCKER_IMAGE:-kuma/kumactl:latest}
     volumes:
     - ./kuma-example-installer.sh:/kuma-example/kuma-example-installer.sh
-    - token-example-app:/token-example-app:rw
-    - token-example-client:/token-example-client:rw
+    - token-example-app:/kuma-example-app:rw
+    - token-example-client:/kuma-example-client:rw
+    - token-example-web:/kuma-example-web:rw
+    - token-example-backend-v1:/kuma-example-backend-v1:rw
+    - token-example-backend-v2:/kuma-example-backend-v2:rw
     - ./certs/client:/certs/client
     user: root # needed to write the tokens, named volumes are mounted with root permissions
     command:
@@ -214,9 +217,222 @@ services:
     volumes:
       - token-example-client:/token-example-client
 
+  #                            -> backend-v1  :  version: v1, env=prod
+  #                          /
+  # Example of routing web -
+  #                          \
+  #                            -> backend-v2  :  version: v2, env=intg
+
+  #
+  # Auxiliary service (container) for sharing Linux network namespace
+  # between Example Web and Kuma Sidecar.
+  #
+  kuma-example-web-namespace:
+    image: busybox:1.31.0
+    command: ["sleep", "infinity"]
+    expose:
+    - "6060"
+    # The following `ports` configuration was originally a part of `kuma-example-web` service.
+    # However, `ports` settings are incompatible with `network_mode: service:...`
+    # and had to be moved here.
+    ports:
+    - "6060:6060"
+    networks:
+      kuma-example:
+        aliases:
+        - kuma-example-web
+    depends_on:
+    - kuma-control-plane
+    restart: on-failure
+
+  #
+  # Example Web deployed into Kuma mesh.
+  #
+  kuma-example-web:
+    image: kong-docker-kuma-ci-docker.bintray.io/curl
+    command:
+    - nc
+    - -lk
+    - -s
+    - 127.0.0.1
+    - -p
+    - "6060"
+    - -e
+    - curl
+    - --silent
+    - --show-error
+    - --include
+    - --fail
+    - http://kuma-example-backend:7070/version
+    # the following setting instructs Docker Compose to add `kuma-example-web` container
+    # to the network namespace of `kuma-example-web-namespace` container
+    network_mode: service:kuma-example-web-namespace
+    depends_on:
+    - kuma-example-web-namespace
+    restart: on-failure
+
+  #
+  # Kuma sidecar for the Example Web.
+  #
+  kuma-example-web-sidecar:
+    # image name must be provided via environment variable KUMA_DP_DOCKER_IMAGE
+    image: ${KUMA_DP_DOCKER_IMAGE:-kuma/kuma-dp:latest}
+    command:
+    - run
+    - --log-level=info
+    volumes:
+    - token-example-web:/var/kuma.io/kuma-dp/kuma-example-web
+    environment:
+    - KUMA_CONTROL_PLANE_API_SERVER_URL=http://kuma-control-plane:5681
+    - KUMA_DATAPLANE_MESH=default
+    - KUMA_DATAPLANE_NAME=kuma-example-web
+    - KUMA_DATAPLANE_ADMIN_PORT=9901
+    - KUMA_DATAPLANE_RUNTIME_TOKEN_PATH=/var/kuma.io/kuma-dp/kuma-example-web/token
+    # the following setting instructs Docker Compose to add `kuma-example-web-sidecar` container
+    # to the network namespace of `kuma-example-web-namespace` container
+    network_mode: service:kuma-example-web
+    depends_on:
+    - kuma-example-web
+    restart: on-failure
+
+  #
+  # Auxiliary service (container) for sharing Linux network namespace
+  # between Example Backend v1 and Kuma Sidecar.
+  #
+  kuma-example-backend-v1-namespace:
+    image: busybox:1.31.0
+    command: ["sleep", "infinity"]
+    expose:
+    - "7070"
+    # The following `ports` configuration was originally a part of `kuma-example-backend-v1` service.
+    # However, `ports` settings are incompatible with `network_mode: service:...`
+    # and had to be moved here.
+    ports:
+    - "17070:7070"
+    networks:
+      kuma-example:
+        aliases:
+        - kuma-example-backend-v1
+    depends_on:
+    - kuma-control-plane
+    restart: on-failure
+
+  #
+  # Example Backend v1 deployed into Kuma mesh.
+  #
+  # Notice that we're using Envoy as a simple HTTP server with predefined responses.
+  #
+  kuma-example-backend-v1:
+    image: envoyproxy/envoy-alpine:v1.12.1
+    command:
+    - sh
+    - -c
+    - echo '{"version":"v1"}' >/tmp/response.json ; envoy -c /etc/envoy/backend.yaml
+    volumes:
+    - ./backend.yaml:/etc/envoy/backend.yaml
+    # the following setting instructs Docker Compose to add `kuma-example-backend-v1` container
+    # to the network namespace of `kuma-example-backend-v1-namespace` container
+    network_mode: service:kuma-example-backend-v1-namespace
+    depends_on:
+    - kuma-example-backend-v1-namespace
+    restart: on-failure
+
+  #
+  # Kuma sidecar for the Example Backend v1.
+  #
+  kuma-example-backend-v1-sidecar:
+    # image name must be provided via environment variable KUMA_DP_DOCKER_IMAGE
+    image: ${KUMA_DP_DOCKER_IMAGE:-kuma/kuma-dp:latest}
+    command:
+    - run
+    - --log-level=info
+    volumes:
+    - token-example-backend-v1:/var/kuma.io/kuma-dp/kuma-example-backend-v1
+    environment:
+    - KUMA_CONTROL_PLANE_API_SERVER_URL=http://kuma-control-plane:5681
+    - KUMA_DATAPLANE_MESH=default
+    - KUMA_DATAPLANE_NAME=kuma-example-backend-v1
+    - KUMA_DATAPLANE_ADMIN_PORT=9901
+    - KUMA_DATAPLANE_RUNTIME_TOKEN_PATH=/var/kuma.io/kuma-dp/kuma-example-backend-v1/token
+    # the following setting instructs Docker Compose to add `kuma-example-backend-v1-sidecar` container
+    # to the network namespace of `kuma-example-backend-v1-namespace` container
+    network_mode: service:kuma-example-backend-v1
+    depends_on:
+    - kuma-example-backend-v1
+    restart: on-failure
+
+  #
+  # Auxiliary service (container) for sharing Linux network namespace
+  # between Example Backend v2 and Kuma Sidecar.
+  #
+  kuma-example-backend-v2-namespace:
+    image: busybox:1.31.0
+    command: ["sleep", "infinity"]
+    expose:
+    - "7070"
+    # The following `ports` configuration was originally a part of `kuma-example-backend-v2` service.
+    # However, `ports` settings are incompatible with `network_mode: service:...`
+    # and had to be moved here.
+    ports:
+    - "27070:7070"
+    networks:
+      kuma-example:
+        aliases:
+        - kuma-example-backend-v2
+    depends_on:
+    - kuma-control-plane
+    restart: on-failure
+
+  #
+  # Example Backend v2 deployed into Kuma mesh.
+  #
+  # Notice that we're using Envoy as a simple HTTP server with predefined responses.
+  #
+  kuma-example-backend-v2:
+    image: envoyproxy/envoy-alpine:v1.12.1
+    command:
+    - sh
+    - -c
+    - echo '{"version":"v2"}' >/tmp/response.json ; envoy -c /etc/envoy/backend.yaml
+    volumes:
+    - ./backend.yaml:/etc/envoy/backend.yaml
+    # the following setting instructs Docker Compose to add `kuma-example-backend-v2` container
+    # to the network namespace of `kuma-example-backend-v2-namespace` container
+    network_mode: service:kuma-example-backend-v2-namespace
+    depends_on:
+    - kuma-example-backend-v2-namespace
+    restart: on-failure
+
+  #
+  # Kuma sidecar for the Example Backend v2.
+  #
+  kuma-example-backend-v2-sidecar:
+    # image name must be provided via environment variable KUMA_DP_DOCKER_IMAGE
+    image: ${KUMA_DP_DOCKER_IMAGE:-kuma/kuma-dp:latest}
+    command:
+    - run
+    - --log-level=info
+    volumes:
+    - token-example-backend-v2:/var/kuma.io/kuma-dp/kuma-example-backend-v2
+    environment:
+    - KUMA_CONTROL_PLANE_API_SERVER_URL=http://kuma-control-plane:5681
+    - KUMA_DATAPLANE_MESH=default
+    - KUMA_DATAPLANE_NAME=kuma-example-backend-v2
+    - KUMA_DATAPLANE_ADMIN_PORT=9901
+    - KUMA_DATAPLANE_RUNTIME_TOKEN_PATH=/var/kuma.io/kuma-dp/kuma-example-backend-v2/token
+    # the following setting instructs Docker Compose to add `kuma-example-backend-v2-sidecar` container
+    # to the network namespace of `kuma-example-backend-v2-namespace` container
+    network_mode: service:kuma-example-backend-v2
+    depends_on:
+    - kuma-example-backend-v2
+    restart: on-failure
+
 networks:
   kuma-example: {}
 
 volumes:
   token-example-app:
   token-example-client:
+  token-example-web:
+  token-example-backend-v1:
+  token-example-backend-v2:

--- a/tools/e2e/examples/docker-compose/kuma-example-installer.sh
+++ b/tools/e2e/examples/docker-compose/kuma-example-installer.sh
@@ -15,6 +15,39 @@ function fail {
   exit "${2-1}"                    ## Return a code specified by $2 or 1 by default.
 }
 
+function create_dataplane {
+  DATAPLANE_HOSTNAME="$1"
+  DATAPLANE_PUBLIC_PORT=$2
+  DATAPLANE_LOCAL_PORT=$3
+  DATAPLANE_RESOURCE="$4"
+  DATAPLANE_NAME="${DATAPLANE_HOSTNAME}"
+
+  #
+  # Resolve IP address allocated to the "${DATAPLANE_NAME}" container
+  #
+
+  DATAPLANE_IP_ADDRESS=$( resolve_ip ${DATAPLANE_HOSTNAME} )
+  if [ -z "${DATAPLANE_IP_ADDRESS}" ]; then
+    fail "failed to resolve IP address allocated to the '${DATAPLANE_HOSTNAME}' container"
+  fi
+  echo "'${DATAPLANE_HOSTNAME}' has the following IP address: ${DATAPLANE_IP_ADDRESS}"
+
+  #
+  # Create Dataplane for "${DATAPLANE_NAME}"
+  #
+
+  echo "${DATAPLANE_RESOURCE}" | kumactl apply -f - \
+    --var IP=${DATAPLANE_IP_ADDRESS} \
+    --var PUBLIC_PORT=${DATAPLANE_PUBLIC_PORT} \
+    --var LOCAL_PORT=${DATAPLANE_LOCAL_PORT}
+
+  #
+  # Create token for "${DATAPLANE_NAME}"
+  #
+
+  kumactl generate dataplane-token --dataplane=${DATAPLANE_NAME} > /${DATAPLANE_NAME}/token
+}
+
 #
 # Arguments
 #
@@ -29,25 +62,17 @@ KUMA_EXAMPLE_CLIENT_HOSTNAME=kuma-example-client
 KUMA_EXAMPLE_CLIENT_PUBLIC_PORT=3000
 KUMA_EXAMPLE_CLIENT_LOCAL_PORT=3000
 
-#
-# Resolve IP address allocated to the `kuma-example-app` container
-#
+KUMA_EXAMPLE_WEB_HOSTNAME=kuma-example-web
+KUMA_EXAMPLE_WEB_PUBLIC_PORT=6060
+KUMA_EXAMPLE_WEB_LOCAL_PORT=6060
 
-KUMA_EXAMPLE_APP_IP_ADDRESS=$( resolve_ip ${KUMA_EXAMPLE_APP_HOSTNAME} )
-if [ -z "${KUMA_EXAMPLE_APP_IP_ADDRESS}" ]; then
-  fail "failed to resolve IP address allocated to the '${KUMA_EXAMPLE_APP_HOSTNAME}' container"
-fi
-echo "'${KUMA_EXAMPLE_APP_HOSTNAME}' has the following IP address: ${KUMA_EXAMPLE_APP_IP_ADDRESS}"
+KUMA_EXAMPLE_BACKEND_V1_HOSTNAME=kuma-example-backend-v1
+KUMA_EXAMPLE_BACKEND_V1_PUBLIC_PORT=7070
+KUMA_EXAMPLE_BACKEND_V1_LOCAL_PORT=7070
 
-#
-# Resolve IP address allocated to the `kuma-example-app` container
-#
-
-KUMA_EXAMPLE_CLIENT_IP_ADDRESS=$( resolve_ip ${KUMA_EXAMPLE_CLIENT_HOSTNAME} )
-if [ -z "${KUMA_EXAMPLE_CLIENT_IP_ADDRESS}" ]; then
-  fail "failed to resolve IP address allocated to the '${KUMA_EXAMPLE_CLIENT_HOSTNAME}' container"
-fi
-echo "'${KUMA_EXAMPLE_CLIENT_HOSTNAME}' has the following IP address: ${KUMA_EXAMPLE_CLIENT_IP_ADDRESS}"
+KUMA_EXAMPLE_BACKEND_V2_HOSTNAME=kuma-example-backend-v2
+KUMA_EXAMPLE_BACKEND_V2_PUBLIC_PORT=7070
+KUMA_EXAMPLE_BACKEND_V2_LOCAL_PORT=7070
 
 #
 # Configure `kumactl`
@@ -59,29 +84,22 @@ kumactl config control-planes add --name universal --address ${KUMA_CONTROL_PLAN
 # Create Dataplane for `kuma-example-app` service
 #
 
-echo "type: Dataplane
+create_dataplane "${KUMA_EXAMPLE_APP_HOSTNAME}" ${KUMA_EXAMPLE_APP_PUBLIC_PORT} ${KUMA_EXAMPLE_APP_LOCAL_PORT} "
+type: Dataplane
 mesh: default
 name: kuma-example-app
 networking:
   inbound:
   - interface: {{ IP }}:{{ PUBLIC_PORT }}:{{ LOCAL_PORT }}
     tags:
-      service: kuma-example-app" | kumactl apply -f - \
-  --var IP=${KUMA_EXAMPLE_APP_IP_ADDRESS} \
-  --var PUBLIC_PORT=${KUMA_EXAMPLE_APP_PUBLIC_PORT} \
-  --var LOCAL_PORT=${KUMA_EXAMPLE_APP_LOCAL_PORT}
-
-#
-# Create token for `kuma-example-app`
-#
-
-kumactl generate dataplane-token --dataplane=kuma-example-app > /token-example-app/token
+      service: kuma-example-app"
 
 #
 # Create Dataplane for `kuma-example-client` service
 #
 
-echo "type: Dataplane
+create_dataplane "${KUMA_EXAMPLE_CLIENT_HOSTNAME}" ${KUMA_EXAMPLE_CLIENT_PUBLIC_PORT} ${KUMA_EXAMPLE_CLIENT_LOCAL_PORT} "
+type: Dataplane
 mesh: default
 name: kuma-example-client
 networking:
@@ -91,13 +109,55 @@ networking:
       service: kuma-example-client
   outbound:
   - interface: :4000
-    service: kuma-example-app" | kumactl apply -f - \
-  --var IP=${KUMA_EXAMPLE_CLIENT_IP_ADDRESS} \
-  --var PUBLIC_PORT=${KUMA_EXAMPLE_CLIENT_PUBLIC_PORT} \
-  --var LOCAL_PORT=${KUMA_EXAMPLE_CLIENT_LOCAL_PORT}
+    service: kuma-example-app"
 
 #
-# Create token for `kuma-example-client`
+# Create Dataplane for `kuma-example-web` service
 #
 
-kumactl generate dataplane-token --dataplane=kuma-example-client > /token-example-client/token
+create_dataplane "${KUMA_EXAMPLE_WEB_HOSTNAME}" ${KUMA_EXAMPLE_WEB_PUBLIC_PORT} ${KUMA_EXAMPLE_WEB_LOCAL_PORT} "
+type: Dataplane
+mesh: default
+name: kuma-example-web
+networking:
+  inbound:
+  - interface: {{ IP }}:{{ PUBLIC_PORT }}:{{ LOCAL_PORT }}
+    tags:
+      service: kuma-example-web
+      version: v8
+      env: prod
+  outbound:
+  - interface: :5000
+    service: kuma-example-backend"
+
+#
+# Create Dataplane v1 for `kuma-example-backend` service
+#
+
+create_dataplane "${KUMA_EXAMPLE_BACKEND_V1_HOSTNAME}" ${KUMA_EXAMPLE_BACKEND_V1_PUBLIC_PORT} ${KUMA_EXAMPLE_BACKEND_V1_LOCAL_PORT} "
+type: Dataplane
+mesh: default
+name: kuma-example-backend-v1
+networking:
+  inbound:
+  - interface: {{ IP }}:{{ PUBLIC_PORT }}:{{ LOCAL_PORT }}
+    tags:
+      service: kuma-example-backend
+      version: v1
+      env: prod"
+
+#
+# Create Dataplane v2 for `kuma-example-backend` service
+#
+
+create_dataplane "${KUMA_EXAMPLE_BACKEND_V2_HOSTNAME}" ${KUMA_EXAMPLE_BACKEND_V2_PUBLIC_PORT} ${KUMA_EXAMPLE_BACKEND_V2_LOCAL_PORT} "
+type: Dataplane
+mesh: default
+name: kuma-example-backend-v2
+networking:
+  inbound:
+  - interface: {{ IP }}:{{ PUBLIC_PORT }}:{{ LOCAL_PORT }}
+    tags:
+      service: kuma-example-backend
+      version: v2
+      env: intg"

--- a/tools/e2e/examples/docker-compose/policies/everyone-to-everyone.traffic-permission.yaml
+++ b/tools/e2e/examples/docker-compose/policies/everyone-to-everyone.traffic-permission.yaml
@@ -1,0 +1,9 @@
+type: TrafficPermission
+name: everyone-to-everyone
+mesh: default
+sources:
+- match:
+    service: '*'
+destinations:
+- match:
+    service: '*'

--- a/tools/e2e/examples/docker-compose/policies/mtls.yaml
+++ b/tools/e2e/examples/docker-compose/policies/mtls.yaml
@@ -1,0 +1,6 @@
+type: Mesh
+name: default
+mtls:
+  ca:
+    builtin: {}
+  enabled: true

--- a/tools/e2e/examples/docker-compose/policies/no-mtls.yaml
+++ b/tools/e2e/examples/docker-compose/policies/no-mtls.yaml
@@ -1,0 +1,7 @@
+type: Mesh
+mesh: default
+name: default
+mtls:
+  ca:
+    builtin: {}
+  enabled: false

--- a/tools/e2e/examples/docker-compose/policies/web-to-backend.traffic-route.yaml
+++ b/tools/e2e/examples/docker-compose/policies/web-to-backend.traffic-route.yaml
@@ -1,0 +1,20 @@
+type: TrafficRoute
+name: web-to-backend
+mesh: default
+sources:
+- match:
+    service: kuma-example-web
+    env: prod
+destinations:
+- match:
+      # NOTE: only `service` tag can be used here (in `universal` all TCP connections will have `127.0.0.1` as destination => it's not enough info to infer any other destination tags)
+    service: kuma-example-backend
+conf:
+- weight: 0
+  destination:
+    service: kuma-example-backend
+    version: v1
+- weight: 100
+  destination:
+    service: kuma-example-backend
+    version: v2

--- a/tools/e2e/examples/minikube/README.md
+++ b/tools/e2e/examples/minikube/README.md
@@ -20,7 +20,7 @@ minikube start
 make build/example/minikube -C ../../../..
 ```
 
-### Deploy demo setup into Minikube
+### Deploy example setup into Minikube
 
 ```bash
 make deploy/example/minikube -C ../../../..
@@ -86,4 +86,34 @@ make verify/example/minikube/mtls -C ../../../..
 
 ```bash
 make kumactl/example/minikube -C ../../../..
+```
+
+### Undeploy example setup
+
+```bash
+make undeploy/example/minikube -C ../../../..
+```
+
+### Deploy example setup for traffic routing
+
+```bash
+make deploy/traffic-routing/minikube -C ../../../..
+```
+
+### Verify traffic routing without mTLS
+
+```bash
+make verify/traffic-routing/minikube/without-mtls
+```
+
+### Verify traffic routing with mTLS
+
+```bash
+make verify/traffic-routing/minikube/with-mtls
+```
+
+### Undeploy example setup for traffic routing
+
+```bash
+make undeploy/traffic-routing/minikube -C ../../../..
 ```

--- a/tools/e2e/examples/minikube/kuma-routing/kuma-routing.yaml
+++ b/tools/e2e/examples/minikube/kuma-routing/kuma-routing.yaml
@@ -1,0 +1,232 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: kuma-example
+  labels:
+    kuma.io/sidecar-injection: enabled
+
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: kuma-example-web
+  namespace: kuma-example
+spec:
+  ports:
+  - port: 6060
+    name: http
+  selector:
+    app: kuma-example-web
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: kuma-example-web
+  namespace: kuma-example
+  labels:
+    app: kuma-example-web
+    version: v8
+    env: prod
+spec:
+  strategy:
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 0
+  selector:
+    matchLabels:
+      app: kuma-example-web
+      version: v8
+      env: prod
+  template:
+    metadata:
+      labels:
+        app: kuma-example-web
+        version: v8
+        env: prod
+    spec:
+      containers:
+      - name: kuma-example-web
+        image: kong-docker-kuma-ci-docker.bintray.io/curl
+        imagePullPolicy: IfNotPresent
+        command:
+        - nc
+        - -lk
+        - -s
+        - 0.0.0.0
+        - -p
+        - "6060"
+        - -e
+        - curl
+        - --silent
+        - --show-error
+        - --include
+        - --fail
+        - http://kuma-example-backend:7070/version
+        ports:
+        - containerPort: 6060
+        livenessProbe:
+          exec:
+            command:
+            - wget
+            - -qO-
+            - http://localhost:6060
+        readinessProbe:
+          exec:
+            command:
+            - wget
+            - -qO-
+            - http://localhost:6060
+        resources:
+          requests:
+            cpu: 50m
+            memory: 64Mi
+
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: kuma-example-backend
+  namespace: kuma-example
+spec:
+  ports:
+  - port: 7070
+    name: http
+  selector:
+    app: kuma-example-backend
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: kuma-example-backend-config
+  namespace: kuma-example
+data:
+  backend.yaml: |
+    #
+    # HTTP server that serves static responses
+    #
+    static_resources:
+      listeners:
+      - name: main
+        address:
+          socket_address:
+            address: 0.0.0.0
+            port_value: 7070
+        filter_chains:
+        - filters:
+          - name: envoy.http_connection_manager
+            config:
+              stat_prefix: ingress_http
+              codec_type: auto
+              route_config:
+                name: local_route
+                virtual_hosts:
+                - name: local_service
+                  domains:
+                  - "*"
+                  routes:
+                  - match:
+                      prefix: "/"
+                    direct_response:
+                      status: 200
+                      body:
+                        filename: /tmp/response.json
+              http_filters:
+              - name: envoy.router
+                config: {}
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: kuma-example-backend-v1
+  namespace: kuma-example
+  labels:
+    app: kuma-example-backend
+    version: v1
+    env: prod
+spec:
+  strategy:
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 0
+  selector:
+    matchLabels:
+      app: kuma-example-backend
+      version: v1
+      env: prod
+  template:
+    metadata:
+      labels:
+        app: kuma-example-backend
+        version: v1
+        env: prod
+    spec:
+      containers:
+      - name: kuma-example-backend
+        image: envoyproxy/envoy-alpine:v1.12.1
+        imagePullPolicy: IfNotPresent
+        ports:
+        - containerPort: 7070
+        command:
+        - sh
+        - -c
+        - echo '{"version":"v1"}' >/tmp/response.json ; envoy -c /etc/envoy/backend.yaml
+        resources:
+          requests:
+            cpu: 10m
+            memory: 16Mi
+        volumeMounts:
+        - name: kuma-example-backend-config
+          mountPath: /etc/envoy
+      volumes:
+      - name: kuma-example-backend-config
+        configMap:
+          name: kuma-example-backend-config
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: kuma-example-backend-v2
+  namespace: kuma-example
+  labels:
+    app: kuma-example-backend
+    version: v2
+    env: intg
+spec:
+  strategy:
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 0
+  selector:
+    matchLabels:
+      app: kuma-example-backend
+      version: v2
+      env: prod
+  template:
+    metadata:
+      labels:
+        app: kuma-example-backend
+        version: v2
+        env: prod
+    spec:
+      containers:
+      - name: kuma-example-backend
+        image: envoyproxy/envoy-alpine:v1.12.1
+        imagePullPolicy: IfNotPresent
+        ports:
+        - containerPort: 7070
+        command:
+        - sh
+        - -c
+        - echo '{"version":"v2"}' >/tmp/response.json ; envoy -c /etc/envoy/backend.yaml
+        resources:
+          requests:
+            cpu: 10m
+            memory: 16Mi
+        volumeMounts:
+        - name: kuma-example-backend-config
+          mountPath: /etc/envoy
+      volumes:
+      - name: kuma-example-backend-config
+        configMap:
+          name: kuma-example-backend-config

--- a/tools/e2e/examples/minikube/policies/mtls.yaml
+++ b/tools/e2e/examples/minikube/policies/mtls.yaml
@@ -3,7 +3,6 @@ apiVersion: kuma.io/v1alpha1
 kind: Mesh
 metadata:
   name: default
-  namespace: kuma-system
 spec:
   mtls:
     ca:
@@ -13,7 +12,7 @@ spec:
 apiVersion: kuma.io/v1alpha1
 kind: TrafficPermission
 metadata:
-  namespace: kuma-demo
+  namespace: kuma-system
   name: everyone-to-everyone
 mesh: default
 spec:

--- a/tools/e2e/examples/minikube/policies/no-mtls.yaml
+++ b/tools/e2e/examples/minikube/policies/no-mtls.yaml
@@ -1,0 +1,8 @@
+---
+apiVersion: kuma.io/v1alpha1
+kind: Mesh
+metadata:
+  name: default
+spec:
+  mtls:
+    enabled: false

--- a/tools/e2e/examples/minikube/policies/web-to-backend.traffic-route.yaml
+++ b/tools/e2e/examples/minikube/policies/web-to-backend.traffic-route.yaml
@@ -1,0 +1,24 @@
+apiVersion: kuma.io/v1alpha1
+kind: TrafficRoute
+metadata:
+  namespace: kuma-example
+  name: web-to-backend
+mesh: default
+spec:
+  sources:
+  - match:
+      service: kuma-example-web.kuma-example.svc:6060
+      env: prod
+  destinations:
+  - match:
+        # NOTE: only `service` tag can be used here (in `universal` all TCP connections will have `127.0.0.1` as destination => it's not enough info to infer any other destination tags)
+      service: kuma-example-backend.kuma-example.svc:7070
+  conf:
+  - weight: 0
+    destination:
+      service: kuma-example-backend.kuma-example.svc:7070
+      version: v1
+  - weight: 100
+    destination:
+      service: kuma-example-backend.kuma-example.svc:7070
+      version: v2


### PR DESCRIPTION
### Summary

* add `e2e` tests for `TrafficRoute`
  * both `universal` and `k8s` modes
  * both with mTLS and without mTLS  