### PR TITLE
kuma-prometheus-sd: check write permissions on the output dir

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 Changes:
 
+* feature: on `kuma-prometheus-sd` start-up, check write permissions on the output dir
+  [#539](https://github.com/Kong/kuma/pull/539)
 * feature: implement MADS xDS client and integrate `kuma-prometheus-sd` with `Prometheus` via `file_sd` discovery
   [#537](https://github.com/Kong/kuma/pull/537)
 * feature: add configuration options to `kuma-prometheus-sd run`

--- a/app/kuma-prometheus-sd/cmd/run.go
+++ b/app/kuma-prometheus-sd/cmd/run.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"context"
+	"path/filepath"
 
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
@@ -15,6 +16,7 @@ import (
 
 	"github.com/Kong/kuma/app/kuma-prometheus-sd/pkg/discovery/xds"
 	util_log "github.com/Kong/kuma/app/kuma-prometheus-sd/pkg/util/go-kit/log"
+	util_os "github.com/Kong/kuma/pkg/util/os"
 )
 
 var (
@@ -46,6 +48,11 @@ func newRunCmd() *cobra.Command {
 			} else {
 				runLog.Error(err, "unable to format effective configuration", "config", cfg)
 				return err
+			}
+
+			outputDir, _ := filepath.Split(cfg.Prometheus.OutputFile)
+			if err := util_os.TryWriteToDir(outputDir); err != nil {
+				return errors.Wrapf(err, "unable to write to directory %q", outputDir)
 			}
 
 			catalogClient, err := catalogClientFactory(cfg.ControlPlane.ApiServer.URL)

--- a/pkg/util/os/fs.go
+++ b/pkg/util/os/fs.go
@@ -1,0 +1,27 @@
+package os
+
+import (
+	"io/ioutil"
+	"os"
+
+	"github.com/pkg/errors"
+)
+
+func TryWriteToDir(dir string) error {
+	file, err := ioutil.TempFile(dir, "write-access-check")
+	if err != nil {
+		if os.IsNotExist(err) {
+			if err := os.MkdirAll(dir, os.ModeDir|0755); err != nil {
+				return errors.Wrapf(err, "unable to create a directory %q", dir)
+			}
+			file, err = ioutil.TempFile(dir, "write-access-check")
+		}
+		if err != nil {
+			return errors.Wrapf(err, "unable to create temporary files in directory %q", dir)
+		}
+	}
+	if err := os.Remove(file.Name()); err != nil {
+		return errors.Wrapf(err, "unable to remove temporary files in directory %q", dir)
+	}
+	return nil
+}


### PR DESCRIPTION
### Summary

* check write permissions on the output dir
