### PR TITLE
kuma-cp: pick a single the most specific HealthCheck for every service reachable from a given a Dataplane (via outbound interfaces and TrafficRoutes)

### DIFF
--- a/pkg/core/policy/matcher.go
+++ b/pkg/core/policy/matcher.go
@@ -30,6 +30,26 @@ func ToOutboundServicesOf(dataplane *mesh_core.DataplaneResource) ServiceIterato
 	})
 }
 
+func ToServicesOf(destinations core_xds.DestinationMap) ServiceIteratorFunc {
+	services := make([]core_xds.ServiceName, 0, len(destinations))
+	for service := range destinations {
+		services = append(services, service)
+	}
+	return ToServices(services)
+}
+
+func ToServices(services []core_xds.ServiceName) ServiceIteratorFunc {
+	idx := 0
+	return ServiceIteratorFunc(func() (core_xds.ServiceName, bool) {
+		if len(services) <= idx {
+			return "", false
+		}
+		service := services[idx]
+		idx++
+		return service, true
+	})
+}
+
 // SelectOutboundConnectionPolicies picks a single the most specific policy for each outbound interface of a given Dataplane.
 func SelectOutboundConnectionPolicies(dataplane *mesh_core.DataplaneResource, policies []ConnectionPolicy) ConnectionPolicyMap {
 	return SelectConnectionPolicies(dataplane, ToOutboundServicesOf(dataplane), policies)

--- a/pkg/core/resources/apis/mesh/health_check.go
+++ b/pkg/core/resources/apis/mesh/health_check.go
@@ -40,6 +40,12 @@ func (r *HealthCheckResource) SetSpec(value model.ResourceSpec) error {
 		return nil
 	}
 }
+func (t *HealthCheckResource) Sources() []*mesh_proto.Selector {
+	return t.Spec.GetSources()
+}
+func (t *HealthCheckResource) Destinations() []*mesh_proto.Selector {
+	return t.Spec.GetDestinations()
+}
 
 var _ model.ResourceList = &HealthCheckResourceList{}
 

--- a/pkg/core/xds/types.go
+++ b/pkg/core/xds/types.go
@@ -51,6 +51,9 @@ type EndpointMap map[ServiceName][]Endpoint
 // LogMap holds the most specific TrafficLog for each outbound interface of a Dataplane.
 type LogMap map[ServiceName]*mesh_proto.LoggingBackend
 
+// HealthCheckMap holds the most specific HealthCheck for each reachable service.
+type HealthCheckMap map[ServiceName]*mesh_core.HealthCheckResource
+
 type Proxy struct {
 	Id                 ProxyId
 	Dataplane          *mesh_core.DataplaneResource
@@ -59,6 +62,7 @@ type Proxy struct {
 	TrafficRoutes      RouteMap
 	OutboundSelectors  DestinationMap
 	OutboundTargets    EndpointMap
+	HealthChecks       HealthCheckMap
 	Metadata           *DataplaneMetadata
 }
 

--- a/pkg/xds/server/components.go
+++ b/pkg/xds/server/components.go
@@ -126,6 +126,11 @@ func DefaultDataplaneSyncTracker(rt core_runtime.Runtime, reconciler SnapshotRec
 					return err
 				}
 
+				healthChecks, err := xds_topology.GetHealthChecks(ctx, dataplane, destinations, rt.ResourceManager())
+				if err != nil {
+					return err
+				}
+
 				matchedPermissions, err := permissionsMatcher.Match(ctx, dataplane)
 				if err != nil {
 					return err
@@ -143,6 +148,7 @@ func DefaultDataplaneSyncTracker(rt core_runtime.Runtime, reconciler SnapshotRec
 					TrafficRoutes:      routes,
 					OutboundSelectors:  destinations,
 					OutboundTargets:    outbound,
+					HealthChecks:       healthChecks,
 					Logs:               matchedLogs,
 					Metadata:           metadataTracker.Metadata(streamId),
 				}

--- a/pkg/xds/topology/healthchecks.go
+++ b/pkg/xds/topology/healthchecks.go
@@ -1,0 +1,42 @@
+package topology
+
+import (
+	"context"
+
+	"github.com/Kong/kuma/pkg/core/policy"
+	mesh_core "github.com/Kong/kuma/pkg/core/resources/apis/mesh"
+	core_manager "github.com/Kong/kuma/pkg/core/resources/manager"
+	core_store "github.com/Kong/kuma/pkg/core/resources/store"
+	core_xds "github.com/Kong/kuma/pkg/core/xds"
+)
+
+// GetHealthChecks resolves all HealthChecks applicable to a given Dataplane.
+func GetHealthChecks(ctx context.Context, dataplane *mesh_core.DataplaneResource, destinations core_xds.DestinationMap, manager core_manager.ResourceManager) (core_xds.HealthCheckMap, error) {
+	if len(destinations) == 0 {
+		return nil, nil
+	}
+	healthChecks := &mesh_core.HealthCheckResourceList{}
+	if err := manager.List(ctx, healthChecks, core_store.ListByMesh(dataplane.Meta.GetMesh())); err != nil {
+		return nil, err
+	}
+	return BuildHealthCheckMap(dataplane, destinations, healthChecks.Items), nil
+}
+
+// BuildHealthCheckMap creates a map with health-checking configuration per reachable service.
+func BuildHealthCheckMap(dataplane *mesh_core.DataplaneResource, destinations core_xds.DestinationMap, healthChecks []*mesh_core.HealthCheckResource) core_xds.HealthCheckMap {
+	if len(destinations) == 0 || len(healthChecks) == 0 {
+		return nil
+	}
+	policies := make([]policy.ConnectionPolicy, len(healthChecks))
+	for i, healthCheck := range healthChecks {
+		policies[i] = healthCheck
+	}
+
+	policyMap := policy.SelectConnectionPolicies(dataplane, policy.ToServicesOf(destinations), policies)
+
+	healthCheckMap := core_xds.HealthCheckMap{}
+	for service, policy := range policyMap {
+		healthCheckMap[service] = policy.(*mesh_core.HealthCheckResource)
+	}
+	return healthCheckMap
+}

--- a/pkg/xds/topology/healthchecks_test.go
+++ b/pkg/xds/topology/healthchecks_test.go
@@ -1,0 +1,628 @@
+package topology_test
+
+import (
+	"context"
+	"time"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/ginkgo/extensions/table"
+	. "github.com/onsi/gomega"
+
+	. "github.com/Kong/kuma/pkg/xds/topology"
+
+	mesh_proto "github.com/Kong/kuma/api/mesh/v1alpha1"
+	mesh_core "github.com/Kong/kuma/pkg/core/resources/apis/mesh"
+	core_manager "github.com/Kong/kuma/pkg/core/resources/manager"
+	core_model "github.com/Kong/kuma/pkg/core/resources/model"
+	core_store "github.com/Kong/kuma/pkg/core/resources/store"
+	core_xds "github.com/Kong/kuma/pkg/core/xds"
+	memory_resources "github.com/Kong/kuma/pkg/plugins/resources/memory"
+	test_model "github.com/Kong/kuma/pkg/test/resources/model"
+
+	"github.com/golang/protobuf/ptypes"
+)
+
+var _ = Describe("HealthCheck", func() {
+
+	var ctx context.Context
+	var rm core_manager.ResourceManager
+
+	BeforeEach(func() {
+		ctx = context.Background()
+		rm = core_manager.NewResourceManager(memory_resources.NewStore())
+	})
+
+	Describe("GetHealthChecks()", func() {
+
+		It("should pick the best matching HealthCheck for each destination service", func() {
+			// given
+			mesh := &mesh_core.MeshResource{ // mesh that is relevant to this test case
+				Meta: &test_model.ResourceMeta{
+					Mesh: "demo",
+					Name: "demo",
+				},
+			}
+			otherMesh := &mesh_core.MeshResource{ // mesh that is irrelevant to this test case
+				Meta: &test_model.ResourceMeta{
+					Mesh: "default",
+					Name: "default",
+				},
+			}
+			backend := &mesh_core.DataplaneResource{ // dataplane that is a source of traffic
+				Meta: &test_model.ResourceMeta{
+					Mesh: "demo",
+					Name: "backend",
+				},
+				Spec: mesh_proto.Dataplane{
+					Networking: &mesh_proto.Dataplane_Networking{
+						Inbound: []*mesh_proto.Dataplane_Networking_Inbound{
+							{Tags: map[string]string{"service": "backend", "region": "eu"}, Interface: "192.168.0.1:8080:18080"},
+							{Tags: map[string]string{"service": "frontend", "region": "eu"}, Interface: "192.168.0.1:7070:17070"},
+						},
+						Outbound: []*mesh_proto.Dataplane_Networking_Outbound{
+							{Service: "redis", Interface: ":10001"},
+							{Service: "elastic", Interface: ":10002"},
+						},
+					},
+				},
+			}
+			destinations := core_xds.DestinationMap{
+				"redis":   core_xds.TagSelectorSet{mesh_proto.MatchService("redis")},
+				"elastic": core_xds.TagSelectorSet{mesh_proto.MatchService("elastic")},
+			}
+			healthCheckRedis := &mesh_core.HealthCheckResource{ // health checks for `redis` service
+				Meta: &test_model.ResourceMeta{
+					Mesh: "demo",
+					Name: "healthcheck-redis",
+				},
+				Spec: mesh_proto.HealthCheck{
+					Sources: []*mesh_proto.Selector{
+						{Match: mesh_proto.TagSelector{"service": "frontend"}},
+						{Match: mesh_proto.TagSelector{"service": "backend"}},
+					},
+					Destinations: []*mesh_proto.Selector{
+						{Match: mesh_proto.TagSelector{"service": "redis"}},
+					},
+					Conf: &mesh_proto.HealthCheck_Conf{
+						ActiveChecks: &mesh_proto.HealthCheck_Conf_Active{
+							Interval:           ptypes.DurationProto(5 * time.Second),
+							Timeout:            ptypes.DurationProto(4 * time.Second),
+							UnhealthyThreshold: 3,
+							HealthyThreshold:   2,
+						},
+					},
+				},
+			}
+			healthCheckElastic := &mesh_core.HealthCheckResource{ // health checks for `elastic` service
+				Meta: &test_model.ResourceMeta{
+					Mesh: "demo",
+					Name: "healthcheck-elastic",
+				},
+				Spec: mesh_proto.HealthCheck{
+					Sources: []*mesh_proto.Selector{
+						{Match: mesh_proto.TagSelector{"service": "*"}},
+					},
+					Destinations: []*mesh_proto.Selector{
+						{Match: mesh_proto.TagSelector{"service": "elastic"}},
+					},
+					Conf: &mesh_proto.HealthCheck_Conf{
+						PassiveChecks: &mesh_proto.HealthCheck_Conf_Passive{
+							UnhealthyThreshold: 1,
+							PenaltyInterval:    ptypes.DurationProto(6 * time.Second),
+						},
+					},
+				},
+			}
+			healthCheckEverything := &mesh_core.HealthCheckResource{ // health checks for any service
+				Meta: &test_model.ResourceMeta{
+					Mesh: "default", // other mesh
+					Name: "healthcheck-everything",
+				},
+				Spec: mesh_proto.HealthCheck{
+					Sources: []*mesh_proto.Selector{
+						{Match: mesh_proto.TagSelector{"service": "*"}},
+					},
+					Destinations: []*mesh_proto.Selector{
+						{Match: mesh_proto.TagSelector{"service": "*"}},
+					},
+					Conf: &mesh_proto.HealthCheck_Conf{
+						PassiveChecks: &mesh_proto.HealthCheck_Conf_Passive{
+							UnhealthyThreshold: 20,
+							PenaltyInterval:    ptypes.DurationProto(30 * time.Second),
+						},
+					},
+				},
+			}
+			for _, resource := range []core_model.Resource{mesh, backend, healthCheckRedis, healthCheckElastic, otherMesh, healthCheckEverything} {
+				// when
+				err := rm.Create(ctx, resource, core_store.CreateBy(core_model.MetaToResourceKey(resource.GetMeta())))
+				// then
+				Expect(err).ToNot(HaveOccurred())
+			}
+
+			// when
+			healthChecks, err := GetHealthChecks(ctx, backend, destinations, rm)
+
+			// then
+			Expect(err).ToNot(HaveOccurred())
+			// and
+			Expect(healthChecks).To(HaveLen(2))
+			// and
+			Expect(healthChecks).To(HaveKey("redis"))
+			Expect(healthChecks["redis"].Meta.GetName()).To(Equal(healthCheckRedis.Meta.GetName()))
+			Expect(healthChecks["redis"].Spec).To(Equal(healthCheckRedis.Spec))
+			// and
+			Expect(healthChecks).To(HaveKey("elastic"))
+			Expect(healthChecks["elastic"].Meta.GetName()).To(Equal(healthCheckElastic.Meta.GetName()))
+			Expect(healthChecks["elastic"].Spec).To(Equal(healthCheckElastic.Spec))
+		})
+	})
+
+	Describe("BuildHealthCheckMap()", func() {
+		sameMeta := func(meta1, meta2 core_model.ResourceMeta) bool {
+			return meta1.GetMesh() == meta2.GetMesh() &&
+				meta1.GetName() == meta2.GetName() &&
+				meta1.GetVersion() == meta2.GetVersion()
+		}
+		type testCase struct {
+			dataplane    *mesh_core.DataplaneResource
+			destinations core_xds.DestinationMap
+			healthChecks []*mesh_core.HealthCheckResource
+			expected     core_xds.HealthCheckMap
+		}
+		DescribeTable("should correctly pick a single the most specific HealthCheck for each outbound interface",
+			func(given testCase) {
+				// setup
+				expectedHealthChecks := core_xds.HealthCheckMap{}
+				for service, expectedHealthCheck := range given.expected {
+					for _, healthCheck := range given.healthChecks {
+						if sameMeta(expectedHealthCheck.GetMeta(), healthCheck.GetMeta()) {
+							expectedHealthChecks[service] = healthCheck
+							break
+						}
+					}
+					if _, ok := expectedHealthChecks[service]; !ok {
+						expectedHealthChecks[service] = expectedHealthCheck
+					}
+				}
+				if len(expectedHealthChecks) == 0 {
+					expectedHealthChecks = nil
+				}
+				// when
+				healthChecks := BuildHealthCheckMap(given.dataplane, given.destinations, given.healthChecks)
+				// expect
+				Expect(healthChecks).Should(Equal(expectedHealthChecks))
+			},
+			Entry("Dataplane without outbound interfaces (and therefore no destinations)", testCase{
+				dataplane:    &mesh_core.DataplaneResource{},
+				destinations: nil,
+				healthChecks: nil,
+				expected:     nil,
+			}),
+			Entry("if a destination service has no matching HealthChecks, none should be used", testCase{
+				dataplane: &mesh_core.DataplaneResource{
+					Spec: mesh_proto.Dataplane{
+						Networking: &mesh_proto.Dataplane_Networking{
+							Inbound: []*mesh_proto.Dataplane_Networking_Inbound{
+								{Tags: map[string]string{"service": "backend"}},
+							},
+							Outbound: []*mesh_proto.Dataplane_Networking_Outbound{
+								{Service: "redis"},
+								{Service: "elastic"},
+							},
+						},
+					},
+				},
+				destinations: core_xds.DestinationMap{
+					"redis":   core_xds.TagSelectorSet{mesh_proto.MatchService("redis")},
+					"elastic": core_xds.TagSelectorSet{mesh_proto.MatchService("elastic")},
+				},
+				healthChecks: nil,
+				expected:     nil,
+			}),
+			Entry("due to TrafficRoutes, a Dataplane might have more destinations than outbound interfaces", testCase{
+				dataplane: &mesh_core.DataplaneResource{
+					Spec: mesh_proto.Dataplane{
+						Networking: &mesh_proto.Dataplane_Networking{
+							Inbound: []*mesh_proto.Dataplane_Networking_Inbound{
+								{Tags: map[string]string{"service": "backend"}},
+							},
+							Outbound: []*mesh_proto.Dataplane_Networking_Outbound{
+								{Service: "redis"},
+							},
+						},
+					},
+				},
+				destinations: core_xds.DestinationMap{
+					"redis":   core_xds.TagSelectorSet{mesh_proto.MatchService("redis")},
+					"elastic": core_xds.TagSelectorSet{mesh_proto.MatchService("elastic")},
+				},
+				healthChecks: []*mesh_core.HealthCheckResource{
+					{
+						Meta: &test_model.ResourceMeta{
+							Name: "healthcheck-elastic",
+						},
+						Spec: mesh_proto.HealthCheck{
+							Sources: []*mesh_proto.Selector{
+								{Match: mesh_proto.TagSelector{"service": "*"}},
+							},
+							Destinations: []*mesh_proto.Selector{
+								{Match: mesh_proto.TagSelector{"service": "elastic"}},
+							},
+							Conf: &mesh_proto.HealthCheck_Conf{
+								ActiveChecks: &mesh_proto.HealthCheck_Conf_Active{
+									Interval:           ptypes.DurationProto(5 * time.Second),
+									Timeout:            ptypes.DurationProto(4 * time.Second),
+									UnhealthyThreshold: 3,
+									HealthyThreshold:   2,
+								},
+							},
+						},
+					},
+					{
+						Meta: &test_model.ResourceMeta{
+							Name: "healthcheck-redis",
+						},
+						Spec: mesh_proto.HealthCheck{
+							Sources: []*mesh_proto.Selector{
+								{Match: mesh_proto.TagSelector{"service": "*"}},
+							},
+							Destinations: []*mesh_proto.Selector{
+								{Match: mesh_proto.TagSelector{"service": "redis"}},
+							},
+							Conf: &mesh_proto.HealthCheck_Conf{
+								PassiveChecks: &mesh_proto.HealthCheck_Conf_Passive{
+									UnhealthyThreshold: 20,
+									PenaltyInterval:    ptypes.DurationProto(30 * time.Second),
+								},
+							},
+						},
+					},
+				},
+				expected: core_xds.HealthCheckMap{
+					"redis": &mesh_core.HealthCheckResource{
+						Meta: &test_model.ResourceMeta{
+							Name: "healthcheck-redis",
+						},
+					},
+					"elastic": &mesh_core.HealthCheckResource{
+						Meta: &test_model.ResourceMeta{
+							Name: "healthcheck-elastic",
+						},
+					},
+				},
+			}),
+			Entry("HealthChecks should be ordered by name to consistently pick between two equally specific HealthCehcks", testCase{
+				dataplane: &mesh_core.DataplaneResource{
+					Spec: mesh_proto.Dataplane{
+						Networking: &mesh_proto.Dataplane_Networking{
+							Inbound: []*mesh_proto.Dataplane_Networking_Inbound{
+								{Tags: map[string]string{"service": "backend"}},
+							},
+							Outbound: []*mesh_proto.Dataplane_Networking_Outbound{
+								{Service: "redis"},
+							},
+						},
+					},
+				},
+				destinations: core_xds.DestinationMap{
+					"redis": core_xds.TagSelectorSet{mesh_proto.MatchService("redis")},
+				},
+				healthChecks: []*mesh_core.HealthCheckResource{
+					{
+						Meta: &test_model.ResourceMeta{
+							Name: "healthcheck-everything-passive",
+						},
+						Spec: mesh_proto.HealthCheck{
+							Sources: []*mesh_proto.Selector{
+								{Match: mesh_proto.TagSelector{"service": "*"}},
+							},
+							Destinations: []*mesh_proto.Selector{
+								{Match: mesh_proto.TagSelector{"service": "*"}},
+							},
+							Conf: &mesh_proto.HealthCheck_Conf{
+								ActiveChecks: &mesh_proto.HealthCheck_Conf_Active{
+									Interval:           ptypes.DurationProto(5 * time.Second),
+									Timeout:            ptypes.DurationProto(4 * time.Second),
+									UnhealthyThreshold: 3,
+									HealthyThreshold:   2,
+								},
+							},
+						},
+					},
+					{
+						Meta: &test_model.ResourceMeta{
+							Name: "healthcheck-everything-active",
+						},
+						Spec: mesh_proto.HealthCheck{
+							Sources: []*mesh_proto.Selector{
+								{Match: mesh_proto.TagSelector{"service": "*"}},
+							},
+							Destinations: []*mesh_proto.Selector{
+								{Match: mesh_proto.TagSelector{"service": "*"}},
+							},
+							Conf: &mesh_proto.HealthCheck_Conf{
+								PassiveChecks: &mesh_proto.HealthCheck_Conf_Passive{
+									UnhealthyThreshold: 20,
+									PenaltyInterval:    ptypes.DurationProto(30 * time.Second),
+								},
+							},
+						},
+					},
+				},
+				expected: core_xds.HealthCheckMap{
+					"redis": &mesh_core.HealthCheckResource{
+						Meta: &test_model.ResourceMeta{
+							Name: "healthcheck-everything-active",
+						},
+					},
+				},
+			}),
+			Entry("HealthCheck with a `source` selector by 2 tags should win over a HealthCheck with a `source` selector by 1 tag", testCase{
+				dataplane: &mesh_core.DataplaneResource{
+					Spec: mesh_proto.Dataplane{
+						Networking: &mesh_proto.Dataplane_Networking{
+							Inbound: []*mesh_proto.Dataplane_Networking_Inbound{
+								{Tags: map[string]string{"service": "backend", "region": "eu"}},
+							},
+							Outbound: []*mesh_proto.Dataplane_Networking_Outbound{
+								{Service: "redis"},
+							},
+						},
+					},
+				},
+				destinations: core_xds.DestinationMap{
+					"redis": core_xds.TagSelectorSet{mesh_proto.MatchService("redis")},
+				},
+				healthChecks: []*mesh_core.HealthCheckResource{
+					{
+						Meta: &test_model.ResourceMeta{
+							Name: "less-specific",
+						},
+						Spec: mesh_proto.HealthCheck{
+							Sources: []*mesh_proto.Selector{
+								{Match: mesh_proto.TagSelector{"service": "backend"}},
+							},
+							Destinations: []*mesh_proto.Selector{
+								{Match: mesh_proto.TagSelector{"service": "*"}},
+							},
+							Conf: &mesh_proto.HealthCheck_Conf{
+								ActiveChecks: &mesh_proto.HealthCheck_Conf_Active{
+									Interval:           ptypes.DurationProto(5 * time.Second),
+									Timeout:            ptypes.DurationProto(4 * time.Second),
+									UnhealthyThreshold: 3,
+									HealthyThreshold:   2,
+								},
+							},
+						},
+					},
+					{
+						Meta: &test_model.ResourceMeta{
+							Name: "more-specific",
+						},
+						Spec: mesh_proto.HealthCheck{
+							Sources: []*mesh_proto.Selector{
+								{Match: mesh_proto.TagSelector{"service": "backend", "region": "eu"}},
+							},
+							Destinations: []*mesh_proto.Selector{
+								{Match: mesh_proto.TagSelector{"service": "*"}},
+							},
+							Conf: &mesh_proto.HealthCheck_Conf{
+								PassiveChecks: &mesh_proto.HealthCheck_Conf_Passive{
+									UnhealthyThreshold: 20,
+									PenaltyInterval:    ptypes.DurationProto(30 * time.Second),
+								},
+							},
+						},
+					},
+				},
+				expected: core_xds.HealthCheckMap{
+					"redis": &mesh_core.HealthCheckResource{
+						Meta: &test_model.ResourceMeta{
+							Name: "more-specific",
+						},
+					},
+				},
+			}),
+			Entry("HealthCheck with a `source` selector by an exact value should win over a HealthCheck with a `source` selector by a wildcard value", testCase{
+				dataplane: &mesh_core.DataplaneResource{
+					Spec: mesh_proto.Dataplane{
+						Networking: &mesh_proto.Dataplane_Networking{
+							Inbound: []*mesh_proto.Dataplane_Networking_Inbound{
+								{Tags: map[string]string{"service": "backend", "region": "eu"}},
+							},
+							Outbound: []*mesh_proto.Dataplane_Networking_Outbound{
+								{Service: "redis"},
+							},
+						},
+					},
+				},
+				destinations: core_xds.DestinationMap{
+					"redis": core_xds.TagSelectorSet{mesh_proto.MatchService("redis")},
+				},
+				healthChecks: []*mesh_core.HealthCheckResource{
+					{
+						Meta: &test_model.ResourceMeta{
+							Name: "less-specific",
+						},
+						Spec: mesh_proto.HealthCheck{
+							Sources: []*mesh_proto.Selector{
+								{Match: mesh_proto.TagSelector{"service": "*"}},
+							},
+							Destinations: []*mesh_proto.Selector{
+								{Match: mesh_proto.TagSelector{"service": "*"}},
+							},
+							Conf: &mesh_proto.HealthCheck_Conf{
+								ActiveChecks: &mesh_proto.HealthCheck_Conf_Active{
+									Interval:           ptypes.DurationProto(5 * time.Second),
+									Timeout:            ptypes.DurationProto(4 * time.Second),
+									UnhealthyThreshold: 3,
+									HealthyThreshold:   2,
+								},
+							},
+						},
+					},
+					{
+						Meta: &test_model.ResourceMeta{
+							Name: "more-specific",
+						},
+						Spec: mesh_proto.HealthCheck{
+							Sources: []*mesh_proto.Selector{
+								{Match: mesh_proto.TagSelector{"service": "backend"}},
+							},
+							Destinations: []*mesh_proto.Selector{
+								{Match: mesh_proto.TagSelector{"service": "*"}},
+							},
+							Conf: &mesh_proto.HealthCheck_Conf{
+								PassiveChecks: &mesh_proto.HealthCheck_Conf_Passive{
+									UnhealthyThreshold: 20,
+									PenaltyInterval:    ptypes.DurationProto(30 * time.Second),
+								},
+							},
+						},
+					},
+				},
+				expected: core_xds.HealthCheckMap{
+					"redis": &mesh_core.HealthCheckResource{
+						Meta: &test_model.ResourceMeta{
+							Name: "more-specific",
+						},
+					},
+				},
+			}),
+			Entry("HealthCheck with a `destination` selector by an exact value should win over a HealthCheck with a `destination` selector by a wildcard value", testCase{
+				dataplane: &mesh_core.DataplaneResource{
+					Spec: mesh_proto.Dataplane{
+						Networking: &mesh_proto.Dataplane_Networking{
+							Inbound: []*mesh_proto.Dataplane_Networking_Inbound{
+								{Tags: map[string]string{"service": "backend", "region": "eu"}},
+							},
+							Outbound: []*mesh_proto.Dataplane_Networking_Outbound{
+								{Service: "redis"},
+							},
+						},
+					},
+				},
+				destinations: core_xds.DestinationMap{
+					"redis": core_xds.TagSelectorSet{mesh_proto.MatchService("redis")},
+				},
+				healthChecks: []*mesh_core.HealthCheckResource{
+					{
+						Meta: &test_model.ResourceMeta{
+							Name: "less-specific",
+						},
+						Spec: mesh_proto.HealthCheck{
+							Sources: []*mesh_proto.Selector{
+								{Match: mesh_proto.TagSelector{"service": "*"}},
+							},
+							Destinations: []*mesh_proto.Selector{
+								{Match: mesh_proto.TagSelector{"service": "*"}},
+							},
+							Conf: &mesh_proto.HealthCheck_Conf{
+								ActiveChecks: &mesh_proto.HealthCheck_Conf_Active{
+									Interval:           ptypes.DurationProto(5 * time.Second),
+									Timeout:            ptypes.DurationProto(4 * time.Second),
+									UnhealthyThreshold: 3,
+									HealthyThreshold:   2,
+								},
+							},
+						},
+					},
+					{
+						Meta: &test_model.ResourceMeta{
+							Name: "more-specific",
+						},
+						Spec: mesh_proto.HealthCheck{
+							Sources: []*mesh_proto.Selector{
+								{Match: mesh_proto.TagSelector{"service": "*"}},
+							},
+							Destinations: []*mesh_proto.Selector{
+								{Match: mesh_proto.TagSelector{"service": "redis"}},
+							},
+							Conf: &mesh_proto.HealthCheck_Conf{
+								PassiveChecks: &mesh_proto.HealthCheck_Conf_Passive{
+									UnhealthyThreshold: 20,
+									PenaltyInterval:    ptypes.DurationProto(30 * time.Second),
+								},
+							},
+						},
+					},
+				},
+				expected: core_xds.HealthCheckMap{
+					"redis": &mesh_core.HealthCheckResource{
+						Meta: &test_model.ResourceMeta{
+							Name: "more-specific",
+						},
+					},
+				},
+			}),
+			Entry("in case if HealthChecks have equal aggregate ranks, most specific one should be selected based on ordering by name", testCase{
+				dataplane: &mesh_core.DataplaneResource{
+					Spec: mesh_proto.Dataplane{
+						Networking: &mesh_proto.Dataplane_Networking{
+							Inbound: []*mesh_proto.Dataplane_Networking_Inbound{
+								{Tags: map[string]string{"service": "backend", "region": "eu"}},
+							},
+							Outbound: []*mesh_proto.Dataplane_Networking_Outbound{
+								{Service: "redis"},
+							},
+						},
+					},
+				},
+				destinations: core_xds.DestinationMap{
+					"redis": core_xds.TagSelectorSet{mesh_proto.MatchService("redis")},
+				},
+				healthChecks: []*mesh_core.HealthCheckResource{
+					{
+						Meta: &test_model.ResourceMeta{
+							Name: "equally-specific-2",
+						},
+						Spec: mesh_proto.HealthCheck{
+							Sources: []*mesh_proto.Selector{
+								{Match: mesh_proto.TagSelector{"service": "*"}},
+							},
+							Destinations: []*mesh_proto.Selector{
+								{Match: mesh_proto.TagSelector{"service": "redis"}},
+							},
+							Conf: &mesh_proto.HealthCheck_Conf{
+								ActiveChecks: &mesh_proto.HealthCheck_Conf_Active{
+									Interval:           ptypes.DurationProto(5 * time.Second),
+									Timeout:            ptypes.DurationProto(4 * time.Second),
+									UnhealthyThreshold: 3,
+									HealthyThreshold:   2,
+								},
+							},
+						},
+					},
+					{
+						Meta: &test_model.ResourceMeta{
+							Name: "equally-specific-1",
+						},
+						Spec: mesh_proto.HealthCheck{
+							Sources: []*mesh_proto.Selector{
+								{Match: mesh_proto.TagSelector{"service": "backend"}},
+							},
+							Destinations: []*mesh_proto.Selector{
+								{Match: mesh_proto.TagSelector{"service": "*"}},
+							},
+							Conf: &mesh_proto.HealthCheck_Conf{
+								PassiveChecks: &mesh_proto.HealthCheck_Conf_Passive{
+									UnhealthyThreshold: 20,
+									PenaltyInterval:    ptypes.DurationProto(30 * time.Second),
+								},
+							},
+						},
+					},
+				},
+				expected: core_xds.HealthCheckMap{
+					"redis": &mesh_core.HealthCheckResource{
+						Meta: &test_model.ResourceMeta{
+							Name: "equally-specific-1",
+						},
+					},
+				},
+			}),
+		)
+	})
+
+})


### PR DESCRIPTION
### Summary

* pick a single the most specific `HealthCheck` for every service reachable from a given a `Dataplane` (via outbound interfaces and `TrafficRoutes`)
