### PR TITLE
kuma-cp: automatically set default values for Prometheus settings in the Mesh resource

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 Changes:
 
+* feature: automatically set default values for Prometheus settings in the Mesh resource
+  [#501](https://github.com/Kong/kuma/pull/501)
 * feature: add proto definitions for metrics that should be collected and exposed by dataplanes
   [#500](https://github.com/Kong/kuma/pull/500)
 * feature: display CA type in kumactl get meshes

--- a/dev/examples/k8s/meshes/prometheus.defaults.yaml
+++ b/dev/examples/k8s/meshes/prometheus.defaults.yaml
@@ -1,0 +1,7 @@
+apiVersion: kuma.io/v1alpha1
+kind: Mesh
+metadata:
+  name: default
+spec:
+  metrics:
+    prometheus: {}

--- a/dev/examples/k8s/meshes/prometheus.manual.yaml
+++ b/dev/examples/k8s/meshes/prometheus.manual.yaml
@@ -1,0 +1,9 @@
+apiVersion: kuma.io/v1alpha1
+kind: Mesh
+metadata:
+  name: default
+spec:
+  metrics:
+    prometheus:
+      port: 1234
+      path: /non-standard-path

--- a/dev/examples/universal/meshes/prometheus.defaults.yaml
+++ b/dev/examples/universal/meshes/prometheus.defaults.yaml
@@ -1,0 +1,4 @@
+type: Mesh
+name: default
+metrics:
+  prometheus: {}

--- a/dev/examples/universal/meshes/prometheus.manual.yaml
+++ b/dev/examples/universal/meshes/prometheus.manual.yaml
@@ -1,0 +1,6 @@
+type: Mesh
+name: default
+metrics:
+  prometheus:
+    port: 1234
+    path: /non-standard-path

--- a/pkg/core/resources/apis/mesh/mesh_defaulter.go
+++ b/pkg/core/resources/apis/mesh/mesh_defaulter.go
@@ -17,4 +17,15 @@ func (mesh *MeshResource) Default() {
 			Builtin: &mesh_proto.CertificateAuthority_Builtin{},
 		}
 	}
+	// default settings for Prometheus metrics
+	if mesh.Spec.Metrics != nil {
+		if mesh.Spec.Metrics.Prometheus != nil {
+			if mesh.Spec.Metrics.Prometheus.Port == 0 {
+				mesh.Spec.Metrics.Prometheus.Port = 5670
+			}
+			if mesh.Spec.Metrics.Prometheus.Path == "" {
+				mesh.Spec.Metrics.Prometheus.Path = "/metrics"
+			}
+		}
+	}
 }

--- a/pkg/core/resources/apis/mesh/mesh_defaulter_test.go
+++ b/pkg/core/resources/apis/mesh/mesh_defaulter_test.go
@@ -19,23 +19,25 @@ var _ = Describe("MeshResource", func() {
 			expected string
 		}
 
+		applyDefaultsScenario := func(given testCase) {
+			// given
+			mesh := &MeshResource{}
+
+			err := util_proto.FromYAML([]byte(given.input), &mesh.Spec)
+			Expect(err).ToNot(HaveOccurred())
+
+			// do
+			mesh.Default()
+
+			// when
+			actual, err := util_proto.ToYAML(&mesh.Spec)
+			// then
+			Expect(err).ToNot(HaveOccurred())
+			Expect(actual).To(MatchYAML(given.expected))
+		}
+
 		DescribeTable("should apply defaults on a target MeshResource",
-			func(given testCase) {
-				// given
-				mesh := &MeshResource{}
-
-				err := util_proto.FromYAML([]byte(given.input), &mesh.Spec)
-				Expect(err).ToNot(HaveOccurred())
-
-				// do
-				mesh.Default()
-
-				// when
-				actual, err := util_proto.ToYAML(&mesh.Spec)
-				// then
-				Expect(err).ToNot(HaveOccurred())
-				Expect(actual).To(MatchYAML(given.expected))
-			},
+			applyDefaultsScenario,
 			Entry("when `mtls` field is not set", testCase{
 				input: ``,
 				expected: `
@@ -63,6 +65,105 @@ var _ = Describe("MeshResource", func() {
                 mtls:
                   ca:
                     builtin: {}
+`,
+			}),
+			Entry("when both `metrics.prometheus.port` and `metrics.prometheus.path` are not set", testCase{
+				input: `
+                metrics:
+                  prometheus: {}
+`,
+				expected: `
+                mtls:
+                  ca:
+                    builtin: {}
+                metrics:
+                  prometheus:
+                    port: 5670
+                    path: /metrics
+`,
+			}),
+			Entry("when `metrics.prometheus.port` is not set", testCase{
+				input: `
+                metrics:
+                  prometheus:
+                    path: /non-standard-path
+`,
+				expected: `
+                mtls:
+                  ca:
+                    builtin: {}
+                metrics:
+                  prometheus:
+                    port: 5670
+                    path: /non-standard-path
+`,
+			}),
+			Entry("when `metrics.prometheus.path` is not set", testCase{
+				input: `
+                metrics:
+                  prometheus:
+                    port: 1234
+`,
+				expected: `
+                mtls:
+                  ca:
+                    builtin: {}
+                metrics:
+                  prometheus:
+                    port: 1234
+                    path: /metrics
+`,
+			}),
+		)
+
+		DescribeTable("should not override user-defined configuration in a target MeshResource",
+			applyDefaultsScenario,
+			Entry("when `mtls` field is set to `provided` CA", testCase{
+				input: `
+                mtls:
+                  ca:
+                    provided: {}
+`,
+				expected: `
+                mtls:
+                  ca:
+                    provided: {}
+`,
+			}),
+			Entry("when `metrics` field is not set", testCase{
+				input: ``,
+				expected: `
+                mtls:
+                  ca:
+                    builtin: {}
+`,
+			}),
+			Entry("when `metrics.prometheus` field is not set", testCase{
+				input: `
+                metrics: {}
+`,
+				expected: `
+                mtls:
+                  ca:
+                    builtin: {}
+                metrics: {}
+`,
+			}),
+			Entry("when `mtls.ca.type` field is not set", testCase{
+				input: `
+                metrics:
+                  prometheus:
+                    port: 1234
+                    path: /non-standard-path
+`,
+				expected: `
+                mtls:
+                  ca:
+                    builtin: {}
+                metrics:
+                  prometheus:
+                    port: 1234
+                    path: /non-standard-path
 `,
 			}),
 		)


### PR DESCRIPTION
### Summary

* automatically set default values for Prometheus settings in the Mesh resource

