### PR TITLE
feat(kuma-cp) order matching policies by modification time

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ Changes:
   [#557](https://github.com/Kong/kuma/pull/557)
 * feature: DB migrations for Postgres
   [#552](https://github.com/Kong/kuma/pull/552)
+* feat: order matching policies by creation time
+  [#522](https://github.com/Kong/kuma/pull/522)
 * feat: add creation and modification time to core entities
   [#521](https://github.com/Kong/kuma/pull/521)
 

--- a/pkg/core/policy/matcher.go
+++ b/pkg/core/policy/matcher.go
@@ -77,7 +77,6 @@ func SelectConnectionPolicies(dataplane *mesh_core.DataplaneResource, destinatio
 			if dataplane.Spec.Matches(sourceSelector) {
 				sourceRank := sourceSelector.Rank()
 				if !matches || sourceRank.CompareTo(candidate.bestSourceRank) > 0 {
-					// TODO(yskopets): use CreationDate to resolve a conflict between 2 equal ranks
 					candidate.bestSourceRank = sourceRank
 				}
 				matches = true
@@ -115,8 +114,9 @@ func SelectConnectionPolicies(dataplane *mesh_core.DataplaneResource, destinatio
 
 					candidateByDestination, exists := candidatesByDestination[service]
 
-					if !exists || aggregateRank.CompareTo(candidateByDestination.bestAggregateRank) > 0 {
-						// TODO(yskopets): use CreationDate to resolve a conflict between 2 equal ranks
+					if !exists ||
+						aggregateRank.CompareTo(candidateByDestination.bestAggregateRank) > 0 ||
+						(aggregateRank.CompareTo(candidateByDestination.bestAggregateRank) == 0 && candidateBySource.policy.GetMeta().GetModificationTime().After(candidateByDestination.policy.GetMeta().GetModificationTime())) {
 						candidateByDestination.candidateBySource = candidateBySource
 						candidateByDestination.bestAggregateRank = aggregateRank
 

--- a/pkg/core/policy/matcher.go
+++ b/pkg/core/policy/matcher.go
@@ -116,7 +116,7 @@ func SelectConnectionPolicies(dataplane *mesh_core.DataplaneResource, destinatio
 
 					if !exists ||
 						aggregateRank.CompareTo(candidateByDestination.bestAggregateRank) > 0 ||
-						(aggregateRank.CompareTo(candidateByDestination.bestAggregateRank) == 0 && candidateBySource.policy.GetMeta().GetModificationTime().After(candidateByDestination.policy.GetMeta().GetModificationTime())) {
+						(aggregateRank.CompareTo(candidateByDestination.bestAggregateRank) == 0 && candidateBySource.policy.GetMeta().GetCreationTime().After(candidateByDestination.policy.GetMeta().GetCreationTime())) {
 						candidateByDestination.candidateBySource = candidateBySource
 						candidateByDestination.bestAggregateRank = aggregateRank
 

--- a/pkg/xds/topology/healthchecks_test.go
+++ b/pkg/xds/topology/healthchecks_test.go
@@ -292,7 +292,7 @@ var _ = Describe("HealthCheck", func() {
 					},
 				},
 			}),
-			Entry("HealthChecks should be ordered by name to consistently pick between two equally specific HealthCehcks", testCase{
+			Entry("HealthChecks should be picked by latest modification date given two equally specific HealthChecks", testCase{
 				dataplane: &mesh_core.DataplaneResource{
 					Spec: mesh_proto.Dataplane{
 						Networking: &mesh_proto.Dataplane_Networking{
@@ -311,7 +311,8 @@ var _ = Describe("HealthCheck", func() {
 				healthChecks: []*mesh_core.HealthCheckResource{
 					{
 						Meta: &test_model.ResourceMeta{
-							Name: "healthcheck-everything-passive",
+							Name:             "healthcheck-everything-passive",
+							ModificationTime: time.Unix(1, 1),
 						},
 						Spec: mesh_proto.HealthCheck{
 							Sources: []*mesh_proto.Selector{
@@ -332,7 +333,8 @@ var _ = Describe("HealthCheck", func() {
 					},
 					{
 						Meta: &test_model.ResourceMeta{
-							Name: "healthcheck-everything-active",
+							Name:             "healthcheck-everything-active",
+							ModificationTime: time.Unix(0, 0),
 						},
 						Spec: mesh_proto.HealthCheck{
 							Sources: []*mesh_proto.Selector{
@@ -353,7 +355,7 @@ var _ = Describe("HealthCheck", func() {
 				expected: core_xds.HealthCheckMap{
 					"redis": &mesh_core.HealthCheckResource{
 						Meta: &test_model.ResourceMeta{
-							Name: "healthcheck-everything-active",
+							Name: "healthcheck-everything-passive",
 						},
 					},
 				},
@@ -556,7 +558,7 @@ var _ = Describe("HealthCheck", func() {
 					},
 				},
 			}),
-			Entry("in case if HealthChecks have equal aggregate ranks, most specific one should be selected based on ordering by name", testCase{
+			Entry("in case if HealthChecks have equal aggregate ranks, most specific one should be selected based on last modification date", testCase{
 				dataplane: &mesh_core.DataplaneResource{
 					Spec: mesh_proto.Dataplane{
 						Networking: &mesh_proto.Dataplane_Networking{
@@ -575,7 +577,8 @@ var _ = Describe("HealthCheck", func() {
 				healthChecks: []*mesh_core.HealthCheckResource{
 					{
 						Meta: &test_model.ResourceMeta{
-							Name: "equally-specific-2",
+							Name:             "equally-specific-2",
+							ModificationTime: time.Unix(1, 1),
 						},
 						Spec: mesh_proto.HealthCheck{
 							Sources: []*mesh_proto.Selector{
@@ -596,7 +599,8 @@ var _ = Describe("HealthCheck", func() {
 					},
 					{
 						Meta: &test_model.ResourceMeta{
-							Name: "equally-specific-1",
+							Name:             "equally-specific-1",
+							ModificationTime: time.Unix(0, 0),
 						},
 						Spec: mesh_proto.HealthCheck{
 							Sources: []*mesh_proto.Selector{
@@ -617,7 +621,7 @@ var _ = Describe("HealthCheck", func() {
 				expected: core_xds.HealthCheckMap{
 					"redis": &mesh_core.HealthCheckResource{
 						Meta: &test_model.ResourceMeta{
-							Name: "equally-specific-1",
+							Name: "equally-specific-2",
 						},
 					},
 				},

--- a/pkg/xds/topology/healthchecks_test.go
+++ b/pkg/xds/topology/healthchecks_test.go
@@ -292,7 +292,7 @@ var _ = Describe("HealthCheck", func() {
 					},
 				},
 			}),
-			Entry("HealthChecks should be picked by latest modification date given two equally specific HealthChecks", testCase{
+			Entry("HealthChecks should be picked by latest creation time given two equally specific HealthChecks", testCase{
 				dataplane: &mesh_core.DataplaneResource{
 					Spec: mesh_proto.Dataplane{
 						Networking: &mesh_proto.Dataplane_Networking{
@@ -311,8 +311,8 @@ var _ = Describe("HealthCheck", func() {
 				healthChecks: []*mesh_core.HealthCheckResource{
 					{
 						Meta: &test_model.ResourceMeta{
-							Name:             "healthcheck-everything-passive",
-							ModificationTime: time.Unix(1, 1),
+							Name:         "healthcheck-everything-passive",
+							CreationTime: time.Unix(1, 1),
 						},
 						Spec: mesh_proto.HealthCheck{
 							Sources: []*mesh_proto.Selector{
@@ -333,8 +333,8 @@ var _ = Describe("HealthCheck", func() {
 					},
 					{
 						Meta: &test_model.ResourceMeta{
-							Name:             "healthcheck-everything-active",
-							ModificationTime: time.Unix(0, 0),
+							Name:         "healthcheck-everything-active",
+							CreationTime: time.Unix(0, 0),
 						},
 						Spec: mesh_proto.HealthCheck{
 							Sources: []*mesh_proto.Selector{
@@ -558,7 +558,7 @@ var _ = Describe("HealthCheck", func() {
 					},
 				},
 			}),
-			Entry("in case if HealthChecks have equal aggregate ranks, most specific one should be selected based on last modification date", testCase{
+			Entry("in case if HealthChecks have equal aggregate ranks, most specific one should be selected based on last creation time", testCase{
 				dataplane: &mesh_core.DataplaneResource{
 					Spec: mesh_proto.Dataplane{
 						Networking: &mesh_proto.Dataplane_Networking{
@@ -577,8 +577,8 @@ var _ = Describe("HealthCheck", func() {
 				healthChecks: []*mesh_core.HealthCheckResource{
 					{
 						Meta: &test_model.ResourceMeta{
-							Name:             "equally-specific-2",
-							ModificationTime: time.Unix(1, 1),
+							Name:         "equally-specific-2",
+							CreationTime: time.Unix(1, 1),
 						},
 						Spec: mesh_proto.HealthCheck{
 							Sources: []*mesh_proto.Selector{
@@ -599,8 +599,8 @@ var _ = Describe("HealthCheck", func() {
 					},
 					{
 						Meta: &test_model.ResourceMeta{
-							Name:             "equally-specific-1",
-							ModificationTime: time.Unix(0, 0),
+							Name:         "equally-specific-1",
+							CreationTime: time.Unix(0, 0),
 						},
 						Spec: mesh_proto.HealthCheck{
 							Sources: []*mesh_proto.Selector{

--- a/pkg/xds/topology/router_test.go
+++ b/pkg/xds/topology/router_test.go
@@ -2,6 +2,7 @@ package topology_test
 
 import (
 	"context"
+	"time"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/ginkgo/extensions/table"
@@ -312,7 +313,7 @@ var _ = Describe("TrafficRoute", func() {
 					},
 				},
 			}),
-			Entry("TrafficRoutes should be ordered by name to consistently pick between two equally specific routes", testCase{
+			Entry("TrafficRoutes should be picked by latest modification date given two equally specific routes", testCase{
 				dataplane: &mesh_core.DataplaneResource{
 					Spec: mesh_proto.Dataplane{
 						Networking: &mesh_proto.Dataplane_Networking{
@@ -328,7 +329,8 @@ var _ = Describe("TrafficRoute", func() {
 				routes: []*mesh_core.TrafficRouteResource{
 					{
 						Meta: &test_model.ResourceMeta{
-							Name: "everything-to-hollygrail",
+							Name:             "everything-to-hollygrail",
+							ModificationTime: time.Unix(1, 1),
 						},
 						Spec: mesh_proto.TrafficRoute{
 							Sources: []*mesh_proto.Selector{
@@ -347,7 +349,8 @@ var _ = Describe("TrafficRoute", func() {
 					},
 					{
 						Meta: &test_model.ResourceMeta{
-							Name: "everything-to-blackhole",
+							Name:             "everything-to-blackhole",
+							ModificationTime: time.Unix(0, 0),
 						},
 						Spec: mesh_proto.TrafficRoute{
 							Sources: []*mesh_proto.Selector{
@@ -368,7 +371,7 @@ var _ = Describe("TrafficRoute", func() {
 				expected: core_xds.RouteMap{
 					"redis": &mesh_core.TrafficRouteResource{
 						Meta: &test_model.ResourceMeta{
-							Name: "everything-to-blackhole",
+							Name: "everything-to-hollygrail",
 						},
 					},
 				},
@@ -556,7 +559,7 @@ var _ = Describe("TrafficRoute", func() {
 					},
 				},
 			}),
-			Entry("in case if TrafficRoutes have equal aggregate ranks, most specific one should be selected based on ordering by name", testCase{
+			Entry("in case if TrafficRoutes have equal aggregate ranks, most specific one should be selected based on last modification date", testCase{
 				dataplane: &mesh_core.DataplaneResource{
 					Spec: mesh_proto.Dataplane{
 						Networking: &mesh_proto.Dataplane_Networking{
@@ -572,7 +575,8 @@ var _ = Describe("TrafficRoute", func() {
 				routes: []*mesh_core.TrafficRouteResource{
 					{
 						Meta: &test_model.ResourceMeta{
-							Name: "equally-specific-2",
+							Name:             "equally-specific-2",
+							ModificationTime: time.Unix(1, 1),
 						},
 						Spec: mesh_proto.TrafficRoute{
 							Sources: []*mesh_proto.Selector{
@@ -591,7 +595,8 @@ var _ = Describe("TrafficRoute", func() {
 					},
 					{
 						Meta: &test_model.ResourceMeta{
-							Name: "equally-specific-1",
+							Name:             "equally-specific-1",
+							ModificationTime: time.Unix(0, 0),
 						},
 						Spec: mesh_proto.TrafficRoute{
 							Sources: []*mesh_proto.Selector{
@@ -612,7 +617,7 @@ var _ = Describe("TrafficRoute", func() {
 				expected: core_xds.RouteMap{
 					"redis": &mesh_core.TrafficRouteResource{
 						Meta: &test_model.ResourceMeta{
-							Name: "equally-specific-1",
+							Name: "equally-specific-2",
 						},
 					},
 				},

--- a/pkg/xds/topology/router_test.go
+++ b/pkg/xds/topology/router_test.go
@@ -313,7 +313,7 @@ var _ = Describe("TrafficRoute", func() {
 					},
 				},
 			}),
-			Entry("TrafficRoutes should be picked by latest modification date given two equally specific routes", testCase{
+			Entry("TrafficRoutes should be picked by latest creation time given two equally specific routes", testCase{
 				dataplane: &mesh_core.DataplaneResource{
 					Spec: mesh_proto.Dataplane{
 						Networking: &mesh_proto.Dataplane_Networking{
@@ -329,8 +329,8 @@ var _ = Describe("TrafficRoute", func() {
 				routes: []*mesh_core.TrafficRouteResource{
 					{
 						Meta: &test_model.ResourceMeta{
-							Name:             "everything-to-hollygrail",
-							ModificationTime: time.Unix(1, 1),
+							Name:         "everything-to-hollygrail",
+							CreationTime: time.Unix(1, 1),
 						},
 						Spec: mesh_proto.TrafficRoute{
 							Sources: []*mesh_proto.Selector{
@@ -349,8 +349,8 @@ var _ = Describe("TrafficRoute", func() {
 					},
 					{
 						Meta: &test_model.ResourceMeta{
-							Name:             "everything-to-blackhole",
-							ModificationTime: time.Unix(0, 0),
+							Name:         "everything-to-blackhole",
+							CreationTime: time.Unix(0, 0),
 						},
 						Spec: mesh_proto.TrafficRoute{
 							Sources: []*mesh_proto.Selector{
@@ -559,7 +559,7 @@ var _ = Describe("TrafficRoute", func() {
 					},
 				},
 			}),
-			Entry("in case if TrafficRoutes have equal aggregate ranks, most specific one should be selected based on last modification date", testCase{
+			Entry("in case if TrafficRoutes have equal aggregate ranks, most specific one should be selected based on last creation time", testCase{
 				dataplane: &mesh_core.DataplaneResource{
 					Spec: mesh_proto.Dataplane{
 						Networking: &mesh_proto.Dataplane_Networking{
@@ -575,8 +575,8 @@ var _ = Describe("TrafficRoute", func() {
 				routes: []*mesh_core.TrafficRouteResource{
 					{
 						Meta: &test_model.ResourceMeta{
-							Name:             "equally-specific-2",
-							ModificationTime: time.Unix(1, 1),
+							Name:         "equally-specific-2",
+							CreationTime: time.Unix(1, 1),
 						},
 						Spec: mesh_proto.TrafficRoute{
 							Sources: []*mesh_proto.Selector{
@@ -595,8 +595,8 @@ var _ = Describe("TrafficRoute", func() {
 					},
 					{
 						Meta: &test_model.ResourceMeta{
-							Name:             "equally-specific-1",
-							ModificationTime: time.Unix(0, 0),
+							Name:         "equally-specific-1",
+							CreationTime: time.Unix(0, 0),
 						},
 						Spec: mesh_proto.TrafficRoute{
 							Sources: []*mesh_proto.Selector{


### PR DESCRIPTION
### Summary

Added ordering matching policies by modification time.
I think we should only resolve conflicts on final choice, otherwise we can eliminate valid policy. 