### PR TITLE
kuma-dp: enable Envoy Admin API by default with an option to opt out

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 Changes:
 
+* feature: enable Envoy Admin API by default with an option to opt out
+  [#523](https://github.com/Kong/kuma/pull/523)
 * feature: add integration with Prometheus on K8S
   [#524](https://github.com/Kong/kuma/pull/524)
 * feature: generate Envoy configuration that exposes Prometheus metrics

--- a/app/kuma-dp/pkg/dataplane/envoy/envoy.go
+++ b/app/kuma-dp/pkg/dataplane/envoy/envoy.go
@@ -3,11 +3,12 @@ package envoy
 import (
 	"context"
 	"fmt"
-	"github.com/Kong/kuma/pkg/catalog"
 	"io"
 	"os"
 	"os/exec"
 	"time"
+
+	"github.com/Kong/kuma/pkg/catalog"
 
 	"path/filepath"
 

--- a/app/kuma-dp/pkg/dataplane/envoy/remote_bootstrap.go
+++ b/app/kuma-dp/pkg/dataplane/envoy/remote_bootstrap.go
@@ -36,7 +36,7 @@ func (b *remoteBootstrap) Generate(url string, cfg kuma_dp.Config) (proto.Messag
 		Name: cfg.Dataplane.Name,
 		// if not set in config, the 0 will be sent which will result in providing default admin port
 		// that is set in the control plane bootstrap params
-		AdminPort:          cfg.Dataplane.AdminPort,
+		AdminPort:          cfg.Dataplane.AdminPort.Lowest(),
 		DataplaneTokenPath: cfg.DataplaneRuntime.TokenPath,
 	}
 	jsonBytes, err := json.Marshal(request)

--- a/pkg/config/app/kuma-dp/config_test.go
+++ b/pkg/config/app/kuma-dp/config_test.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/Kong/kuma/pkg/config"
 	kuma_dp "github.com/Kong/kuma/pkg/config/app/kuma-dp"
+	config_types "github.com/Kong/kuma/pkg/config/types"
 )
 
 var _ = Describe("Config", func() {
@@ -27,7 +28,7 @@ var _ = Describe("Config", func() {
 
 		// and
 		Expect(cfg.ControlPlane.ApiServer.URL).To(Equal("https://kuma-control-plane.internal:5682"))
-		Expect(cfg.Dataplane.AdminPort).To(Equal(uint32(2345)))
+		Expect(cfg.Dataplane.AdminPort).To(Equal(config_types.MustExactPort(2345)))
 		Expect(cfg.Dataplane.DrainTime).To(Equal(60 * time.Second))
 	})
 
@@ -76,7 +77,7 @@ var _ = Describe("Config", func() {
 			Expect(cfg.ControlPlane.ApiServer.URL).To(Equal("https://kuma-control-plane.internal:5682"))
 			Expect(cfg.Dataplane.Mesh).To(Equal("demo"))
 			Expect(cfg.Dataplane.Name).To(Equal("example"))
-			Expect(cfg.Dataplane.AdminPort).To(Equal(uint32(2345)))
+			Expect(cfg.Dataplane.AdminPort).To(Equal(config_types.MustExactPort(2345)))
 			Expect(cfg.Dataplane.DrainTime).To(Equal(60 * time.Second))
 			Expect(cfg.DataplaneRuntime.BinaryPath).To(Equal("envoy.sh"))
 			Expect(cfg.DataplaneRuntime.ConfigDir).To(Equal("/var/run/envoy"))
@@ -109,6 +110,6 @@ var _ = Describe("Config", func() {
 		err := config.Load(filepath.Join("testdata", "invalid-config.input.yaml"), &cfg)
 
 		// then
-		Expect(err).To(MatchError(`Invalid configuration: .ControlPlane is not valid: .ApiServer is not valid: .URL must be a valid absolute URI; .Dataplane is not valid: .Mesh must be non-empty; .Name must be non-empty; .AdminPort must be in the range [0, 65535]; .DrainTime must be positive; .DataplaneRuntime is not valid: .BinaryPath must be non-empty`))
+		Expect(err).To(MatchError(`Invalid configuration: .ControlPlane is not valid: .ApiServer is not valid: .URL must be a valid absolute URI; .Dataplane is not valid: .Mesh must be non-empty; .Name must be non-empty; .DrainTime must be positive; .DataplaneRuntime is not valid: .BinaryPath must be non-empty`))
 	})
 })

--- a/pkg/config/app/kuma-dp/testdata/invalid-config.input.yaml
+++ b/pkg/config/app/kuma-dp/testdata/invalid-config.input.yaml
@@ -4,7 +4,12 @@ controlPlane:
 dataplane:
   mesh:
   name:
-  adminPort: 82345
+  # If a field value is not valid, config loader fails early
+  # and `Validate()` method is not be called at all.
+  # Notice that it's not specific to the `adminPort` field, though;
+  # putting text into a number field will cause the same behaviour.
+  #
+  # adminPort: 82345
   drainTime: 0
 dataplaneRuntime:
   binaryPath:

--- a/pkg/config/types/portrange.go
+++ b/pkg/config/types/portrange.go
@@ -1,0 +1,161 @@
+package types
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+
+	"github.com/pkg/errors"
+)
+
+const (
+	MinPort uint32 = 1
+	MaxPort uint32 = 65535
+)
+
+// PortRange reprensents a closed interval of TCP ports constrained by the Lowest and the Highest limits.
+//
+// E.g.,
+// PortRange{8080, 8080} is a range consisting of a single port 8080,
+// PortRange{8080, 8081} is a range consisting of 2 ports: 8080 and 8081,
+// PortRange{0, 0} is an empty range (which is as a convenient way to indicate that no TCP port is necessary).
+type PortRange struct {
+	// Lowest port in the range, one of [0, 65535].
+	lowest uint32
+	// Highest port in the range, one of [Lowest, 65535].
+	highest uint32
+}
+
+func NewPortRange(lowest, highest uint32) (*PortRange, error) {
+	r := PortRange{lowest, highest}
+	if err := r.validate(); err != nil {
+		return nil, err
+	}
+	return &r, nil
+}
+
+func MustExactPort(port uint32) PortRange {
+	return MustPortRange(port, port)
+}
+
+func MustPortRange(lowest, highest uint32) PortRange {
+	r, err := NewPortRange(lowest, highest)
+	if err != nil {
+		panic(err)
+	}
+	return *r
+}
+
+func (r PortRange) Empty() bool {
+	return r.lowest == 0 && r.highest == 0
+}
+
+func (r PortRange) Lowest() uint32 {
+	return r.lowest
+}
+
+func (r PortRange) Highest() uint32 {
+	return r.highest
+}
+
+// validate is made non-public since PortRange
+// has been designed to always be valid.
+func (r PortRange) validate() error {
+	if r.Empty() {
+		return nil
+	}
+	if r.lowest < MinPort || r.highest < MinPort ||
+		MaxPort < r.lowest || MaxPort < r.highest ||
+		r.highest < r.lowest {
+		return errors.New(invalidPortRange(r.String()))
+	}
+	return nil
+}
+
+func (r PortRange) String() string {
+	switch {
+	case r.Empty():
+		return ""
+	case r.lowest == r.highest:
+		return fmt.Sprintf("%d", r.lowest)
+	default:
+		return fmt.Sprintf("%d-%d", r.lowest, r.highest)
+	}
+}
+
+func (r *PortRange) Set(value string) error {
+	return r.UnmarshalText([]byte(value))
+}
+
+func (PortRange) Type() string {
+	return "portOrRange"
+}
+
+func (r *PortRange) UnmarshalText(text []byte) error {
+	value, err := ParsePortRange(string(text))
+	if err != nil {
+		return err
+	}
+	*r = *value
+	return nil
+}
+
+// ParsePortRange parses a string representation of the PortRange.
+//
+// Valid values include:
+// "8080"      - represents a PortRange{8080, 8080}
+// "8080-8081" - represents a PortRange{8080, 8081}
+// "8080-"     - represents a PortRange{8080, 65535}
+// "-8080"     - represents a PortRange{1, 8080}
+// ""          - represents an empty port range
+// "-"         - represents an empty port range
+func ParsePortRange(text string) (*PortRange, error) {
+	// split into left and right bounds
+	left, right := "", ""
+	parts := strings.Split(text, "-")
+	switch len(parts) {
+	case 1:
+		left, right = parts[0], parts[0]
+	case 2:
+		left, right = parts[0], parts[1]
+	default:
+		return nil, errors.New(invalidPortRange(text))
+	}
+	if left == "" && right == "" {
+		// empty port range
+		return NewPortRange(0, 0)
+	}
+	// parse input values
+	lowest, highest := uint32(0), uint32(0)
+	var err error
+	lowest, err = parsePortOrDefault(left, MinPort)
+	if err != nil {
+		return nil, errors.Wrapf(err, invalidPortRange(text))
+	}
+	highest, err = parsePortOrDefault(right, MaxPort)
+	if err != nil {
+		return nil, errors.Wrapf(err, invalidPortRange(text))
+	}
+	// convert into a range
+	r, err := NewPortRange(lowest, highest)
+	if err != nil || r.Empty() {
+		return nil, errors.New(invalidPortRange(text))
+	}
+	return r, nil
+}
+
+func parsePortOrDefault(text string, defaultValue uint32) (uint32, error) {
+	if text == "" {
+		return defaultValue, nil
+	} else {
+		if value, err := strconv.ParseUint(text, 10, 32); err != nil {
+			return 0, err
+		} else {
+			return uint32(value), nil
+		}
+	}
+}
+
+func invalidPortRange(text string) string {
+	return fmt.Sprintf(`invalid value %q. %s`, text, `Valid port range formats: "8080", "8080-8081", "8080-", "-8080", "" (empty range), "-" (empty range). Valid port values are 1-65535.`)
+}

--- a/pkg/config/types/portrange_test.go
+++ b/pkg/config/types/portrange_test.go
@@ -1,0 +1,400 @@
+package types_test
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/ginkgo/extensions/table"
+	. "github.com/onsi/gomega"
+
+	. "github.com/Kong/kuma/pkg/config/types"
+)
+
+var _ = Describe("ParsePortRange()", func() {
+	Describe("happy paths", func() {
+		type testCase struct {
+			input    string
+			expected PortRange
+		}
+
+		DescribeTable("should parse valid text representations",
+			func(given testCase) {
+				// when
+				actual, err := ParsePortRange(given.input)
+				// then
+				Expect(err).ToNot(HaveOccurred())
+				// and
+				Expect(*actual).To(Equal(given.expected))
+			},
+			Entry("", testCase{
+				input:    ``,
+				expected: MustPortRange(0, 0),
+			}),
+			Entry("-", testCase{
+				input:    `-`,
+				expected: MustPortRange(0, 0),
+			}),
+			Entry("8080", testCase{
+				input:    `8080`,
+				expected: MustPortRange(8080, 8080),
+			}),
+			Entry("8080-8081", testCase{
+				input:    `8080-8081`,
+				expected: MustPortRange(8080, 8081),
+			}),
+			Entry("-8080", testCase{
+				input:    `-8080`,
+				expected: MustPortRange(1, 8080),
+			}),
+			Entry("8080-", testCase{
+				input:    `8080-`,
+				expected: MustPortRange(8080, 65535),
+			}),
+		)
+	})
+
+	Describe("error paths", func() {
+		type testCase struct {
+			input       string
+			expectedErr string
+		}
+
+		DescribeTable("should fail to parse invalid text representations",
+			func(given testCase) {
+				// when
+				actual, err := ParsePortRange(given.input)
+				// then
+				Expect(actual).To(BeNil())
+				// and
+				Expect(err.Error()).To(ContainSubstring(given.expectedErr))
+			},
+			Entry("0", testCase{
+				input:       `0`,
+				expectedErr: `invalid value "0". Valid port range formats: "8080", "8080-8081", "8080-", "-8080", "" (empty range), "-" (empty range). Valid port values are 1-65535.`,
+			}),
+			Entry("0-", testCase{
+				input:       `0-`,
+				expectedErr: `invalid value "0-". Valid port range formats: "8080", "8080-8081", "8080-", "-8080", "" (empty range), "-" (empty range). Valid port values are 1-65535.`,
+			}),
+			Entry("-0", testCase{
+				input:       `-0`,
+				expectedErr: `invalid value "-0". Valid port range formats: "8080", "8080-8081", "8080-", "-8080", "" (empty range), "-" (empty range). Valid port values are 1-65535.`,
+			}),
+			Entry("0-8080", testCase{
+				input:       `0-8080`,
+				expectedErr: `invalid value "0-8080". Valid port range formats: "8080", "8080-8081", "8080-", "-8080", "" (empty range), "-" (empty range). Valid port values are 1-65535.`,
+			}),
+			Entry("8080-0", testCase{
+				input:       `8080-0`,
+				expectedErr: `invalid value "8080-0". Valid port range formats: "8080", "8080-8081", "8080-", "-8080", "" (empty range), "-" (empty range). Valid port values are 1-65535.`,
+			}),
+			Entry("82345", testCase{
+				input:       `82345`,
+				expectedErr: `invalid value "82345". Valid port range formats: "8080", "8080-8081", "8080-", "-8080", "" (empty range), "-" (empty range). Valid port values are 1-65535.`,
+			}),
+			Entry("-1-2", testCase{
+				input:       `-1-2`,
+				expectedErr: `invalid value "-1-2". Valid port range formats: "8080", "8080-8081", "8080-", "-8080", "" (empty range), "-" (empty range). Valid port values are 1-65535.`,
+			}),
+			Entry("1-2-", testCase{
+				input:       `1-2-`,
+				expectedErr: `invalid value "1-2-". Valid port range formats: "8080", "8080-8081", "8080-", "-8080", "" (empty range), "-" (empty range). Valid port values are 1-65535.`,
+			}),
+			Entry("1and2", testCase{
+				input:       `1and2`,
+				expectedErr: `invalid value "1and2". Valid port range formats: "8080", "8080-8081", "8080-", "-8080", "" (empty range), "-" (empty range). Valid port values are 1-65535.`,
+			}),
+			Entry("1one-2", testCase{
+				input:       `1one-2`,
+				expectedErr: `invalid value "1one-2". Valid port range formats: "8080", "8080-8081", "8080-", "-8080", "" (empty range), "-" (empty range). Valid port values are 1-65535.`,
+			}),
+			Entry("1-2two", testCase{
+				input:       `1-2two`,
+				expectedErr: `invalid value "1-2two". Valid port range formats: "8080", "8080-8081", "8080-", "-8080", "" (empty range), "-" (empty range). Valid port values are 1-65535.`,
+			}),
+			Entry("8081-8080", testCase{
+				input:       `8081-8080`,
+				expectedErr: `invalid value "8081-8080". Valid port range formats: "8080", "8080-8081", "8080-", "-8080", "" (empty range), "-" (empty range). Valid port values are 1-65535.`,
+			}),
+		)
+	})
+})
+
+var _ = Describe("MustExactPort()", func() {
+	Describe("happy paths", func() {
+		type testCase struct {
+			port uint32
+		}
+
+		DescribeTable("should create a range that consists of a single port",
+			func(given testCase) {
+				// when
+				actual := MustExactPort(given.port)
+				// then
+				Expect(actual.Empty()).To(Equal(given.port == 0))
+				Expect(actual.Lowest()).To(Equal(given.port))
+				Expect(actual.Highest()).To(Equal(given.port))
+			},
+			Entry("0", testCase{
+				port: 0,
+			}),
+			Entry("1", testCase{
+				port: 1,
+			}),
+			Entry("8080", testCase{
+				port: 8080,
+			}),
+		)
+	})
+
+	Describe("error paths", func() {
+		type testCase struct {
+			port uint32
+		}
+
+		DescribeTable("should fail to create a range of invalid port",
+			func(given testCase) {
+				Expect(func() { MustExactPort(given.port) }).To(Panic())
+			},
+			Entry("78901", testCase{
+				port: 78901,
+			}),
+		)
+	})
+})
+
+var _ = Describe("MustPortRange()", func() {
+	Describe("happy paths", func() {
+		type testCase struct {
+			lowest  uint32
+			highest uint32
+		}
+
+		DescribeTable("should create a valid range",
+			func(given testCase) {
+				// when
+				actual := MustPortRange(given.lowest, given.highest)
+				// then
+				Expect(actual.Empty()).To(Equal(given.lowest == 0 && given.highest == 0))
+				Expect(actual.Lowest()).To(Equal(given.lowest))
+				Expect(actual.Highest()).To(Equal(given.highest))
+			},
+			Entry("0, 0", testCase{
+				lowest:  0,
+				highest: 0,
+			}),
+			Entry("8080, 8080", testCase{
+				lowest:  8080,
+				highest: 8080,
+			}),
+			Entry("8080, 8081", testCase{
+				lowest:  8080,
+				highest: 8081,
+			}),
+		)
+	})
+
+	Describe("error paths", func() {
+		type testCase struct {
+			lowest  uint32
+			highest uint32
+		}
+
+		DescribeTable("should fail to create an invalid range",
+			func(given testCase) {
+				Expect(func() { MustPortRange(given.lowest, given.highest) }).To(Panic())
+			},
+			Entry("8081, 8080", testCase{
+				lowest:  8081,
+				highest: 8080,
+			}),
+			Entry("1, 70000", testCase{
+				lowest:  1,
+				highest: 70000,
+			}),
+		)
+	})
+})
+
+var _ = Describe("PortRange", func() {
+	Describe("String()", func() {
+		type testCase struct {
+			lowest   uint32
+			highest  uint32
+			expected string
+		}
+
+		DescribeTable("should format port range properly",
+			func(given testCase) {
+				// given
+				r := MustPortRange(given.lowest, given.highest)
+				// when
+				actual := r.String()
+				// then
+				Expect(actual).To(Equal(given.expected))
+			},
+			Entry("0, 0", testCase{
+				lowest:   0,
+				highest:  0,
+				expected: ``,
+			}),
+			Entry("8080, 8080", testCase{
+				lowest:   8080,
+				highest:  8080,
+				expected: `8080`,
+			}),
+			Entry("8080, 8081", testCase{
+				lowest:   8080,
+				highest:  8081,
+				expected: `8080-8081`,
+			}),
+		)
+	})
+
+	Describe("UnmarshalText()", func() {
+		Describe("happy paths", func() {
+			type testCase struct {
+				input    string
+				expected PortRange
+			}
+
+			DescribeTable("should unmarshal a valid range",
+				func(given testCase) {
+					// given
+					r := PortRange{}
+					// when
+					err := r.UnmarshalText([]byte(given.input))
+					// then
+					Expect(err).ToNot(HaveOccurred())
+					// and
+					Expect(r).To(Equal(given.expected))
+				},
+				Entry("", testCase{
+					input:    ``,
+					expected: PortRange{},
+				}),
+				Entry("8080", testCase{
+					input:    `8080`,
+					expected: MustExactPort(8080),
+				}),
+				Entry("8080-8081", testCase{
+					input:    `8080-8081`,
+					expected: MustPortRange(8080, 8081),
+				}),
+			)
+		})
+
+		Describe("error paths", func() {
+			type testCase struct {
+				input       string
+				expectedErr string
+			}
+
+			DescribeTable("should unmarshal a valid range",
+				func(given testCase) {
+					// given
+					r := PortRange{}
+					// when
+					err := r.UnmarshalText([]byte(given.input))
+					// then
+					Expect(err.Error()).To(ContainSubstring(given.expectedErr))
+				},
+				Entry("0", testCase{
+					input:       `0`,
+					expectedErr: `invalid value "0". Valid port range formats: "8080", "8080-8081", "8080-", "-8080", "" (empty range), "-" (empty range). Valid port values are 1-65535.`,
+				}),
+				Entry("8081-8080", testCase{
+					input:       `8081-8080`,
+					expectedErr: `invalid value "8081-8080". Valid port range formats: "8080", "8080-8081", "8080-", "-8080", "" (empty range), "-" (empty range). Valid port values are 1-65535.`,
+				}),
+				Entry("78901", testCase{
+					input:       `78901`,
+					expectedErr: `invalid value "78901". Valid port range formats: "8080", "8080-8081", "8080-", "-8080", "" (empty range), "-" (empty range). Valid port values are 1-65535.`,
+				}),
+			)
+		})
+	})
+
+	Describe("Set()", func() {
+		Describe("happy paths", func() {
+			type testCase struct {
+				input    string
+				expected PortRange
+			}
+
+			DescribeTable("should unmarshal a valid range",
+				func(given testCase) {
+					// given
+					r := PortRange{}
+					// when
+					err := r.Set(given.input)
+					// then
+					Expect(err).ToNot(HaveOccurred())
+					// and
+					Expect(r).To(Equal(given.expected))
+				},
+				Entry("", testCase{
+					input:    ``,
+					expected: PortRange{},
+				}),
+				Entry("8080", testCase{
+					input:    `8080`,
+					expected: MustExactPort(8080),
+				}),
+				Entry("8080-8081", testCase{
+					input:    `8080-8081`,
+					expected: MustPortRange(8080, 8081),
+				}),
+			)
+		})
+
+		Describe("error paths", func() {
+			type testCase struct {
+				input       string
+				expectedErr string
+			}
+
+			DescribeTable("should unmarshal a valid range",
+				func(given testCase) {
+					// given
+					r := PortRange{}
+					// when
+					err := r.Set(given.input)
+					// then
+					Expect(err.Error()).To(ContainSubstring(given.expectedErr))
+				},
+				Entry("0", testCase{
+					input:       `0`,
+					expectedErr: `invalid value "0". Valid port range formats: "8080", "8080-8081", "8080-", "-8080", "" (empty range), "-" (empty range). Valid port values are 1-65535.`,
+				}),
+				Entry("8081-8080", testCase{
+					input:       `8081-8080`,
+					expectedErr: `invalid value "8081-8080". Valid port range formats: "8080", "8080-8081", "8080-", "-8080", "" (empty range), "-" (empty range). Valid port values are 1-65535.`,
+				}),
+				Entry("78901", testCase{
+					input:       `78901`,
+					expectedErr: `invalid value "78901". Valid port range formats: "8080", "8080-8081", "8080-", "-8080", "" (empty range), "-" (empty range). Valid port values are 1-65535.`,
+				}),
+			)
+		})
+	})
+
+	Describe("Type()", func() {
+		type testCase struct {
+			input PortRange
+		}
+
+		DescribeTable("should always return `portOrRange`",
+			func(given testCase) {
+				Expect(given.input.Type()).To(Equal(`portOrRange`))
+			},
+			Entry("", testCase{
+				input: PortRange{},
+			}),
+			Entry("8080", testCase{
+				input: MustExactPort(8080),
+			}),
+			Entry("8080-8081", testCase{
+				input: MustPortRange(8080, 8081),
+			}),
+		)
+	})
+})

--- a/pkg/config/types/types_suite_test.go
+++ b/pkg/config/types/types_suite_test.go
@@ -1,0 +1,13 @@
+package types_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+func TestPflag(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Types Suite")
+}

--- a/pkg/test/network.go
+++ b/pkg/test/network.go
@@ -1,14 +1,22 @@
 package test
 
-import "net"
+import (
+	"fmt"
+	"net"
+)
 
 func GetFreePort() (int, error) {
-	ln, err := net.Listen("tcp", ":0")
+	port, err := FindFreePort("")
+	return int(port), err
+}
+
+func FindFreePort(ip string) (uint32, error) {
+	ln, err := net.Listen("tcp", fmt.Sprintf("%s:0", ip))
 	if err != nil {
 		return 0, err
 	}
 	if err := ln.Close(); err != nil {
 		return 0, err
 	}
-	return ln.Addr().(*net.TCPAddr).Port, nil
+	return uint32(ln.Addr().(*net.TCPAddr).Port), nil
 }

--- a/pkg/util/net/net_suite_test.go
+++ b/pkg/util/net/net_suite_test.go
@@ -1,0 +1,13 @@
+package net_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+func TestNet(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Net Suite")
+}

--- a/pkg/util/net/tcpsock.go
+++ b/pkg/util/net/tcpsock.go
@@ -1,0 +1,34 @@
+package net
+
+import (
+	"fmt"
+	"net"
+)
+
+func PickTCPPort(ip string, leftPort, rightPort uint32) (actualPort uint32, err error) {
+	lowestPort, highestPort := leftPort, rightPort
+	if highestPort < lowestPort {
+		lowestPort, highestPort = highestPort, lowestPort
+	}
+	// we prefer a port to remain stable over time, that's why we do sequential availability check
+	// instead of random selection
+	for port := lowestPort; port <= highestPort; port++ {
+		if actualPort, err = ReserveTCPAddr(fmt.Sprintf("%s:%d", ip, port)); err == nil {
+			return actualPort, nil
+		}
+	}
+	return 0, err
+}
+
+func ReserveTCPAddr(address string) (uint32, error) {
+	addr, err := net.ResolveTCPAddr("tcp", address)
+	if err != nil {
+		return 0, err
+	}
+	l, err := net.ListenTCP("tcp", addr)
+	if err != nil {
+		return 0, err
+	}
+	defer l.Close()
+	return uint32(l.Addr().(*net.TCPAddr).Port), nil
+}

--- a/pkg/util/net/tcpsock_test.go
+++ b/pkg/util/net/tcpsock_test.go
@@ -1,0 +1,196 @@
+package net_test
+
+import (
+	"fmt"
+	"net"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/ginkgo/extensions/table"
+	. "github.com/onsi/gomega"
+
+	. "github.com/Kong/kuma/pkg/util/net"
+
+	"github.com/Kong/kuma/pkg/test"
+)
+
+var _ = Describe("ReserveTCPAddr()", func() {
+	It("should successfully reserve a free TCP address (ip + port)", func() {
+		// given
+		loopback := "127.0.0.1"
+
+		// setup
+		freePort, err := test.FindFreePort(loopback)
+		Expect(err).ToNot(HaveOccurred())
+		// and
+		address := fmt.Sprintf("%s:%d", loopback, freePort)
+
+		// when
+		actualPort, err := ReserveTCPAddr(address)
+		// then
+		Expect(err).ToNot(HaveOccurred())
+		// and
+		Expect(actualPort).To(Equal(freePort))
+	})
+
+	It("should fail to reserve a TCP address already in use (ip + port)", func() {
+		// given
+		loopback := "127.0.0.1"
+
+		// setup
+		freePort, err := test.FindFreePort(loopback)
+		Expect(err).ToNot(HaveOccurred())
+		// and
+		address := fmt.Sprintf("%s:%d", loopback, freePort)
+
+		By("simulating another Envoy instance that already uses this port")
+		// when
+		l, err := net.Listen("tcp", address)
+		// then
+		Expect(err).ToNot(HaveOccurred())
+		// and
+		defer l.Close()
+
+		// when
+		actualPort, err := ReserveTCPAddr(address)
+		// then
+		Expect(err.Error()).To(ContainSubstring(`bind: address already in use`))
+		// and
+		Expect(actualPort).To(Equal(uint32(0)))
+	})
+})
+
+var _ = Describe("PickTCPPort()", func() {
+
+	It("should be able to pick the 1st port in the range", func() {
+		// given
+		loopback := "127.0.0.1"
+
+		// setup
+		freePort, err := test.FindFreePort(loopback)
+		Expect(err).ToNot(HaveOccurred())
+
+		// when
+		actualPort, err := PickTCPPort(loopback, freePort, freePort)
+		// then
+		Expect(err).ToNot(HaveOccurred())
+		// and
+		Expect(actualPort).To(Equal(freePort))
+	})
+
+	Describe("should be able to pick the Nth port in the range", func() {
+
+		// given
+		loopback := "127.0.0.1"
+
+		findFreePortRange := func(n uint32) (lowestPort uint32, highestPort uint32) {
+			Expect(n).To(BeNumerically(">", 0))
+		attempts:
+			for a := 0; a < 65535; a++ {
+				// first port in a range
+				freePort, err := test.FindFreePort(loopback)
+				Expect(err).ToNot(HaveOccurred())
+
+				// next n-1 ports in that range
+				for i := uint32(1); i < n; i++ {
+					address := fmt.Sprintf("%s:%d", loopback, freePort+i)
+					if _, err := ReserveTCPAddr(address); err != nil {
+						continue attempts
+					}
+				}
+
+				return freePort, freePort + n - 1
+			}
+			Fail(fmt.Sprintf(`unable to find "%d" free ports in a row`, n))
+			return
+		}
+
+		type testCase struct {
+			n uint32
+		}
+
+		testSet := func(n uint32) []TableEntry {
+			cases := make([]TableEntry, 0, n)
+			for i := uint32(2); i <= n; i++ {
+				cases = append(cases, Entry(fmt.Sprintf("%d", i), testCase{n: i}))
+			}
+			return cases
+		}
+
+		DescribeTable("should be able to pick the Nth port in the range",
+			func(given testCase) {
+				By("finding N consecutive free ports in a row")
+				lowestPort, highestPort := findFreePortRange(given.n)
+
+				By("simulating another Envoy instances using first N-1 ports")
+				for i := uint32(0); i < given.n-1; i++ {
+					// given
+					address := fmt.Sprintf("%s:%d", loopback, lowestPort+i)
+					// when
+					l, err := net.Listen("tcp", address)
+					// then
+					Expect(err).ToNot(HaveOccurred())
+					// and
+					defer l.Close()
+				}
+
+				// when
+				actualPort, err := PickTCPPort(loopback, lowestPort, highestPort)
+				// then
+				Expect(err).ToNot(HaveOccurred())
+				// and
+				Expect(actualPort).To(Equal(highestPort))
+			},
+			testSet(10)...,
+		)
+	})
+
+	It("should fail to pick a free port when all ports in the range are in use", func() {
+		// given
+		loopback := "127.0.0.1"
+
+		// setup
+		freePort, err := test.FindFreePort(loopback)
+		Expect(err).ToNot(HaveOccurred())
+		// and
+		address := fmt.Sprintf("%s:%d", loopback, freePort)
+
+		By("simulating another Envoy instance that already uses this port")
+		// when
+		l, err := net.Listen("tcp", address)
+		// then
+		Expect(err).ToNot(HaveOccurred())
+		// and
+		defer l.Close()
+
+		// when
+		actualPort, err := PickTCPPort(loopback, freePort, freePort)
+		// then
+		Expect(err.Error()).To(ContainSubstring(`bind: address already in use`))
+		// and
+		Expect(actualPort).To(Equal(uint32(0)))
+	})
+
+	It("should be able to pick a random port", func() {
+		// given
+		loopback := "127.0.0.1"
+
+		// when
+		actualPort, err := PickTCPPort(loopback, 0, 0)
+		// then
+		Expect(err).ToNot(HaveOccurred())
+		// and
+		Expect(actualPort).ToNot(Equal(uint32(0)))
+	})
+
+	It("should re-order port range bounds if necessary", func() {
+		// given
+		loopback := "127.0.0.1"
+
+		// when
+		actualPort, err := PickTCPPort(loopback, 1, 0)
+		// then
+		Expect(err).ToNot(HaveOccurred())
+		// and
+		Expect(actualPort).ToNot(Equal(uint32(0)))
+	})
+})


### PR DESCRIPTION
### Summary

* `kuma-dp`
   * enable `Envoy Admin API` by default with an option to opt out
   * `--admin-port` option now accepts a port or range of ports to choose from, e.g.
     * `9901`
     * `9901-9999`
     * `9901-`
     * `-9901`
   * the default value of `--admin-port` has changed from `` (empty) to `30001-65535`
   * on startup, `kuma-dp` will pick the first available port from the range
