### PR TITLE
feat(kuma-cp) redirect requests from gui server to api server

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ Changes:
 
 * feature: add integration with Prometheus on K8S
   [#524](https://github.com/Kong/kuma/pull/524)
+* feature: redirect requests to /api path on GUI server to API Server
+  [#520](https://github.com/Kong/kuma/pull/520)
 * feature: generate Envoy configuration that exposes Prometheus metrics
   [#510](https://github.com/Kong/kuma/pull/510)
 * feature: make port of Envoy Admin API available to Envoy config generators

--- a/app/kuma-ui/pkg/server/server.go
+++ b/app/kuma-ui/pkg/server/server.go
@@ -19,8 +19,7 @@ var log = core.Log.WithName("gui-server")
 
 func SetupServer(rt core_runtime.Runtime) error {
 	srv := Server{
-		Config:        rt.Config().GuiServer,
-		ApiServerPort: rt.Config().ApiServer.Port,
+		Config: rt.Config().GuiServer,
 	}
 	if err := core_runtime.Add(rt, &srv); err != nil {
 		return err
@@ -29,8 +28,7 @@ func SetupServer(rt core_runtime.Runtime) error {
 }
 
 type Server struct {
-	Config        *gui_server.GuiServerConfig
-	ApiServerPort int
+	Config *gui_server.GuiServerConfig
 }
 
 var _ core_runtime.Component = &Server{}
@@ -77,7 +75,7 @@ func (g *Server) Start(stop <-chan struct{}) error {
 }
 
 func (g *Server) apiHandler() (http.Handler, error) {
-	apiServerUrl, err := url.Parse(fmt.Sprintf("http://localhost:%d", g.ApiServerPort))
+	apiServerUrl, err := url.Parse(g.Config.ApiServerUrl)
 	if err != nil {
 		return nil, err
 	}

--- a/app/kuma-ui/pkg/server/server_test.go
+++ b/app/kuma-ui/pkg/server/server_test.go
@@ -54,8 +54,8 @@ var _ = Describe("GUI Server", func() {
 					ApiUrl:      "http://kuma.internal:5681",
 					Environment: "kubernetes",
 				},
+				ApiServerUrl: fmt.Sprintf("http://localhost:%d", apiSrvPort),
 			},
-			ApiServerPort: apiSrvPort,
 		}
 		stop = make(chan struct{})
 		go func() {

--- a/pkg/api-server/config_ws_test.go
+++ b/pkg/api-server/config_ws_test.go
@@ -104,7 +104,8 @@ var _ = Describe("Config WS", func() {
             "advertisedHostname": "localhost"
           },
           "guiServer": {
-            "port": 5683
+            "port": 5683,
+            "apiServerUrl": ""
           },
           "reports": {
             "enabled": true

--- a/pkg/config/app/kuma-cp/kuma-cp.defaults.yaml
+++ b/pkg/config/app/kuma-cp/kuma-cp.defaults.yaml
@@ -175,3 +175,5 @@ general:
 guiServer:
   # Port on which the server is exposed
   port: 5683 # ENV: KUMA_GUI_SERVER_PORT
+  # URL of the Api Server that requests with /api prefix will be redirected to. By default autoconfigured to http://locahost:port_of_api_server
+  apiServerUrl: # ENV: KUMA_GUI_SERVER_API_SERVER_URL

--- a/pkg/config/gui-server/config.go
+++ b/pkg/config/gui-server/config.go
@@ -9,8 +9,10 @@ import (
 type GuiServerConfig struct {
 	// Port on which the server is exposed
 	Port uint32 `yaml:"port" envconfig:"kuma_gui_server_port"`
+	// URL of the Api Server that requests with /api prefix will be redirected to. By default autoconfigured to http://locahost:port_of_api_server
+	ApiServerUrl string `yaml:"apiServerUrl" envconfig:"kuma_gui_server_api_server_url"`
 	// Config of the GUI itself
-	GuiConfig *GuiConfig `yaml:"-"`
+	GuiConfig *GuiConfig `yaml:"-"` // DEPRECATED, will be removed when GUI is switched to use /api URL
 }
 
 func (g *GuiServerConfig) Sanitize() {

--- a/pkg/config/loader_test.go
+++ b/pkg/config/loader_test.go
@@ -115,6 +115,7 @@ var _ = Describe("Config loader", func() {
 			Expect(cfg.General.AdvertisedHostname).To(Equal("kuma.internal"))
 
 			Expect(cfg.GuiServer.Port).To(Equal(uint32(8888)))
+			Expect(cfg.GuiServer.ApiServerUrl).To(Equal("http://localhost:1234"))
 		},
 		Entry("from config file", testCase{
 			envVars: map[string]string{},
@@ -185,6 +186,7 @@ general:
   advertisedHostname: kuma.internal
 guiServer:
   port: 8888
+  apiServerUrl: http://localhost:1234
 `,
 		}),
 		Entry("from env variables", testCase{
@@ -232,6 +234,7 @@ guiServer:
 				"KUMA_GENERAL_ADVERTISED_HOSTNAME":                    "kuma.internal",
 				"KUMA_API_SERVER_CORS_ALLOWED_DOMAINS":                "https://kuma,https://someapi",
 				"KUMA_GUI_SERVER_PORT":                                "8888",
+				"KUMA_GUI_SERVER_API_SERVER_URL":                      "http://localhost:1234",
 			},
 			yamlFileConfig: "",
 		}),

--- a/pkg/core/bootstrap/autoconfig.go
+++ b/pkg/core/bootstrap/autoconfig.go
@@ -105,6 +105,7 @@ func autoconfigureAdminServer(cfg *kuma_cp.Config) {
 }
 
 func autoconfigureGui(cfg *kuma_cp.Config) {
+	cfg.GuiServer.ApiServerUrl = fmt.Sprintf("http://localhost:%d", cfg.ApiServer.Port)
 	cfg.GuiServer.GuiConfig = &gui_server.GuiConfig{
 		ApiUrl:      fmt.Sprintf("http://%s:%d", cfg.General.AdvertisedHostname, cfg.ApiServer.Port),
 		Environment: cfg.Environment,


### PR DESCRIPTION
### Summary

Redirect requests from GUI on /api prefix to API Server. This simplifies setup since you don't have to coordinate exposing GUI and API server and configuring proper external address.