### PR TITLE
kuma-cp: refactor Envoy config generators to have access to a complete Mesh resource

### DIFF
--- a/pkg/xds/context/context.go
+++ b/pkg/xds/context/context.go
@@ -5,6 +5,7 @@ import (
 	"io/ioutil"
 
 	kuma_cp "github.com/Kong/kuma/pkg/config/app/kuma-cp"
+	mesh_core "github.com/Kong/kuma/pkg/core/resources/apis/mesh"
 )
 
 type Context struct {
@@ -18,7 +19,7 @@ type ControlPlaneContext struct {
 }
 
 type MeshContext struct {
-	TlsEnabled bool
+	Resource *mesh_core.MeshResource
 }
 
 func BuildControlPlaneContext(config kuma_cp.Config) (*ControlPlaneContext, error) {

--- a/pkg/xds/envoy/envoy.go
+++ b/pkg/xds/envoy/envoy.go
@@ -270,7 +270,7 @@ func CreateInboundListener(ctx xds_context.Context, listenerName string, address
 		}},
 	}
 
-	if ctx.Mesh.TlsEnabled {
+	if ctx.Mesh.Resource.Spec.GetMtls().GetEnabled() {
 		filter := createRbacFilter(listenerName, permissions)
 		// RBAC filter should be first in chain
 		listener.FilterChains[0].Filters = append([]*envoy_listener.Filter{&filter}, listener.FilterChains[0].Filters...)
@@ -286,7 +286,7 @@ func CreateInboundListener(ctx xds_context.Context, listenerName string, address
 }
 
 func CreateDownstreamTlsContext(ctx xds_context.Context, metadata *core_xds.DataplaneMetadata) *envoy_auth.DownstreamTlsContext {
-	if !ctx.Mesh.TlsEnabled {
+	if !ctx.Mesh.Resource.Spec.GetMtls().GetEnabled() {
 		return nil
 	}
 	return &envoy_auth.DownstreamTlsContext{
@@ -296,7 +296,7 @@ func CreateDownstreamTlsContext(ctx xds_context.Context, metadata *core_xds.Data
 }
 
 func CreateUpstreamTlsContext(ctx xds_context.Context, metadata *core_xds.DataplaneMetadata) *envoy_auth.UpstreamTlsContext {
-	if !ctx.Mesh.TlsEnabled {
+	if !ctx.Mesh.Resource.Spec.GetMtls().GetEnabled() {
 		return nil
 	}
 	return &envoy_auth.UpstreamTlsContext{

--- a/pkg/xds/envoy/envoy_test.go
+++ b/pkg/xds/envoy/envoy_test.go
@@ -168,7 +168,7 @@ var _ = Describe("Envoy", func() {
 				ctx: xds_context.Context{
 					ControlPlane: &xds_context.ControlPlaneContext{},
 					Mesh: xds_context.MeshContext{
-						TlsEnabled: false,
+						Resource: &mesh_core.MeshResource{},
 					},
 				},
 				metadata: xds.DataplaneMetadata{},
@@ -188,7 +188,13 @@ var _ = Describe("Envoy", func() {
 						SdsTlsCert:  []byte("CERTIFICATE"),
 					},
 					Mesh: xds_context.MeshContext{
-						TlsEnabled: true,
+						Resource: &mesh_core.MeshResource{
+							Spec: mesh_proto.Mesh{
+								Mtls: &mesh_proto.Mesh_Mtls{
+									Enabled: true,
+								},
+							},
+						},
 					},
 				},
 				metadata: xds.DataplaneMetadata{},
@@ -236,7 +242,13 @@ var _ = Describe("Envoy", func() {
 						SdsTlsCert:  []byte("CERTIFICATE"),
 					},
 					Mesh: xds_context.MeshContext{
-						TlsEnabled: true,
+						Resource: &mesh_core.MeshResource{
+							Spec: mesh_proto.Mesh{
+								Mtls: &mesh_proto.Mesh_Mtls{
+									Enabled: true,
+								},
+							},
+						},
 					},
 				},
 				metadata: xds.DataplaneMetadata{
@@ -550,7 +562,7 @@ var _ = Describe("Envoy", func() {
 				ctx: xds_context.Context{
 					ControlPlane: &xds_context.ControlPlaneContext{},
 					Mesh: xds_context.MeshContext{
-						TlsEnabled: false,
+						Resource: &mesh_core.MeshResource{},
 					},
 				},
 				virtual: false,
@@ -573,7 +585,7 @@ var _ = Describe("Envoy", func() {
 				ctx: xds_context.Context{
 					ControlPlane: &xds_context.ControlPlaneContext{},
 					Mesh: xds_context.MeshContext{
-						TlsEnabled: false,
+						Resource: &mesh_core.MeshResource{},
 					},
 				},
 				virtual: true,
@@ -601,7 +613,13 @@ var _ = Describe("Envoy", func() {
 						SdsTlsCert:  []byte("CERTIFICATE"),
 					},
 					Mesh: xds_context.MeshContext{
-						TlsEnabled: true,
+						Resource: &mesh_core.MeshResource{
+							Spec: mesh_proto.Mesh{
+								Mtls: &mesh_proto.Mesh_Mtls{
+									Enabled: true,
+								},
+							},
+						},
 					},
 				},
 				virtual: false,
@@ -669,7 +687,13 @@ var _ = Describe("Envoy", func() {
 						SdsTlsCert:  []byte("CERTIFICATE"),
 					},
 					Mesh: xds_context.MeshContext{
-						TlsEnabled: true,
+						Resource: &mesh_core.MeshResource{
+							Spec: mesh_proto.Mesh{
+								Mtls: &mesh_proto.Mesh_Mtls{
+									Enabled: true,
+								},
+							},
+						},
 					},
 				},
 				virtual: false,
@@ -809,7 +833,7 @@ var _ = Describe("Envoy", func() {
 				ctx: xds_context.Context{
 					ControlPlane: &xds_context.ControlPlaneContext{},
 					Mesh: xds_context.MeshContext{
-						TlsEnabled: false,
+						Resource: &mesh_core.MeshResource{},
 					},
 				},
 				virtual:  false,
@@ -833,7 +857,7 @@ var _ = Describe("Envoy", func() {
 				ctx: xds_context.Context{
 					ControlPlane: &xds_context.ControlPlaneContext{},
 					Mesh: xds_context.MeshContext{
-						TlsEnabled: false,
+						Resource: &mesh_core.MeshResource{},
 					},
 				},
 				virtual:  true,
@@ -862,7 +886,13 @@ var _ = Describe("Envoy", func() {
 						SdsTlsCert:  []byte("CERTIFICATE"),
 					},
 					Mesh: xds_context.MeshContext{
-						TlsEnabled: true,
+						Resource: &mesh_core.MeshResource{
+							Spec: mesh_proto.Mesh{
+								Mtls: &mesh_proto.Mesh_Mtls{
+									Enabled: true,
+								},
+							},
+						},
 					},
 				},
 				virtual:  false,
@@ -889,7 +919,13 @@ var _ = Describe("Envoy", func() {
 						SdsTlsCert:  []byte("CERTIFICATE"),
 					},
 					Mesh: xds_context.MeshContext{
-						TlsEnabled: true,
+						Resource: &mesh_core.MeshResource{
+							Spec: mesh_proto.Mesh{
+								Mtls: &mesh_proto.Mesh_Mtls{
+									Enabled: true,
+								},
+							},
+						},
 					},
 				},
 				virtual:  false,
@@ -913,7 +949,7 @@ var _ = Describe("Envoy", func() {
 				ctx: xds_context.Context{
 					ControlPlane: &xds_context.ControlPlaneContext{},
 					Mesh: xds_context.MeshContext{
-						TlsEnabled: false,
+						Resource: &mesh_core.MeshResource{},
 					},
 				},
 				clusters: singleCluster,
@@ -951,7 +987,7 @@ var _ = Describe("Envoy", func() {
 				ctx: xds_context.Context{
 					ControlPlane: &xds_context.ControlPlaneContext{},
 					Mesh: xds_context.MeshContext{
-						TlsEnabled: false,
+						Resource: &mesh_core.MeshResource{},
 					},
 				},
 				clusters: singleCluster,
@@ -992,7 +1028,7 @@ var _ = Describe("Envoy", func() {
 				ctx: xds_context.Context{
 					ControlPlane: &xds_context.ControlPlaneContext{},
 					Mesh: xds_context.MeshContext{
-						TlsEnabled: false,
+						Resource: &mesh_core.MeshResource{},
 					},
 				},
 				virtual: false,

--- a/pkg/xds/generator/inbound_proxy_generator_test.go
+++ b/pkg/xds/generator/inbound_proxy_generator_test.go
@@ -1,9 +1,10 @@
 package generator_test
 
 import (
-	"github.com/Kong/kuma/pkg/core/permissions"
 	"io/ioutil"
 	"path/filepath"
+
+	"github.com/Kong/kuma/pkg/core/permissions"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/ginkgo/extensions/table"
@@ -36,7 +37,13 @@ var _ = Describe("InboundProxyGenerator", func() {
 					SdsTlsCert:  []byte("12345"),
 				},
 				Mesh: xds_context.MeshContext{
-					TlsEnabled: true,
+					Resource: &mesh_core.MeshResource{
+						Spec: mesh_proto.Mesh{
+							Mtls: &mesh_proto.Mesh_Mtls{
+								Enabled: true,
+							},
+						},
+					},
 				},
 			}
 

--- a/pkg/xds/generator/outbound_proxy_generator_test.go
+++ b/pkg/xds/generator/outbound_proxy_generator_test.go
@@ -24,7 +24,7 @@ var _ = Describe("OutboundProxyGenerator", func() {
 	plainCtx := xds_context.Context{
 		ControlPlane: &xds_context.ControlPlaneContext{},
 		Mesh: xds_context.MeshContext{
-			TlsEnabled: false,
+			Resource: &mesh_core.MeshResource{},
 		},
 	}
 
@@ -34,7 +34,13 @@ var _ = Describe("OutboundProxyGenerator", func() {
 			SdsTlsCert:  []byte("12345"),
 		},
 		Mesh: xds_context.MeshContext{
-			TlsEnabled: true,
+			Resource: &mesh_core.MeshResource{
+				Spec: mesh_proto.Mesh{
+					Mtls: &mesh_proto.Mesh_Mtls{
+						Enabled: true,
+					},
+				},
+			},
 		},
 	}
 

--- a/pkg/xds/generator/proxy_template_profile_source_test.go
+++ b/pkg/xds/generator/proxy_template_profile_source_test.go
@@ -42,7 +42,13 @@ var _ = Describe("ProxyTemplateProfileSource", func() {
 					SdsTlsCert:  []byte("12345"),
 				},
 				Mesh: xds_context.MeshContext{
-					TlsEnabled: true,
+					Resource: &mesh_core.MeshResource{
+						Spec: mesh_proto.Mesh{
+							Mtls: &mesh_proto.Mesh_Mtls{
+								Enabled: true,
+							},
+						},
+					},
 				},
 			}
 

--- a/pkg/xds/generator/proxy_template_test.go
+++ b/pkg/xds/generator/proxy_template_test.go
@@ -38,6 +38,9 @@ var _ = Describe("TemplateProxyGenerator", func() {
 						SdsLocation: "kuma-system:5677",
 						SdsTlsCert:  []byte("12345"),
 					},
+					Mesh: xds_context.MeshContext{
+						Resource: &mesh_core.MeshResource{},
+					},
 				}
 
 				// when
@@ -111,7 +114,13 @@ var _ = Describe("TemplateProxyGenerator", func() {
 						SdsTlsCert:  []byte("12345"),
 					},
 					Mesh: xds_context.MeshContext{
-						TlsEnabled: true,
+						Resource: &mesh_core.MeshResource{
+							Spec: mesh_proto.Mesh{
+								Mtls: &mesh_proto.Mesh_Mtls{
+									Enabled: true,
+								},
+							},
+						},
 					},
 				}
 

--- a/pkg/xds/server/components.go
+++ b/pkg/xds/server/components.go
@@ -107,7 +107,7 @@ func DefaultDataplaneSyncTracker(rt core_runtime.Runtime, reconciler SnapshotRec
 				envoyCtx := xds_context.Context{
 					ControlPlane: envoyCpCtx,
 					Mesh: xds_context.MeshContext{
-						TlsEnabled: meshList.Items[0].Spec.GetMtls().GetEnabled(),
+						Resource: meshList.Items[0],
 					},
 				}
 

--- a/pkg/xds/server/snapshot_generator_test.go
+++ b/pkg/xds/server/snapshot_generator_test.go
@@ -1,9 +1,10 @@
 package server
 
 import (
-	"github.com/Kong/kuma/pkg/core/permissions"
 	"io/ioutil"
 	"path/filepath"
+
+	"github.com/Kong/kuma/pkg/core/permissions"
 
 	"github.com/Kong/kuma/pkg/core/resources/manager"
 	. "github.com/onsi/ginkgo"
@@ -39,7 +40,13 @@ var _ = Describe("Reconcile", func() {
 					SdsTlsCert:  []byte("12345"),
 				},
 				Mesh: xds_context.MeshContext{
-					TlsEnabled: true,
+					Resource: &mesh_core.MeshResource{
+						Spec: mesh_proto.Mesh{
+							Mtls: &mesh_proto.Mesh_Mtls{
+								Enabled: true,
+							},
+						},
+					},
 				},
 			}
 


### PR DESCRIPTION
### Summary

* refactor Envoy config generators to have access to a complete `Mesh` resource

