### PR TITLE
kuma-cp: advertise MonitoringAssignment server via API Catalog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 Changes:
 
+* feature: advertise MonitoringAssignment server via API Catalog
+  [#534](https://github.com/Kong/kuma/pull/534)
 * feature: generate MonitoringAssignment for each Dataplane in a Mesh
   [#532](https://github.com/Kong/kuma/pull/532)
 * feature: add a Monitoring Assignment Discovery Service (MADS) server

--- a/pkg/api-server/catalog_ws_test.go
+++ b/pkg/api-server/catalog_ws_test.go
@@ -2,12 +2,13 @@ package api_server_test
 
 import (
 	"fmt"
+	"io/ioutil"
+	"net/http"
+
 	config "github.com/Kong/kuma/pkg/config/api-server"
 	"github.com/Kong/kuma/pkg/plugins/resources/memory"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
-	"io/ioutil"
-	"net/http"
 )
 
 var _ = Describe("Catalog WS", func() {
@@ -20,6 +21,7 @@ var _ = Describe("Catalog WS", func() {
 		cfg.Catalog.DataplaneToken.LocalUrl = "http://localhost:1111"
 		cfg.Catalog.DataplaneToken.PublicUrl = "https://kuma.internal:2222"
 		cfg.Catalog.Bootstrap.Url = "http://kuma.internal:3333"
+		cfg.Catalog.MonitoringAssignment.Url = "grpc://kuma.internal:4444"
 
 		// setup
 		resourceStore := memory.NewStore()
@@ -59,6 +61,9 @@ var _ = Describe("Catalog WS", func() {
 				"admin": {
 					"localUrl": "http://localhost:1111",
 					"publicUrl": "https://kuma.internal:2222"
+				},
+				"monitoringAssignment": {
+					"url": "grpc://kuma.internal:4444"
 				}
 			}
 		}

--- a/pkg/catalog/types.go
+++ b/pkg/catalog/types.go
@@ -9,9 +9,10 @@ type Catalog struct {
 }
 
 type Apis struct {
-	Bootstrap      BootstrapApi      `json:"bootstrap"`
-	DataplaneToken DataplaneTokenApi `json:"dataplaneToken"` // DEPRECATED: remove in next major version of Kuma
-	Admin          AdminApi          `json:"admin"`
+	Bootstrap            BootstrapApi            `json:"bootstrap"`
+	DataplaneToken       DataplaneTokenApi       `json:"dataplaneToken"` // DEPRECATED: remove in next major version of Kuma
+	Admin                AdminApi                `json:"admin"`
+	MonitoringAssignment MonitoringAssignmentApi `json:"monitoringAssignment"`
 }
 
 type AdminApi struct {
@@ -26,6 +27,10 @@ type BootstrapApi struct {
 type DataplaneTokenApi struct {
 	LocalUrl  string `json:"localUrl"`
 	PublicUrl string `json:"publicUrl"`
+}
+
+type MonitoringAssignmentApi struct {
+	Url string `json:"url"`
 }
 
 func (d *DataplaneTokenApi) Enabled() bool {
@@ -45,6 +50,9 @@ func FromConfig(cfg catalog.CatalogConfig) Catalog {
 			Admin: AdminApi{
 				LocalUrl:  cfg.Admin.LocalUrl,
 				PublicUrl: cfg.Admin.PublicUrl,
+			},
+			MonitoringAssignment: MonitoringAssignmentApi{
+				Url: cfg.MonitoringAssignment.Url,
 			},
 		},
 	}

--- a/pkg/config/api-server/catalog/config.go
+++ b/pkg/config/api-server/catalog/config.go
@@ -2,9 +2,10 @@ package catalog
 
 // Not yet exposed via YAML and env vars on purpose
 type CatalogConfig struct {
-	Bootstrap      BootstrapApiConfig
-	DataplaneToken DataplaneTokenApiConfig // DEPRECATED: remove in next major version of Kuma
-	Admin          AdminApiConfig
+	Bootstrap            BootstrapApiConfig
+	DataplaneToken       DataplaneTokenApiConfig // DEPRECATED: remove in next major version of Kuma
+	Admin                AdminApiConfig
+	MonitoringAssignment MonitoringAssignmentApiConfig
 }
 
 type BootstrapApiConfig struct {
@@ -19,4 +20,8 @@ type DataplaneTokenApiConfig struct {
 type AdminApiConfig struct {
 	LocalUrl  string
 	PublicUrl string
+}
+
+type MonitoringAssignmentApiConfig struct {
+	Url string
 }

--- a/pkg/core/bootstrap/autoconfig.go
+++ b/pkg/core/bootstrap/autoconfig.go
@@ -2,13 +2,14 @@ package bootstrap
 
 import (
 	"fmt"
+	"io/ioutil"
+	"os"
+	"reflect"
+
 	admin_server "github.com/Kong/kuma/pkg/config/admin-server"
 	"github.com/Kong/kuma/pkg/config/api-server/catalog"
 	gui_server "github.com/Kong/kuma/pkg/config/gui-server"
 	token_server "github.com/Kong/kuma/pkg/config/token-server"
-	"io/ioutil"
-	"os"
-	"reflect"
 
 	"github.com/pkg/errors"
 
@@ -35,6 +36,9 @@ func autoconfigureCatalog(cfg *kuma_cp.Config) {
 		},
 		Admin: catalog.AdminApiConfig{
 			LocalUrl: fmt.Sprintf("http://localhost:%d", cfg.AdminServer.Local.Port),
+		},
+		MonitoringAssignment: catalog.MonitoringAssignmentApiConfig{
+			Url: fmt.Sprintf("grpc://%s:%d", cfg.General.AdvertisedHostname, cfg.MonitoringAssignmentServer.GrpcPort),
 		},
 	}
 	if cfg.AdminServer.Public.Enabled {

--- a/pkg/core/bootstrap/autoconfig_test.go
+++ b/pkg/core/bootstrap/autoconfig_test.go
@@ -53,6 +53,9 @@ var _ = Describe("Auto configuration", func() {
 					LocalUrl:  "http://localhost:1111",
 					PublicUrl: "https://kuma.internal:2222",
 				},
+				MonitoringAssignment: catalog.MonitoringAssignmentApiConfig{
+					Url: "grpc://kuma.internal:5676",
+				},
 			},
 		}),
 		Entry("without public port explicitly defined", testCase{
@@ -77,6 +80,9 @@ var _ = Describe("Auto configuration", func() {
 					LocalUrl:  "http://localhost:1111",
 					PublicUrl: "https://kuma.internal:1111", // port is autoconfigured from the local port
 				},
+				MonitoringAssignment: catalog.MonitoringAssignmentApiConfig{
+					Url: "grpc://kuma.internal:5676",
+				},
 			},
 		}),
 		Entry("without public settings for dataplane token server", testCase{
@@ -99,6 +105,9 @@ var _ = Describe("Auto configuration", func() {
 					LocalUrl:  "http://localhost:1111",
 					PublicUrl: "",
 				},
+				MonitoringAssignment: catalog.MonitoringAssignmentApiConfig{
+					Url: "grpc://kuma.internal:5676",
+				},
 			},
 		}),
 		Entry("without dataplane token server", testCase{
@@ -118,6 +127,9 @@ var _ = Describe("Auto configuration", func() {
 				Admin: catalog.AdminApiConfig{
 					LocalUrl:  "http://localhost:5679",
 					PublicUrl: "",
+				},
+				MonitoringAssignment: catalog.MonitoringAssignmentApiConfig{
+					Url: "grpc://localhost:5676",
 				},
 			},
 		}),
@@ -200,5 +212,21 @@ var _ = Describe("Auto configuration", func() {
 		Expect(cfg.AdminServer.Public.Enabled).To(BeTrue())
 		Expect(cfg.AdminServer.Public.Port).To(Equal(uint32(2222)))
 		Expect(cfg.AdminServer.Local.Port).To(Equal(uint32(1111)))
+	})
+
+	It("should autoconfigure MonitoringAssignment server", func() {
+		// given
+		cfg := kuma_cp.DefaultConfig()
+		cfg.General.AdvertisedHostname = "kuma.internal"
+		cfg.MonitoringAssignmentServer.GrpcPort = 8765
+
+		// when
+		err := autoconfigure(&cfg)
+
+		// then
+		Expect(err).ToNot(HaveOccurred())
+
+		// and
+		Expect(cfg.ApiServer.Catalog.MonitoringAssignment.Url).To(Equal("grpc://kuma.internal:8765"))
 	})
 })


### PR DESCRIPTION
### Summary

* advertise `MonitoringAssignment` server via `API Catalog`