### PR TITLE
kumactl: add `METRICS` column to the table output of `kumactl get meshes` to make it visible whether Prometheus settings have been configured

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 Changes:
 
+* feature: add `METRICS` column to the table output of `kumactl get meshes` to make it visible whether Prometheus settings have been configured
+  [#502](https://github.com/Kong/kuma/pull/502)
 * feature: automatically set default values for Prometheus settings in the Mesh resource
   [#501](https://github.com/Kong/kuma/pull/501)
 * feature: add proto definitions for metrics that should be collected and exposed by dataplanes

--- a/app/kumactl/cmd/get/get_meshes.go
+++ b/app/kumactl/cmd/get/get_meshes.go
@@ -47,7 +47,7 @@ func newGetMeshesCmd(pctx *getContext) *cobra.Command {
 
 func printMeshes(meshes *mesh.MeshResourceList, out io.Writer) error {
 	data := printers.Table{
-		Headers: []string{"NAME", "mTLS", "CA"},
+		Headers: []string{"NAME", "mTLS", "CA", "METRICS"},
 		NextRow: func() func() []string {
 			i := 0
 			return func() []string {
@@ -67,10 +67,17 @@ func printMeshes(meshes *mesh.MeshResourceList, out io.Writer) error {
 					ca = "unknown"
 				}
 
+				metrics := "off"
+				switch {
+				case mesh.Spec.Metrics.GetPrometheus() != nil:
+					metrics = "prometheus"
+				}
+
 				return []string{
 					mesh.GetMeta().GetName(),                 // NAME
 					table.OnOff(mesh.Spec.Mtls.GetEnabled()), // mTLS
 					ca,                                       // CA
+					metrics,                                  // METRICS
 				}
 			}
 		}(),

--- a/app/kumactl/cmd/get/get_meshes_test.go
+++ b/app/kumactl/cmd/get/get_meshes_test.go
@@ -54,6 +54,12 @@ var _ = Describe("kumactl get meshes", func() {
 						},
 					},
 				},
+				Metrics: &v1alpha1.Metrics{
+					Prometheus: &v1alpha1.Metrics_Prometheus{
+						Port: 1234,
+						Path: "/non-standard-path",
+					},
+				},
 			},
 			Meta: &test_model.ResourceMeta{
 				Mesh: "mesh2",

--- a/app/kumactl/cmd/get/testdata/get-meshes.golden.json
+++ b/app/kumactl/cmd/get/testdata/get-meshes.golden.json
@@ -11,6 +11,12 @@
       "type": "Mesh"
     },
     {
+      "metrics": {
+        "prometheus": {
+          "port": 1234,
+          "path": "/non-standard-path"
+        }
+      },
       "mtls": {
         "ca": {
           "provided": {}

--- a/app/kumactl/cmd/get/testdata/get-meshes.golden.txt
+++ b/app/kumactl/cmd/get/testdata/get-meshes.golden.txt
@@ -1,3 +1,3 @@
-NAME    mTLS   CA
-mesh1   on     builtin
-mesh2   off    provided
+NAME    mTLS   CA         METRICS
+mesh1   on     builtin    off
+mesh2   off    provided   prometheus

--- a/app/kumactl/cmd/get/testdata/get-meshes.golden.yaml
+++ b/app/kumactl/cmd/get/testdata/get-meshes.golden.yaml
@@ -5,7 +5,11 @@ items:
         builtin: {}
     name: mesh1
     type: Mesh
-  - mtls:
+  - metrics:
+      prometheus:
+        path: /non-standard-path
+        port: 1234
+    mtls:
       ca:
         provided: {}
     name: mesh2


### PR DESCRIPTION
### Summary

* add `METRICS` column to the table output of `kumactl get meshes` to make it visible whether Prometheus settings have been configured
