### PR TITLE
refactoring: make `Resource` types reusable by both primary ADS server and future MADS server

### DIFF
--- a/pkg/core/xds/resource.go
+++ b/pkg/core/xds/resource.go
@@ -1,7 +1,12 @@
 package xds
 
 import (
+	"github.com/golang/protobuf/ptypes"
+
+	envoy "github.com/envoyproxy/go-control-plane/envoy/api/v2"
 	envoy_cache "github.com/envoyproxy/go-control-plane/pkg/cache"
+
+	util_error "github.com/Kong/kuma/pkg/util/error"
 )
 
 // ResourcePayload is a convenience type alias.
@@ -12,4 +17,21 @@ type Resource struct {
 	Name     string
 	Version  string
 	Resource ResourcePayload
+}
+
+// ResourceList represents a list of generic xDS resources.
+type ResourceList []*Resource
+
+func (rs ResourceList) ToDeltaDiscoveryResponse() *envoy.DeltaDiscoveryResponse {
+	resp := &envoy.DeltaDiscoveryResponse{}
+	for _, r := range rs {
+		pbany, err := ptypes.MarshalAny(r.Resource)
+		util_error.MustNot(err)
+		resp.Resources = append(resp.Resources, &envoy.Resource{
+			Name:     r.Name,
+			Version:  r.Version,
+			Resource: pbany,
+		})
+	}
+	return resp
 }

--- a/pkg/core/xds/resource.go
+++ b/pkg/core/xds/resource.go
@@ -1,0 +1,15 @@
+package xds
+
+import (
+	envoy_cache "github.com/envoyproxy/go-control-plane/pkg/cache"
+)
+
+// ResourcePayload is a convenience type alias.
+type ResourcePayload = envoy_cache.Resource
+
+// Resource represents a generic xDS resource with name and version.
+type Resource struct {
+	Name     string
+	Version  string
+	Resource ResourcePayload
+}

--- a/pkg/core/xds/resource_test.go
+++ b/pkg/core/xds/resource_test.go
@@ -1,12 +1,10 @@
-package generator_test
+package xds_test
 
 import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 
-	. "github.com/Kong/kuma/pkg/xds/generator"
-
-	core_xds "github.com/Kong/kuma/pkg/core/xds"
+	. "github.com/Kong/kuma/pkg/core/xds"
 
 	envoy "github.com/envoyproxy/go-control-plane/envoy/api/v2"
 )
@@ -22,7 +20,7 @@ var _ = Describe("ResourceSet", func() {
 
 	It("set of 1 element should return a list of 1 element", func() {
 		// given
-		resource := &core_xds.Resource{
+		resource := &Resource{
 			Name:    "backend",
 			Version: "v1",
 			Resource: &envoy.Cluster{
@@ -40,14 +38,14 @@ var _ = Describe("ResourceSet", func() {
 
 	It("set of 2 elements should return a list of 2 elements", func() {
 		// given
-		resource1 := &core_xds.Resource{
+		resource1 := &Resource{
 			Name:    "backend",
 			Version: "v1",
 			Resource: &envoy.Cluster{
 				Name: "backend",
 			},
 		}
-		resource2 := &core_xds.Resource{
+		resource2 := &Resource{
 			Name:    "outbound:127.0.0.1:8080",
 			Version: "v2",
 			Resource: &envoy.Listener{
@@ -68,14 +66,14 @@ var _ = Describe("ResourceSet", func() {
 
 	It("should not be possible to add 2 resources with same name and type", func() {
 		// given
-		resource1 := &core_xds.Resource{
+		resource1 := &Resource{
 			Name:    "backend",
 			Version: "v1",
 			Resource: &envoy.Cluster{
 				Name: "backend",
 			},
 		}
-		resource2 := &core_xds.Resource{
+		resource2 := &Resource{
 			Name:    "backend",
 			Version: "v2",
 			Resource: &envoy.Cluster{
@@ -96,14 +94,14 @@ var _ = Describe("ResourceSet", func() {
 
 	It("should be possible to add 2 resources with same name but different types", func() {
 		// given
-		resource1 := &core_xds.Resource{
+		resource1 := &Resource{
 			Name:    "backend",
 			Version: "v1",
 			Resource: &envoy.Cluster{
 				Name: "backend",
 			},
 		}
-		resource2 := &core_xds.Resource{
+		resource2 := &Resource{
 			Name:    "backend",
 			Version: "v2",
 			Resource: &envoy.Listener{

--- a/pkg/xds/generator/inbound_proxy_generator_test.go
+++ b/pkg/xds/generator/inbound_proxy_generator_test.go
@@ -99,7 +99,7 @@ var _ = Describe("InboundProxyGenerator", func() {
 			Expect(err).ToNot(HaveOccurred())
 
 			// then
-			resp := generator.ResourceList(rs).ToDeltaDiscoveryResponse()
+			resp := model.ResourceList(rs).ToDeltaDiscoveryResponse()
 			actual, err := util_proto.ToYAML(resp)
 			Expect(err).ToNot(HaveOccurred())
 

--- a/pkg/xds/generator/outbound_proxy_generator_test.go
+++ b/pkg/xds/generator/outbound_proxy_generator_test.go
@@ -119,7 +119,7 @@ var _ = Describe("OutboundProxyGenerator", func() {
 			Expect(err).ToNot(HaveOccurred())
 
 			// then
-			resp := generator.ResourceList(rs).ToDeltaDiscoveryResponse()
+			resp := model.ResourceList(rs).ToDeltaDiscoveryResponse()
 			actual, err := util_proto.ToYAML(resp)
 			Expect(err).ToNot(HaveOccurred())
 

--- a/pkg/xds/generator/prometheus_endpoint_generator.go
+++ b/pkg/xds/generator/prometheus_endpoint_generator.go
@@ -23,7 +23,7 @@ import (
 type PrometheusEndpointGenerator struct {
 }
 
-func (g PrometheusEndpointGenerator) Generate(ctx xds_context.Context, proxy *core_xds.Proxy) ([]*Resource, error) {
+func (g PrometheusEndpointGenerator) Generate(ctx xds_context.Context, proxy *core_xds.Proxy) ([]*core_xds.Resource, error) {
 	meshLevelSettings := ctx.Mesh.Resource.Spec.Metrics.GetPrometheus()
 	if meshLevelSettings == nil {
 		// Prometheus metrics must be enabled Mesh-wide for Prometheus endpoint to be generated.
@@ -64,15 +64,15 @@ func (g PrometheusEndpointGenerator) Generate(ctx xds_context.Context, proxy *co
 	envoyAdminClusterName := envoyAdminClusterName()
 	prometheusListenerName := prometheusListenerName()
 	virtual := proxy.Dataplane.Spec.Networking.GetTransparentProxying().GetRedirectPort() != 0
-	return []*Resource{
+	return []*core_xds.Resource{
 		// CDS resource
-		&Resource{
+		&core_xds.Resource{
 			Name:     envoyAdminClusterName,
 			Version:  "",
 			Resource: envoy.CreateLocalCluster(envoyAdminClusterName, adminAddress, adminPort),
 		},
 		// LDS resource
-		&Resource{
+		&core_xds.Resource{
 			Name:     prometheusListenerName,
 			Version:  "",
 			Resource: envoy.CreatePrometheusListener(ctx, prometheusListenerName, prometheusEndpointAddress, prometheusEndpoint.Port, prometheusEndpoint.Path, envoyAdminClusterName, virtual, proxy.Metadata),

--- a/pkg/xds/generator/prometheus_endpoint_generator_test.go
+++ b/pkg/xds/generator/prometheus_endpoint_generator_test.go
@@ -140,7 +140,7 @@ var _ = Describe("PrometheusEndpointGenerator", func() {
 			Expect(err).ToNot(HaveOccurred())
 
 			// then
-			resp := generator.ResourceList(rs).ToDeltaDiscoveryResponse()
+			resp := model.ResourceList(rs).ToDeltaDiscoveryResponse()
 			actual, err := util_proto.ToYAML(resp)
 
 			Expect(err).ToNot(HaveOccurred())

--- a/pkg/xds/generator/proxy_template.go
+++ b/pkg/xds/generator/proxy_template.go
@@ -94,7 +94,7 @@ func (_ InboundProxyGenerator) Generate(ctx xds_context.Context, proxy *model.Pr
 		return nil, nil
 	}
 	virtual := proxy.Dataplane.Spec.Networking.GetTransparentProxying().GetRedirectPort() != 0
-	resources := &ResourceSet{}
+	resources := &model.ResourceSet{}
 	for _, endpoint := range endpoints {
 		// generate CDS resource
 		localClusterName := localClusterName(endpoint.WorkloadPort)
@@ -124,7 +124,7 @@ func (g OutboundProxyGenerator) Generate(ctx xds_context.Context, proxy *model.P
 		return nil, nil
 	}
 	virtual := proxy.Dataplane.Spec.Networking.GetTransparentProxying().GetRedirectPort() != 0
-	resources := &ResourceSet{}
+	resources := &model.ResourceSet{}
 	sourceService := proxy.Dataplane.Spec.GetIdentifyingService()
 	for i, oface := range ofaces {
 		endpoint, err := kuma_mesh.ParseOutboundInterface(oface.Interface)

--- a/pkg/xds/generator/proxy_template.go
+++ b/pkg/xds/generator/proxy_template.go
@@ -20,8 +20,8 @@ type TemplateProxyGenerator struct {
 	ProxyTemplate *kuma_mesh.ProxyTemplate
 }
 
-func (g *TemplateProxyGenerator) Generate(ctx xds_context.Context, proxy *model.Proxy) ([]*Resource, error) {
-	resources := make([]*Resource, 0, len(g.ProxyTemplate.GetConf().GetImports())+1)
+func (g *TemplateProxyGenerator) Generate(ctx xds_context.Context, proxy *model.Proxy) ([]*model.Resource, error) {
+	resources := make([]*model.Resource, 0, len(g.ProxyTemplate.GetConf().GetImports())+1)
 	for i, name := range g.ProxyTemplate.GetConf().GetImports() {
 		generator := &ProxyTemplateProfileSource{ProfileName: name}
 		if rs, err := generator.Generate(ctx, proxy); err != nil {
@@ -43,15 +43,15 @@ type ProxyTemplateRawSource struct {
 	Resources []*kuma_mesh.ProxyTemplateRawResource
 }
 
-func (s *ProxyTemplateRawSource) Generate(_ xds_context.Context, proxy *model.Proxy) ([]*Resource, error) {
-	resources := make([]*Resource, 0, len(s.Resources))
+func (s *ProxyTemplateRawSource) Generate(_ xds_context.Context, proxy *model.Proxy) ([]*model.Resource, error) {
+	resources := make([]*model.Resource, 0, len(s.Resources))
 	for i, r := range s.Resources {
 		res, err := util_envoy.ResourceFromYaml(r.Resource)
 		if err != nil {
 			return nil, fmt.Errorf("raw.resources[%d]{name=%q}.resource: %s", i, r.Name, err)
 		}
 
-		resources = append(resources, &Resource{
+		resources = append(resources, &model.Resource{
 			Name:     r.Name,
 			Version:  r.Version,
 			Resource: res,
@@ -74,7 +74,7 @@ type ProxyTemplateProfileSource struct {
 	ProfileName string
 }
 
-func (s *ProxyTemplateProfileSource) Generate(ctx xds_context.Context, proxy *model.Proxy) ([]*Resource, error) {
+func (s *ProxyTemplateProfileSource) Generate(ctx xds_context.Context, proxy *model.Proxy) ([]*model.Resource, error) {
 	g, ok := predefinedProfiles[s.ProfileName]
 	if !ok {
 		return nil, fmt.Errorf("profile{name=%q}: unknown profile", s.ProfileName)
@@ -85,7 +85,7 @@ func (s *ProxyTemplateProfileSource) Generate(ctx xds_context.Context, proxy *mo
 type InboundProxyGenerator struct {
 }
 
-func (_ InboundProxyGenerator) Generate(ctx xds_context.Context, proxy *model.Proxy) ([]*Resource, error) {
+func (_ InboundProxyGenerator) Generate(ctx xds_context.Context, proxy *model.Proxy) ([]*model.Resource, error) {
 	endpoints, err := proxy.Dataplane.Spec.Networking.GetInboundInterfaces()
 	if err != nil {
 		return nil, err
@@ -98,7 +98,7 @@ func (_ InboundProxyGenerator) Generate(ctx xds_context.Context, proxy *model.Pr
 	for _, endpoint := range endpoints {
 		// generate CDS resource
 		localClusterName := localClusterName(endpoint.WorkloadPort)
-		resources.Add(&Resource{
+		resources.Add(&model.Resource{
 			Name:     localClusterName,
 			Version:  "",
 			Resource: envoy.CreateLocalCluster(localClusterName, "127.0.0.1", endpoint.WorkloadPort),
@@ -106,7 +106,7 @@ func (_ InboundProxyGenerator) Generate(ctx xds_context.Context, proxy *model.Pr
 
 		// generate LDS resource
 		inboundListenerName := localListenerName(endpoint.DataplaneIP, endpoint.DataplanePort)
-		resources.Add(&Resource{
+		resources.Add(&model.Resource{
 			Name:     inboundListenerName,
 			Version:  "",
 			Resource: envoy.CreateInboundListener(ctx, inboundListenerName, endpoint.DataplaneIP, endpoint.DataplanePort, localClusterName, virtual, proxy.TrafficPermissions.Get(endpoint.String()), proxy.Metadata),
@@ -118,7 +118,7 @@ func (_ InboundProxyGenerator) Generate(ctx xds_context.Context, proxy *model.Pr
 type OutboundProxyGenerator struct {
 }
 
-func (g OutboundProxyGenerator) Generate(ctx xds_context.Context, proxy *model.Proxy) ([]*Resource, error) {
+func (g OutboundProxyGenerator) Generate(ctx xds_context.Context, proxy *model.Proxy) ([]*model.Resource, error) {
 	ofaces := proxy.Dataplane.Spec.Networking.GetOutbound()
 	if len(ofaces) == 0 {
 		return nil, nil
@@ -154,7 +154,7 @@ func (g OutboundProxyGenerator) Generate(ctx xds_context.Context, proxy *model.P
 		if err != nil {
 			return nil, errors.Wrapf(err, "%s: could not generate listener %s", validators.RootedAt("dataplane").Field("networking").Field("outbound").Index(i), outboundListenerName)
 		}
-		resources.Add(&Resource{
+		resources.Add(&model.Resource{
 			Name:     outboundListenerName,
 			Resource: listener,
 		})
@@ -181,16 +181,16 @@ func (_ OutboundProxyGenerator) determineClusters(ctx xds_context.Context, proxy
 	return
 }
 
-func (_ OutboundProxyGenerator) generateEds(ctx xds_context.Context, proxy *model.Proxy, clusters []envoy.ClusterInfo) (resources []*Resource) {
+func (_ OutboundProxyGenerator) generateEds(ctx xds_context.Context, proxy *model.Proxy, clusters []envoy.ClusterInfo) (resources []*model.Resource) {
 	for _, cluster := range clusters {
 		serviceName := cluster.Tags[kuma_mesh.ServiceTag]
 		healthCheck := proxy.HealthChecks[serviceName]
-		resources = append(resources, &Resource{
+		resources = append(resources, &model.Resource{
 			Name:     cluster.Name,
 			Resource: envoy.ClusterWithHealthChecks(envoy.CreateEdsCluster(ctx, cluster.Name, proxy.Metadata), healthCheck),
 		})
 		endpoints := model.EndpointList(proxy.OutboundTargets[serviceName]).Filter(kuma_mesh.MatchTags(cluster.Tags))
-		resources = append(resources, &Resource{
+		resources = append(resources, &model.Resource{
 			Name:     cluster.Name,
 			Resource: envoy.CreateClusterLoadAssignment(cluster.Name, endpoints),
 		})
@@ -201,18 +201,18 @@ func (_ OutboundProxyGenerator) generateEds(ctx xds_context.Context, proxy *mode
 type TransparentProxyGenerator struct {
 }
 
-func (_ TransparentProxyGenerator) Generate(ctx xds_context.Context, proxy *model.Proxy) ([]*Resource, error) {
+func (_ TransparentProxyGenerator) Generate(ctx xds_context.Context, proxy *model.Proxy) ([]*model.Resource, error) {
 	redirectPort := proxy.Dataplane.Spec.Networking.GetTransparentProxying().GetRedirectPort()
 	if redirectPort == 0 {
 		return nil, nil
 	}
-	return []*Resource{
-		&Resource{
+	return []*model.Resource{
+		&model.Resource{
 			Name:     "catch_all",
 			Version:  proxy.Dataplane.Meta.GetVersion(),
 			Resource: envoy.CreateCatchAllListener(ctx, "catch_all", "0.0.0.0", redirectPort, "pass_through"),
 		},
-		&Resource{
+		&model.Resource{
 			Name:     "pass_through",
 			Version:  proxy.Dataplane.Meta.GetVersion(),
 			Resource: envoy.CreatePassThroughCluster("pass_through"),

--- a/pkg/xds/generator/proxy_template_profile_source_test.go
+++ b/pkg/xds/generator/proxy_template_profile_source_test.go
@@ -118,7 +118,7 @@ var _ = Describe("ProxyTemplateProfileSource", func() {
 			Expect(err).ToNot(HaveOccurred())
 
 			// then
-			resp := generator.ResourceList(rs).ToDeltaDiscoveryResponse()
+			resp := model.ResourceList(rs).ToDeltaDiscoveryResponse()
 			actual, err := util_proto.ToYAML(resp)
 			Expect(err).ToNot(HaveOccurred())
 

--- a/pkg/xds/generator/proxy_template_raw_source_test.go
+++ b/pkg/xds/generator/proxy_template_raw_source_test.go
@@ -210,7 +210,7 @@ var _ = Describe("ProxyTemplateRawSource", func() {
 			Expect(err).ToNot(HaveOccurred())
 
 			// then
-			resp := generator.ResourceList(rs).ToDeltaDiscoveryResponse()
+			resp := model.ResourceList(rs).ToDeltaDiscoveryResponse()
 			actual, err := util_proto.ToYAML(resp)
 
 			Expect(err).ToNot(HaveOccurred())

--- a/pkg/xds/generator/proxy_template_test.go
+++ b/pkg/xds/generator/proxy_template_test.go
@@ -145,7 +145,7 @@ var _ = Describe("TemplateProxyGenerator", func() {
 				Expect(err).ToNot(HaveOccurred())
 
 				// then
-				resp := generator.ResourceList(rs).ToDeltaDiscoveryResponse()
+				resp := model.ResourceList(rs).ToDeltaDiscoveryResponse()
 				actual, err := util_proto.ToYAML(resp)
 				Expect(err).ToNot(HaveOccurred())
 

--- a/pkg/xds/generator/resource_generator.go
+++ b/pkg/xds/generator/resource_generator.go
@@ -2,12 +2,9 @@ package generator
 
 import (
 	"github.com/golang/protobuf/proto"
-	"github.com/golang/protobuf/ptypes"
 
 	model "github.com/Kong/kuma/pkg/core/xds"
-	util_error "github.com/Kong/kuma/pkg/util/error"
 	xds_context "github.com/Kong/kuma/pkg/xds/context"
-	envoy "github.com/envoyproxy/go-control-plane/envoy/api/v2"
 )
 
 type ResourceGenerator interface {
@@ -26,22 +23,6 @@ func (c CompositeResourceGenerator) Generate(ctx xds_context.Context, proxy *mod
 		resources = append(resources, rs...)
 	}
 	return resources, nil
-}
-
-type ResourceList []*model.Resource
-
-func (rs ResourceList) ToDeltaDiscoveryResponse() *envoy.DeltaDiscoveryResponse {
-	resp := &envoy.DeltaDiscoveryResponse{}
-	for _, r := range rs {
-		pbany, err := ptypes.MarshalAny(r.Resource)
-		util_error.MustNot(err)
-		resp.Resources = append(resp.Resources, &envoy.Resource{
-			Name:     r.Name,
-			Version:  r.Version,
-			Resource: pbany,
-		})
-	}
-	return resp
 }
 
 type ResourceSet struct {

--- a/pkg/xds/generator/resource_generator.go
+++ b/pkg/xds/generator/resource_generator.go
@@ -1,8 +1,6 @@
 package generator
 
 import (
-	"github.com/golang/protobuf/proto"
-
 	model "github.com/Kong/kuma/pkg/core/xds"
 	xds_context "github.com/Kong/kuma/pkg/xds/context"
 )
@@ -23,50 +21,4 @@ func (c CompositeResourceGenerator) Generate(ctx xds_context.Context, proxy *mod
 		resources = append(resources, rs...)
 	}
 	return resources, nil
-}
-
-type ResourceSet struct {
-	// we want to keep resources in the order they were added
-	resources []*model.Resource
-	// we want to prevent duplicates
-	typeToNamesIndex map[string]map[string]bool
-}
-
-func (s *ResourceSet) Contains(name string, resource model.ResourcePayload) bool {
-	names, ok := s.typeToNamesIndex[s.typeName(resource)]
-	if !ok {
-		return false
-	}
-	_, ok = names[name]
-	return ok
-}
-
-func (s *ResourceSet) Add(resources ...*model.Resource) *ResourceSet {
-	for _, resource := range resources {
-		if s.Contains(resource.Name, resource.Resource) {
-			continue
-		}
-		s.resources = append(s.resources, resource)
-		s.index(resource)
-	}
-	return s
-}
-
-func (s *ResourceSet) typeName(resource model.ResourcePayload) string {
-	return proto.MessageName(resource)
-}
-
-func (s *ResourceSet) index(resource *model.Resource) {
-	if s.typeToNamesIndex == nil {
-		s.typeToNamesIndex = map[string]map[string]bool{}
-	}
-	typeName := s.typeName(resource.Resource)
-	if s.typeToNamesIndex[typeName] == nil {
-		s.typeToNamesIndex[typeName] = map[string]bool{}
-	}
-	s.typeToNamesIndex[typeName][resource.Name] = true
-}
-
-func (s *ResourceSet) List() []*model.Resource {
-	return s.resources
 }

--- a/pkg/xds/generator/resource_generator_test.go
+++ b/pkg/xds/generator/resource_generator_test.go
@@ -6,6 +6,8 @@ import (
 
 	. "github.com/Kong/kuma/pkg/xds/generator"
 
+	core_xds "github.com/Kong/kuma/pkg/core/xds"
+
 	envoy "github.com/envoyproxy/go-control-plane/envoy/api/v2"
 )
 
@@ -20,7 +22,7 @@ var _ = Describe("ResourceSet", func() {
 
 	It("set of 1 element should return a list of 1 element", func() {
 		// given
-		resource := &Resource{
+		resource := &core_xds.Resource{
 			Name:    "backend",
 			Version: "v1",
 			Resource: &envoy.Cluster{
@@ -38,14 +40,14 @@ var _ = Describe("ResourceSet", func() {
 
 	It("set of 2 elements should return a list of 2 elements", func() {
 		// given
-		resource1 := &Resource{
+		resource1 := &core_xds.Resource{
 			Name:    "backend",
 			Version: "v1",
 			Resource: &envoy.Cluster{
 				Name: "backend",
 			},
 		}
-		resource2 := &Resource{
+		resource2 := &core_xds.Resource{
 			Name:    "outbound:127.0.0.1:8080",
 			Version: "v2",
 			Resource: &envoy.Listener{
@@ -66,14 +68,14 @@ var _ = Describe("ResourceSet", func() {
 
 	It("should not be possible to add 2 resources with same name and type", func() {
 		// given
-		resource1 := &Resource{
+		resource1 := &core_xds.Resource{
 			Name:    "backend",
 			Version: "v1",
 			Resource: &envoy.Cluster{
 				Name: "backend",
 			},
 		}
-		resource2 := &Resource{
+		resource2 := &core_xds.Resource{
 			Name:    "backend",
 			Version: "v2",
 			Resource: &envoy.Cluster{
@@ -94,14 +96,14 @@ var _ = Describe("ResourceSet", func() {
 
 	It("should be possible to add 2 resources with same name but different types", func() {
 		// given
-		resource1 := &Resource{
+		resource1 := &core_xds.Resource{
 			Name:    "backend",
 			Version: "v1",
 			Resource: &envoy.Cluster{
 				Name: "backend",
 			},
 		}
-		resource2 := &Resource{
+		resource2 := &core_xds.Resource{
 			Name:    "backend",
 			Version: "v2",
 			Resource: &envoy.Listener{

--- a/pkg/xds/generator/transparent_proxy_generator_test.go
+++ b/pkg/xds/generator/transparent_proxy_generator_test.go
@@ -35,7 +35,7 @@ var _ = Describe("TransparentProxyGenerator", func() {
 			Expect(err).ToNot(HaveOccurred())
 
 			// then
-			resp := generator.ResourceList(rs).ToDeltaDiscoveryResponse()
+			resp := model.ResourceList(rs).ToDeltaDiscoveryResponse()
 			actual, err := util_proto.ToYAML(resp)
 
 			Expect(err).ToNot(HaveOccurred())


### PR DESCRIPTION
### Summary

* make `Resource` type reusable
* make `ResourceList` type reusable
* make `ResourceSet` type reusable


