### PR TITLE
feat(kuma-cp) Reuse matching logic for traffic logs

### DIFF
--- a/pkg/core/logs/matcher.go
+++ b/pkg/core/logs/matcher.go
@@ -25,9 +25,9 @@ type TrafficLogsMatcher struct {
 	ResourceManager manager.ResourceManager
 }
 
-type MatchedLog map[string]*mesh_proto.LoggingBackend
+type LogMap map[string]*mesh_proto.LoggingBackend
 
-func (m *TrafficLogsMatcher) Match(ctx context.Context, dataplane *mesh_core.DataplaneResource) (MatchedLog, error) {
+func (m *TrafficLogsMatcher) Match(ctx context.Context, dataplane *mesh_core.DataplaneResource) (LogMap, error) {
 	logs := &mesh_core.TrafficLogResourceList{}
 	if err := m.ResourceManager.List(ctx, logs, store.ListByMesh(dataplane.GetMeta().GetMesh())); err != nil {
 		return nil, errors.Wrap(err, "could not retrieve traffic logs")
@@ -38,12 +38,12 @@ func (m *TrafficLogsMatcher) Match(ctx context.Context, dataplane *mesh_core.Dat
 	}
 
 	policies := make([]policy.ConnectionPolicy, len(logs.Items))
-	for i, route := range logs.Items {
-		policies[i] = route
+	for i, log := range logs.Items {
+		policies[i] = log
 	}
 	matchMap := policy.SelectOutboundConnectionPolicies(dataplane, policies)
 
-	matchedLog := MatchedLog{}
+	matchedLog := LogMap{}
 	for service, policy := range matchMap {
 		log := policy.(*mesh_core.TrafficLogResource)
 		backend, found := backends[log.Spec.GetConf().GetBackend()]

--- a/pkg/core/logs/matcher.go
+++ b/pkg/core/logs/matcher.go
@@ -4,11 +4,11 @@ import (
 	"context"
 	mesh_proto "github.com/Kong/kuma/api/mesh/v1alpha1"
 	"github.com/Kong/kuma/pkg/core"
+	"github.com/Kong/kuma/pkg/core/policy"
 	mesh_core "github.com/Kong/kuma/pkg/core/resources/apis/mesh"
 	"github.com/Kong/kuma/pkg/core/resources/manager"
 	"github.com/Kong/kuma/pkg/core/resources/store"
 	"github.com/pkg/errors"
-	"sort"
 )
 
 var logger = core.Log.WithName("logs")
@@ -25,28 +25,9 @@ type TrafficLogsMatcher struct {
 	ResourceManager manager.ResourceManager
 }
 
-type MatchedLogs struct {
-	Outbounds map[string][]*mesh_proto.LoggingBackend
-}
+type MatchedLog map[string]*mesh_proto.LoggingBackend
 
-func NewMatchedLogs() *MatchedLogs {
-	return &MatchedLogs{
-		Outbounds: map[string][]*mesh_proto.LoggingBackend{},
-	}
-}
-
-func (m *MatchedLogs) AddForOutbound(outbound string, backend *mesh_proto.LoggingBackend) {
-	if _, ok := m.Outbounds[outbound]; !ok {
-		m.Outbounds[outbound] = []*mesh_proto.LoggingBackend{}
-	}
-	m.Outbounds[outbound] = append(m.Outbounds[outbound], backend)
-	// sort the slice for stability of envoy configuration
-	sort.Slice(m.Outbounds[outbound], func(i, j int) bool {
-		return m.Outbounds[outbound][i].Name > m.Outbounds[outbound][j].Name
-	})
-}
-
-func (m *TrafficLogsMatcher) Match(ctx context.Context, dataplane *mesh_core.DataplaneResource) (*MatchedLogs, error) {
+func (m *TrafficLogsMatcher) Match(ctx context.Context, dataplane *mesh_core.DataplaneResource) (MatchedLog, error) {
 	logs := &mesh_core.TrafficLogResourceList{}
 	if err := m.ResourceManager.List(ctx, logs, store.ListByMesh(dataplane.GetMeta().GetMesh())); err != nil {
 		return nil, errors.Wrap(err, "could not retrieve traffic logs")
@@ -55,16 +36,22 @@ func (m *TrafficLogsMatcher) Match(ctx context.Context, dataplane *mesh_core.Dat
 	if err != nil {
 		return nil, err
 	}
-	matchedLog := NewMatchedLogs()
-	for outbound, backendsNames := range matchBackends(&dataplane.Spec, logs) {
-		for backendName := range backendsNames {
-			backend, found := backends[backendName]
-			if !found {
-				logger.Info("Logging backend is not found. Ignoring.", "name", backendName)
-				continue
-			}
-			matchedLog.AddForOutbound(outbound, backend)
+
+	policies := make([]policy.ConnectionPolicy, len(logs.Items))
+	for i, route := range logs.Items {
+		policies[i] = route
+	}
+	matchMap := policy.SelectOutboundConnectionPolicies(dataplane, policies)
+
+	matchedLog := MatchedLog{}
+	for service, policy := range matchMap {
+		log := policy.(*mesh_core.TrafficLogResource)
+		backend, found := backends[log.Spec.GetConf().GetBackend()]
+		if !found {
+			logger.Info("Logging backend is not found. Ignoring.", "name", log.Spec.GetConf().GetBackend(), "trafficLog", log.GetMeta())
+			continue
 		}
+		matchedLog[service] = backend
 	}
 	return matchedLog, nil
 }
@@ -83,45 +70,4 @@ func (m *TrafficLogsMatcher) backendsByName(ctx context.Context, dataplane *mesh
 		backendsByName[""] = backendsByName[defaultBackend]
 	}
 	return backendsByName, nil
-}
-
-func matchBackends(dataplane *mesh_proto.Dataplane, logs *mesh_core.TrafficLogResourceList) map[string]map[string]bool {
-	outboundToBackend := map[string]map[string]bool{}
-	for _, outbound := range dataplane.GetNetworking().GetOutbound() {
-		for _, logRes := range matchOutbound(outbound, dataplane.Networking.Inbound, logs.Items) {
-			if _, ok := outboundToBackend[outbound.Interface]; !ok {
-				outboundToBackend[outbound.Interface] = map[string]bool{}
-			}
-			outboundToBackend[outbound.Interface][logRes.Spec.Conf.GetBackend()] = true
-		}
-	}
-	return outboundToBackend
-}
-
-// To Match outbound, we need to match service tag of outbound and all tags of any inbound interface
-func matchOutbound(outbound *mesh_proto.Dataplane_Networking_Outbound, inbounds []*mesh_proto.Dataplane_Networking_Inbound, logs []*mesh_core.TrafficLogResource) []*mesh_core.TrafficLogResource {
-	matchedLogs := []*mesh_core.TrafficLogResource{}
-	for _, log := range logs {
-		if !anySelectorMatchAnyInbound(log.Spec.Sources, inbounds) {
-			continue
-		}
-		for _, dest := range log.Spec.Destinations {
-			if outbound.MatchTags(dest.Match) {
-				matchedLogs = append(matchedLogs, log)
-				break
-			}
-		}
-	}
-	return matchedLogs
-}
-
-func anySelectorMatchAnyInbound(selectors []*mesh_proto.Selector, inbounds []*mesh_proto.Dataplane_Networking_Inbound) bool {
-	for _, inbound := range inbounds {
-		for _, selector := range selectors {
-			if inbound.MatchTags(selector.Match) {
-				return true
-			}
-		}
-	}
-	return false
 }

--- a/pkg/core/logs/matcher_test.go
+++ b/pkg/core/logs/matcher_test.go
@@ -109,31 +109,6 @@ var _ = Describe("Matcher", func() {
 		Expect(err).ToNot(HaveOccurred())
 
 		// and
-		logRes2 := core_mesh.TrafficLogResource{
-			Spec: mesh_proto.TrafficLog{
-				Sources: []*mesh_proto.Selector{
-					{
-						Match: map[string]string{
-							"service": "kong-admin",
-						},
-					},
-				},
-				Destinations: []*mesh_proto.Selector{
-					{
-						Match: map[string]string{
-							"service": "web",
-						},
-					},
-				},
-				Conf: &mesh_proto.TrafficLog_Conf{
-					Backend: "file3",
-				},
-			},
-		}
-		err = manager.Create(context.Background(), &logRes2, store.CreateByKey("lr-2", "sample"))
-		Expect(err).ToNot(HaveOccurred())
-
-		// and
 		logRes3 := core_mesh.TrafficLogResource{
 			Spec: mesh_proto.TrafficLog{
 				Sources: []*mesh_proto.Selector{
@@ -160,17 +135,10 @@ var _ = Describe("Matcher", func() {
 
 		// then
 		Expect(err).ToNot(HaveOccurred())
-		Expect(log.Outbounds[":9091"]).To(HaveLen(2))
-		// should match because *->* rule with file-1 logging backend as default
-		Expect(log.Outbounds[":9091"]).To(ContainElement(backendFile1))
 		// should match because kong->backend rule
-		Expect(log.Outbounds[":9091"]).To(ContainElement(backendFile2))
-
-		Expect(log.Outbounds[":9092"]).To(HaveLen(2))
-		// should match because *->* rule with file-1 logging backend as default
-		Expect(log.Outbounds[":9092"]).To(ContainElement(backendFile1))
-		// should match because kong-admin->web rule
-		Expect(log.Outbounds[":9092"]).To(ContainElement(backendFile3))
+		Expect(log["backend"]).To(Equal(backendFile2))
+		// should match because *->* rule and default backend file1
+		Expect(log["web"]).To(Equal(backendFile1))
 	})
 
 	It("should not match services", func() {
@@ -204,7 +172,7 @@ var _ = Describe("Matcher", func() {
 
 		// then
 		Expect(err).ToNot(HaveOccurred())
-		Expect(log.Outbounds).To(HaveLen(0))
+		Expect(log).To(HaveLen(0))
 	})
 
 	It("should skip unknown backends", func() {
@@ -238,6 +206,6 @@ var _ = Describe("Matcher", func() {
 
 		// then
 		Expect(err).ToNot(HaveOccurred())
-		Expect(log.Outbounds).To(HaveLen(0))
+		Expect(log).To(HaveLen(0))
 	})
 })

--- a/pkg/core/policy/types.go
+++ b/pkg/core/policy/types.go
@@ -5,6 +5,7 @@ import (
 	"github.com/Kong/kuma/pkg/core/resources/model"
 )
 
+// ConnectionPolicy is a Policy that is applied on a connection between two data planes that match source and destination.
 type ConnectionPolicy interface {
 	model.Resource
 	Sources() []*v1alpha1.Selector

--- a/pkg/core/resources/apis/mesh/traffic_log.go
+++ b/pkg/core/resources/apis/mesh/traffic_log.go
@@ -72,3 +72,11 @@ func init() {
 	registry.RegisterType(&TrafficLogResource{})
 	registry.RegistryListType(&TrafficLogResourceList{})
 }
+
+func (t *TrafficLogResource) Sources() []*mesh_proto.Selector {
+	return t.Spec.GetSources()
+}
+
+func (t *TrafficLogResource) Destinations() []*mesh_proto.Selector {
+	return t.Spec.GetDestinations()
+}

--- a/pkg/core/xds/types.go
+++ b/pkg/core/xds/types.go
@@ -53,7 +53,7 @@ type Proxy struct {
 	Id                 ProxyId
 	Dataplane          *mesh_core.DataplaneResource
 	TrafficPermissions permissions.MatchedPermissions
-	Logs               logs.MatchedLog
+	Logs               logs.LogMap
 	TrafficRoutes      RouteMap
 	OutboundSelectors  DestinationMap
 	OutboundTargets    EndpointMap

--- a/pkg/core/xds/types.go
+++ b/pkg/core/xds/types.go
@@ -53,7 +53,7 @@ type Proxy struct {
 	Id                 ProxyId
 	Dataplane          *mesh_core.DataplaneResource
 	TrafficPermissions permissions.MatchedPermissions
-	Logs               *logs.MatchedLogs
+	Logs               logs.MatchedLog
 	TrafficRoutes      RouteMap
 	OutboundSelectors  DestinationMap
 	OutboundTargets    EndpointMap

--- a/pkg/xds/envoy/access_logs.go
+++ b/pkg/xds/envoy/access_logs.go
@@ -18,19 +18,10 @@ const AccessLogDefaultFormat = "[%START_TIME%] %KUMA_SOURCE_ADDRESS%(%KUMA_SOURC
 
 const AccessLogSink = "access_log_sink"
 
-func convertLoggingBackends(sourceService string, destinationService string, backends []*v1alpha1.LoggingBackend, proxy *core_xds.Proxy) ([]*filter_accesslog.AccessLog, error) {
-	var result []*filter_accesslog.AccessLog
-	for _, backend := range backends {
-		log, err := convertLoggingBackend(sourceService, destinationService, backend, proxy)
-		if err != nil {
-			return nil, err
-		}
-		result = append(result, log)
-	}
-	return result, nil
-}
-
 func convertLoggingBackend(sourceService string, destinationService string, backend *v1alpha1.LoggingBackend, proxy *core_xds.Proxy) (*filter_accesslog.AccessLog, error) {
+	if backend == nil {
+		return nil, nil
+	}
 	format := AccessLogDefaultFormat
 	if backend.Format != "" {
 		format = backend.Format

--- a/pkg/xds/generator/outbound_proxy_generator_test.go
+++ b/pkg/xds/generator/outbound_proxy_generator_test.go
@@ -4,8 +4,6 @@ import (
 	"io/ioutil"
 	"path/filepath"
 
-	"github.com/Kong/kuma/pkg/core/logs"
-
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/ginkgo/extensions/table"
 	. "github.com/onsi/gomega"
@@ -105,7 +103,6 @@ var _ = Describe("OutboundProxyGenerator", func() {
 						{Target: "192.168.0.3", Port: 5432, Tags: map[string]string{"service": "db", "role": "master"}},
 					},
 				},
-				Logs:     logs.NewMatchedLogs(),
 				Metadata: &model.DataplaneMetadata{},
 			}
 
@@ -280,7 +277,6 @@ var _ = Describe("OutboundProxyGenerator", func() {
 							{Target: "192.168.0.3", Port: 5432, Tags: map[string]string{"service": "db", "role": "master"}},
 						},
 					},
-					Logs:     logs.NewMatchedLogs(),
 					Metadata: &model.DataplaneMetadata{},
 				}
 

--- a/pkg/xds/generator/proxy_template.go
+++ b/pkg/xds/generator/proxy_template.go
@@ -150,7 +150,7 @@ func (g OutboundProxyGenerator) Generate(ctx xds_context.Context, proxy *model.P
 		// generate LDS resource
 		outboundListenerName := fmt.Sprintf("outbound:%s:%d", endpoint.DataplaneIP, endpoint.DataplanePort)
 		destinationService := oface.Service
-		listener, err := envoy.CreateOutboundListener(ctx, outboundListenerName, endpoint.DataplaneIP, endpoint.DataplanePort, oface.Service, clusters, virtual, sourceService, destinationService, proxy.Logs.Outbounds[oface.Interface], proxy)
+		listener, err := envoy.CreateOutboundListener(ctx, outboundListenerName, endpoint.DataplaneIP, endpoint.DataplanePort, oface.Service, clusters, virtual, sourceService, destinationService, proxy.Logs[oface.Service], proxy)
 		if err != nil {
 			return nil, errors.Wrapf(err, "%s: could not generate listener %s", validators.RootedAt("dataplane").Field("networking").Field("outbound").Index(i), outboundListenerName)
 		}

--- a/pkg/xds/generator/proxy_template_profile_source_test.go
+++ b/pkg/xds/generator/proxy_template_profile_source_test.go
@@ -9,7 +9,6 @@ import (
 	. "github.com/onsi/gomega"
 
 	mesh_proto "github.com/Kong/kuma/api/mesh/v1alpha1"
-	"github.com/Kong/kuma/pkg/core/logs"
 	"github.com/Kong/kuma/pkg/core/permissions"
 	mesh_core "github.com/Kong/kuma/pkg/core/resources/apis/mesh"
 	model "github.com/Kong/kuma/pkg/core/xds"
@@ -70,7 +69,6 @@ var _ = Describe("ProxyTemplateProfileSource", func() {
 						{Target: "192.168.0.3", Port: 5432, Tags: map[string]string{"service": "db", "role": "master"}},
 					},
 				},
-				Logs:               logs.NewMatchedLogs(),
 				TrafficPermissions: permissions.MatchedPermissions{},
 				Metadata:           &model.DataplaneMetadata{},
 			}

--- a/pkg/xds/server/snapshot_generator_test.go
+++ b/pkg/xds/server/snapshot_generator_test.go
@@ -1,7 +1,6 @@
 package server
 
 import (
-	"github.com/Kong/kuma/pkg/core/logs"
 	"github.com/Kong/kuma/pkg/core/permissions"
 	"io/ioutil"
 	"path/filepath"
@@ -87,7 +86,6 @@ var _ = Describe("Reconcile", func() {
 						},
 					},
 				},
-				Logs:     logs.NewMatchedLogs(),
 				Metadata: &model.DataplaneMetadata{},
 			}
 


### PR DESCRIPTION
### Summary

Current implementation of Traffic Logs matcher workedn in a way that every Traffic Log that matched was applied. We want to have consistent behaviour in every policy therefore now only the most matched Traffic Log is applied, just like Traffic Route.

### Breaking change

This is a breaking change since we alter the behaviour of applying Traffic Log policies.