### PR TITLE
refactoring: use getter methods to avoid dereferencing a nil pointer

### DIFF
--- a/pkg/core/xds/metadata.go
+++ b/pkg/core/xds/metadata.go
@@ -36,6 +36,20 @@ type DataplaneMetadata struct {
 	AdminPort          uint32
 }
 
+func (m *DataplaneMetadata) GetDataplaneTokenPath() string {
+	if m == nil {
+		return ""
+	}
+	return m.DataplaneTokenPath
+}
+
+func (m *DataplaneMetadata) GetAdminPort() uint32 {
+	if m == nil {
+		return 0
+	}
+	return m.AdminPort
+}
+
 func DataplaneMetadataFromNode(node *envoy_core.Node) *DataplaneMetadata {
 	metadata := DataplaneMetadata{}
 	if node.Metadata == nil {

--- a/pkg/xds/envoy/envoy.go
+++ b/pkg/xds/envoy/envoy.go
@@ -317,14 +317,14 @@ func CreateCommonTlsContext(ctx xds_context.Context, metadata *core_xds.Dataplan
 
 func sdsSecretConfig(context xds_context.Context, name string, metadata *core_xds.DataplaneMetadata) *envoy_auth.SdsSecretConfig {
 	withCallCredentials := func(grpc *envoy_core.GrpcService_GoogleGrpc) *envoy_core.GrpcService_GoogleGrpc {
-		if metadata.DataplaneTokenPath == "" {
+		if metadata.GetDataplaneTokenPath() == "" {
 			return grpc
 		}
 
 		config := &envoy_grpc_credential.FileBasedMetadataConfig{
 			SecretData: &envoy_core.DataSource{
 				Specifier: &envoy_core.DataSource_Filename{
-					Filename: metadata.DataplaneTokenPath,
+					Filename: metadata.GetDataplaneTokenPath(),
 				},
 			},
 		}

--- a/pkg/xds/server/dataplane_metadata_tracker_test.go
+++ b/pkg/xds/server/dataplane_metadata_tracker_test.go
@@ -41,7 +41,7 @@ var _ = Describe("Dataplane Metadata Tracker", func() {
 		metadata := tracker.Metadata(streamId)
 
 		// then
-		Expect(metadata.DataplaneTokenPath).To(Equal("/tmp/token"))
+		Expect(metadata.GetDataplaneTokenPath()).To(Equal("/tmp/token"))
 
 		// when
 		tracker.OnStreamClosed(streamId)
@@ -68,6 +68,6 @@ var _ = Describe("Dataplane Metadata Tracker", func() {
 		metadata := tracker.Metadata(streamId)
 
 		// then
-		Expect(metadata.DataplaneTokenPath).To(Equal("/tmp/token"))
+		Expect(metadata.GetDataplaneTokenPath()).To(Equal("/tmp/token"))
 	})
 })


### PR DESCRIPTION
### Summary

* refactoring: use getter methods to avoid dereferencing a `nil` pointer