### PR TITLE
feat(kuma-dp) update envoy to v1.12.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # CHANGELOG
 
+## [Unreleased]
+
+Changes:
+
+* chore: update Envoy to v1.12.2
+  [#493](https://github.com/Kong/kuma/pull/493)
+
 ## [0.3.1]
 
 > Released on 2019/12/13

--- a/tools/e2e/examples/docker-compose/docker-compose.yaml
+++ b/tools/e2e/examples/docker-compose/docker-compose.yaml
@@ -341,7 +341,7 @@ services:
   # Notice that we're using Envoy as a simple HTTP server with predefined responses.
   #
   kuma-example-backend-v1:
-    image: envoyproxy/envoy-alpine:v1.12.1
+    image: envoyproxy/envoy-alpine:v1.12.2
     command:
     - sh
     - -c
@@ -407,7 +407,7 @@ services:
   # Notice that we're using Envoy as a simple HTTP server with predefined responses.
   #
   kuma-example-backend-v2:
-    image: envoyproxy/envoy-alpine:v1.12.1
+    image: envoyproxy/envoy-alpine:v1.12.2
     command:
     - sh
     - -c

--- a/tools/e2e/examples/minikube/kuma-routing/kuma-routing.yaml
+++ b/tools/e2e/examples/minikube/kuma-routing/kuma-routing.yaml
@@ -163,7 +163,7 @@ spec:
     spec:
       containers:
       - name: kuma-example-backend
-        image: envoyproxy/envoy-alpine:v1.12.1
+        image: envoyproxy/envoy-alpine:v1.12.2
         imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 7070
@@ -211,7 +211,7 @@ spec:
     spec:
       containers:
       - name: kuma-example-backend
-        image: envoyproxy/envoy-alpine:v1.12.1
+        image: envoyproxy/envoy-alpine:v1.12.2
         imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 7070

--- a/tools/releases/distros.sh
+++ b/tools/releases/distros.sh
@@ -12,7 +12,7 @@ DISTRIBUTIONS=(debian:linux ubuntu:linux rhel:linux centos:linux darwin:darwin)
 BINTRAY_ENDPOINT="https://api.bintray.com/"
 BINTRAY_SUBJECT="kong"
 [ -z "$BINTRAY_REPOSITORY" ] && BINTRAY_REPOSITORY="kuma"
-ENVOY_VERSION=1.12.1
+ENVOY_VERSION=1.12.2
 
 function msg_green {
   builtin echo -en "\033[1;32m"

--- a/tools/releases/dockerfiles/Dockerfile.kuma-dp
+++ b/tools/releases/dockerfiles/Dockerfile.kuma-dp
@@ -1,5 +1,5 @@
 # using Envoy's base to inherit the Envoy binary
-FROM envoyproxy/envoy-alpine:v1.12.1
+FROM envoyproxy/envoy-alpine:v1.12.2
 
 ADD $KUMA_ROOT/build/artifacts-linux-amd64/kuma-dp/kuma-dp /usr/bin
 


### PR DESCRIPTION
### Summary

Update Envoy to v1.12.2
All new binaries are in the bintray.