### PR TITLE
kuma-cp: make port of Envoy Admin API available to Envoy config generators

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 Changes:
 
+* feature: make port of Envoy Admin API available to Envoy config generators
+  [#508](https://github.com/Kong/kuma/pull/508)
 * feature: add option to run dataplane as a gateway without inbounds
   [#503](https://github.com/Kong/kuma/pull/503)
 * feature: add `METRICS` column to the table output of `kumactl get meshes` to make it visible whether Prometheus settings have been configured

--- a/pkg/core/xds/metadata.go
+++ b/pkg/core/xds/metadata.go
@@ -1,11 +1,39 @@
 package xds
 
 import (
+	"strconv"
+
+	"github.com/Kong/kuma/pkg/core"
+
 	envoy_core "github.com/envoyproxy/go-control-plane/envoy/api/v2/core"
 )
 
+var metadataLog = core.Log.WithName("xds-server").WithName("metadata-tracker")
+
+const (
+	// Supported Envoy node metadata fields.
+
+	fieldDataplaneTokenPath = "dataplaneTokenPath"
+	fieldDataplaneAdminPort = "dataplane.admin.port"
+)
+
+// DataplaneMetadata represents environment-specific part of a dataplane configuration.
+//
+// This information might change from one dataplane run to another
+// and therefore it cannot be a part of Dataplane resource.
+//
+// On start-up, a dataplane captures its effective configuration (that might come
+// from a file, environment variables and command line options) and includes it
+// into request for a bootstrap config.
+// Control Plane can use this information to fill in node metadata in the bootstrap
+// config.
+// Envoy will include node metadata from the bootstrap config
+// at least into the very first discovery request on every xDS stream.
+// This way, xDS server will be able to use Envoy node metadata
+// to generate xDS resources that depend on environment-specific configuration.
 type DataplaneMetadata struct {
 	DataplaneTokenPath string
+	AdminPort          uint32
 }
 
 func DataplaneMetadataFromNode(node *envoy_core.Node) *DataplaneMetadata {
@@ -13,8 +41,15 @@ func DataplaneMetadataFromNode(node *envoy_core.Node) *DataplaneMetadata {
 	if node.Metadata == nil {
 		return &metadata
 	}
-	if field := node.Metadata.Fields["dataplaneTokenPath"]; field != nil {
+	if field := node.Metadata.Fields[fieldDataplaneTokenPath]; field != nil {
 		metadata.DataplaneTokenPath = field.GetStringValue()
+	}
+	if value := node.Metadata.Fields[fieldDataplaneAdminPort]; value != nil {
+		if port, err := strconv.Atoi(value.GetStringValue()); err == nil {
+			metadata.AdminPort = uint32(port)
+		} else {
+			metadataLog.Error(err, "invalid value in dataplane metadata", "field", fieldDataplaneAdminPort, "value", value)
+		}
 	}
 	return &metadata
 }

--- a/pkg/core/xds/metadata_test.go
+++ b/pkg/core/xds/metadata_test.go
@@ -35,11 +35,17 @@ var _ = DescribeTable("DataplaneMetadataFromNode",
 							StringValue: "/tmp/token",
 						},
 					},
+					"dataplane.admin.port": &pstruct.Value{
+						Kind: &pstruct.Value_StringValue{
+							StringValue: "1234",
+						},
+					},
 				},
 			},
 		},
 		expected: xds.DataplaneMetadata{
 			DataplaneTokenPath: "/tmp/token",
+			AdminPort:          1234,
 		},
 	}),
 )

--- a/pkg/xds/bootstrap/template.go
+++ b/pkg/xds/bootstrap/template.go
@@ -22,7 +22,10 @@ node:
   metadata:
 {{if .DataplaneTokenPath}}
     dataplaneTokenPath: {{.DataplaneTokenPath}}
-{{end}}    
+{{end}}
+{{if .AdminPort }}
+    dataplane.admin.port: "{{ .AdminPort }}"
+{{ end }}
 
 {{if .AdminPort }}
 admin:

--- a/pkg/xds/bootstrap/testdata/bootstrap.overridden.golden.yaml
+++ b/pkg/xds/bootstrap/testdata/bootstrap.overridden.golden.yaml
@@ -18,6 +18,7 @@ node:
   cluster: backend
   id: default.dp-1.default
   metadata:
+    dataplane.admin.port: "1234"
     dataplaneTokenPath: /tmp/token
 staticResources:
   clusters:

--- a/pkg/xds/bootstrap/testdata/generator.custom-config-minimal-request.golden.yaml
+++ b/pkg/xds/bootstrap/testdata/generator.custom-config-minimal-request.golden.yaml
@@ -17,6 +17,8 @@ dynamicResources:
 node:
   cluster: backend
   id: mesh.name.namespace
+  metadata:
+    dataplane.admin.port: "9902"
 staticResources:
   clusters:
   - connectTimeout: 2s

--- a/pkg/xds/bootstrap/testdata/generator.custom-config.golden.yaml
+++ b/pkg/xds/bootstrap/testdata/generator.custom-config.golden.yaml
@@ -18,6 +18,7 @@ node:
   cluster: backend
   id: mesh.name.namespace
   metadata:
+    dataplane.admin.port: "1234"
     dataplaneTokenPath: /tmp/token
 staticResources:
   clusters:

--- a/pkg/xds/bootstrap/testdata/generator.default-config.golden.yaml
+++ b/pkg/xds/bootstrap/testdata/generator.default-config.golden.yaml
@@ -18,6 +18,7 @@ node:
   cluster: backend
   id: mesh.name.namespace
   metadata:
+    dataplane.admin.port: "1234"
     dataplaneTokenPath: /tmp/token
 staticResources:
   clusters:


### PR DESCRIPTION
### Summary

* make port of Envoy Admin API available to Envoy config generators
