### PR TITLE
kuma-prometheus-sd: support MonitoringAssignments with arbitrary `Target` labels (rather than only `__address__`)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 Changes:
 
+* feature: add support for `MonitoringAssignment`s with arbitrary `Target` labels (rather than only `__address__`) to `kuma-prometheus-sd`
+  [#540](https://github.com/Kong/kuma/pull/540)
 * feature: on `kuma-prometheus-sd` start-up, check write permissions on the output dir
   [#539](https://github.com/Kong/kuma/pull/539)
 * feature: implement MADS xDS client and integrate `kuma-prometheus-sd` with `Prometheus` via `file_sd` discovery

--- a/app/kuma-prometheus-sd/pkg/discovery/xds/config.go
+++ b/app/kuma-prometheus-sd/pkg/discovery/xds/config.go
@@ -1,0 +1,6 @@
+package xds
+
+type DiscoveryConfig struct {
+	ServerURL  string
+	ClientName string
+}

--- a/app/kuma-prometheus-sd/pkg/discovery/xds/converter.go
+++ b/app/kuma-prometheus-sd/pkg/discovery/xds/converter.go
@@ -1,0 +1,56 @@
+package xds
+
+import (
+	"fmt"
+
+	"github.com/prometheus/common/model"
+	"github.com/prometheus/prometheus/discovery/targetgroup"
+	"github.com/prometheus/prometheus/util/strutil"
+
+	observability_proto "github.com/Kong/kuma/api/observability/v1alpha1"
+)
+
+type Converter struct{}
+
+func (c Converter) ConvertAll(assignments []*observability_proto.MonitoringAssignment) []*targetgroup.Group {
+	var groups []*targetgroup.Group
+	for _, assignment := range assignments {
+		groups = append(groups, c.Convert(assignment)...)
+	}
+	return groups
+}
+
+func (c Converter) Convert(assignment *observability_proto.MonitoringAssignment) []*targetgroup.Group {
+	var groups []*targetgroup.Group
+	commonLabels := c.convertLabels(assignment.Labels)
+	for i, target := range assignment.Targets {
+		targetLabels := c.convertLabels(target.Labels)
+		allLabels := commonLabels.Clone().Merge(targetLabels)
+
+		address := allLabels[model.AddressLabel]
+		delete(allLabels, model.AddressLabel)
+
+		group := &targetgroup.Group{
+			Source: c.subSourceName(assignment.Name, i),
+			Targets: []model.LabelSet{{
+				model.AddressLabel: address,
+			}},
+			Labels: allLabels,
+		}
+		groups = append(groups, group)
+	}
+	return groups
+}
+
+func (c Converter) convertLabels(labels map[string]string) model.LabelSet {
+	labelSet := model.LabelSet{}
+	for key, value := range labels {
+		name := strutil.SanitizeLabelName(key)
+		labelSet[model.LabelName(name)] = model.LabelValue(value)
+	}
+	return labelSet
+}
+
+func (c Converter) subSourceName(source string, i int) string {
+	return fmt.Sprintf("%s/%d", source, i)
+}

--- a/app/kuma-prometheus-sd/pkg/discovery/xds/converter_test.go
+++ b/app/kuma-prometheus-sd/pkg/discovery/xds/converter_test.go
@@ -1,0 +1,182 @@
+package xds_test
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/ginkgo/extensions/table"
+	. "github.com/onsi/gomega"
+
+	. "github.com/Kong/kuma/app/kuma-prometheus-sd/pkg/discovery/xds"
+
+	"github.com/prometheus/common/model"
+	"github.com/prometheus/prometheus/discovery/targetgroup"
+
+	observability_proto "github.com/Kong/kuma/api/observability/v1alpha1"
+)
+
+var _ = Describe("Converter", func() {
+
+	Describe("Convert()", func() {
+
+		type testCase struct {
+			input    *observability_proto.MonitoringAssignment
+			expected []*targetgroup.Group
+		}
+
+		DescribeTable("should convert Kuma MonitoringAssignments into Prometheus Target Groups",
+			func(given testCase) {
+				// setup
+				c := Converter{}
+				// when
+				actual := c.Convert(given.input)
+				// then
+				Expect(actual).To(Equal(given.expected))
+			},
+			Entry("1 Dataplane per assignment, in the format expected by `custom-sd` adapter", testCase{
+				input: &observability_proto.MonitoringAssignment{
+					Name: "/meshes/default/dataplanes/backend-01",
+					Targets: []*observability_proto.MonitoringAssignment_Target{{
+						Labels: map[string]string{
+							"__address__": "192.168.0.1:8080",
+						},
+					}},
+					Labels: map[string]string{
+						"__scheme__":       "http",
+						"__metrics_path__": "/metrics",
+						"job":              "backend",
+						"instance":         "backend-01",
+						"mesh":             "default",
+						"dataplane":        "backend-01",
+						"env":              "prod",
+						"service":          "backend",
+					},
+				},
+				expected: []*targetgroup.Group{{
+					Source: "/meshes/default/dataplanes/backend-01/0",
+					Targets: []model.LabelSet{
+						{
+							"__address__": "192.168.0.1:8080",
+						},
+					},
+					Labels: model.LabelSet{
+						"mesh":             "default",
+						"dataplane":        "backend-01",
+						"env":              "prod",
+						"service":          "backend",
+						"__scheme__":       "http",
+						"__metrics_path__": "/metrics",
+						"job":              "backend",
+						"instance":         "backend-01",
+					},
+				}},
+			}),
+			Entry("1 Dataplane per assignment, in a free format", testCase{
+				input: &observability_proto.MonitoringAssignment{
+					Name: "/meshes/default/dataplanes/backend-01",
+					Targets: []*observability_proto.MonitoringAssignment_Target{{
+						Labels: map[string]string{
+							"__address__":      "192.168.0.1:8080",
+							"__scheme__":       "http",
+							"__metrics_path__": "/metrics",
+							"instance":         "backend-01",
+							"dataplane":        "backend-01",
+						},
+					}},
+					Labels: map[string]string{
+						"job":     "backend",
+						"mesh":    "default",
+						"service": "backend",
+						"env":     "prod",
+					},
+				},
+				expected: []*targetgroup.Group{{
+					Source: "/meshes/default/dataplanes/backend-01/0",
+					Targets: []model.LabelSet{
+						{
+							"__address__": "192.168.0.1:8080",
+						},
+					},
+					Labels: model.LabelSet{
+						"mesh":             "default",
+						"dataplane":        "backend-01",
+						"env":              "prod",
+						"service":          "backend",
+						"__scheme__":       "http",
+						"__metrics_path__": "/metrics",
+						"job":              "backend",
+						"instance":         "backend-01",
+					},
+				}},
+			}),
+			Entry("N Dataplanes per assignment, in a free format", testCase{
+				input: &observability_proto.MonitoringAssignment{
+					Name: "/meshes/default/services/backend",
+					Targets: []*observability_proto.MonitoringAssignment_Target{
+						{
+							Labels: map[string]string{
+								"__address__":      "192.168.0.1:8080",
+								"__scheme__":       "http",
+								"__metrics_path__": "/metrics",
+								"instance":         "backend-01",
+								"dataplane":        "backend-01",
+								"env":              "prod",
+							},
+						},
+						{
+							Labels: map[string]string{
+								"__address__":      "192.168.0.2:8081",
+								"__scheme__":       "http",
+								"__metrics_path__": "/metrics",
+								"instance":         "backend-02",
+								"dataplane":        "backend-02",
+								"env":              "test",
+							},
+						},
+					},
+					Labels: map[string]string{
+						"job":     "backend",
+						"mesh":    "default",
+						"service": "backend",
+					},
+				},
+				expected: []*targetgroup.Group{
+					{
+						Source: "/meshes/default/services/backend/0",
+						Targets: []model.LabelSet{
+							{
+								"__address__": "192.168.0.1:8080",
+							},
+						},
+						Labels: model.LabelSet{
+							"mesh":             "default",
+							"dataplane":        "backend-01",
+							"env":              "prod",
+							"service":          "backend",
+							"__scheme__":       "http",
+							"__metrics_path__": "/metrics",
+							"job":              "backend",
+							"instance":         "backend-01",
+						},
+					},
+					{
+						Source: "/meshes/default/services/backend/1",
+						Targets: []model.LabelSet{
+							{
+								"__address__": "192.168.0.2:8081",
+							},
+						},
+						Labels: model.LabelSet{
+							"mesh":             "default",
+							"dataplane":        "backend-02",
+							"env":              "test",
+							"service":          "backend",
+							"__scheme__":       "http",
+							"__metrics_path__": "/metrics",
+							"job":              "backend",
+							"instance":         "backend-02",
+						},
+					},
+				},
+			}),
+		)
+	})
+})

--- a/app/kuma-prometheus-sd/pkg/discovery/xds/handler.go
+++ b/app/kuma-prometheus-sd/pkg/discovery/xds/handler.go
@@ -1,0 +1,44 @@
+package xds
+
+import (
+	"github.com/prometheus/prometheus/discovery/targetgroup"
+
+	observability_proto "github.com/Kong/kuma/api/observability/v1alpha1"
+)
+
+type sourceList = map[string]bool
+
+type Handler struct {
+	converter     Converter
+	oldSourceList sourceList
+}
+
+func (h *Handler) Handle(assignments []*observability_proto.MonitoringAssignment, ch chan<- []*targetgroup.Group) {
+	newGroups := h.converter.ConvertAll(assignments)
+	newSourceList := h.buildSourceList(newGroups)
+	removedGroups := h.buildRemovedGroups(newSourceList)
+	allGroups := append(newGroups, removedGroups...)
+	ch <- allGroups
+	h.oldSourceList = newSourceList
+}
+
+func (h *Handler) buildSourceList(newGroups []*targetgroup.Group) sourceList {
+	newSourceList := sourceList{}
+	for _, group := range newGroups {
+		newSourceList[group.Source] = true
+	}
+	return newSourceList
+}
+
+func (h *Handler) buildRemovedGroups(newSourceList sourceList) []*targetgroup.Group {
+	// when targetGroup disappears, we should send an update with an empty targetList
+	var deletedGroups []*targetgroup.Group
+	for name := range h.oldSourceList {
+		if !newSourceList[name] {
+			deletedGroups = append(deletedGroups, &targetgroup.Group{
+				Source: name,
+			})
+		}
+	}
+	return deletedGroups
+}

--- a/app/kuma-prometheus-sd/pkg/discovery/xds/stream.go
+++ b/app/kuma-prometheus-sd/pkg/discovery/xds/stream.go
@@ -1,0 +1,79 @@
+package xds
+
+import (
+	"context"
+	"io"
+
+	"github.com/go-logr/logr"
+	"github.com/pkg/errors"
+	"go.uber.org/multierr"
+
+	"github.com/prometheus/prometheus/discovery/targetgroup"
+
+	mads_client "github.com/Kong/kuma/pkg/mads/client"
+)
+
+type stream struct {
+	log     logr.Logger
+	config  DiscoveryConfig
+	handler *Handler
+}
+
+func (s *stream) Run(ctx context.Context, ch chan<- []*targetgroup.Group) (errs error) {
+	s.log.Info("creating a gRPC client for Monitoring Assignment Discovery Service (MADS) server ...")
+	client, err := mads_client.New(s.config.ServerURL)
+	if err != nil {
+		return errors.Wrap(err, "failed to connect to gRPC server")
+	}
+	defer func() {
+		s.log.Info("closing a connection ...")
+		if err := client.Close(); err != nil {
+			errs = multierr.Append(errs, errors.Wrapf(err, "failed to close a connection"))
+		}
+	}()
+
+	s.log.Info("starting an xDS stream ...")
+	stream, err := client.StartStream()
+	if err != nil {
+		return errors.Wrap(err, "failed to start an xDS stream")
+	}
+	defer func() {
+		s.log.Info("closing an xDS stream ...")
+		if err := stream.Close(); err != nil {
+			errs = multierr.Append(errs, errors.Wrapf(err, "failed to close an xDS stream"))
+		}
+	}()
+
+	s.log.Info("sending first discovery request on a new xDS stream ...")
+	err = stream.RequestAssignments(s.config.ClientName)
+	if err != nil {
+		return errors.Wrap(err, "failed to send a discovery request")
+	}
+
+	for {
+		select {
+		case <-ctx.Done():
+			return nil
+		default:
+		}
+
+		s.log.Info("waiting for a discovery response ...")
+		assignments, err := stream.WaitForAssignments()
+		if err != nil {
+			return errors.Wrap(err, "failed to receive a discovery response")
+		}
+		s.log.Info("received monitoring assignments", "len", len(assignments))
+		s.log.V(1).Info("received monitoring assignments", "assignments", assignments)
+
+		s.handler.Handle(assignments, ch)
+
+		if err := stream.ACK(); err != nil {
+			if err == io.EOF {
+				break
+			}
+			return errors.Wrap(err, "failed to ACK a discovery response")
+		}
+	}
+
+	return nil
+}

--- a/app/kuma-prometheus-sd/pkg/discovery/xds/xds.go
+++ b/app/kuma-prometheus-sd/pkg/discovery/xds/xds.go
@@ -2,38 +2,24 @@ package xds
 
 import (
 	"context"
-	"io"
 
 	"github.com/go-logr/logr"
 	"github.com/pkg/errors"
-	"go.uber.org/multierr"
 
-	"github.com/prometheus/common/model"
 	"github.com/prometheus/prometheus/discovery/targetgroup"
-	"github.com/prometheus/prometheus/util/strutil"
-
-	observability_proto "github.com/Kong/kuma/api/observability/v1alpha1"
-	mads_client "github.com/Kong/kuma/pkg/mads/client"
 )
 
-type DiscoveryConfig struct {
-	ServerURL  string
-	ClientName string
-}
-
 type discoverer struct {
-	log           logr.Logger
-	config        DiscoveryConfig
-	oldSourceList map[string]bool
+	log     logr.Logger
+	config  DiscoveryConfig
+	handler Handler
 }
 
 func NewDiscoverer(config DiscoveryConfig, log logr.Logger) (*discoverer, error) {
-	cd := &discoverer{
-		log:           log,
-		config:        config,
-		oldSourceList: make(map[string]bool),
-	}
-	return cd, nil
+	return &discoverer{
+		log:    log,
+		config: config,
+	}, nil
 }
 
 // Run implements discovery.Discoverer interface.
@@ -54,7 +40,12 @@ func (d *discoverer) Run(ctx context.Context, ch chan<- []*targetgroup.Group) {
 					}
 				}
 			}()
-			errCh <- d.stream(ctx, streamID, ch)
+			stream := stream{
+				log:     d.log.WithValues("streamID", streamID),
+				config:  d.config,
+				handler: &d.handler,
+			}
+			errCh <- stream.Run(ctx, ch)
 		}(errCh)
 		select {
 		case <-ctx.Done():
@@ -66,107 +57,4 @@ func (d *discoverer) Run(ctx context.Context, ch chan<- []*targetgroup.Group) {
 			}
 		}
 	}
-}
-
-func (d *discoverer) stream(ctx context.Context, streamID uint64, ch chan<- []*targetgroup.Group) (errs error) {
-	log := d.log.WithValues("streamID", streamID)
-
-	log.Info("creating a gRPC client for Monitoring Assignment Discovery Service (MADS) server ...")
-	client, err := mads_client.New(d.config.ServerURL)
-	if err != nil {
-		return errors.Wrap(err, "failed to connect to gRPC server")
-	}
-	defer func() {
-		log.Info("closing a connection ...")
-		if err := client.Close(); err != nil {
-			errs = multierr.Append(errs, errors.Wrapf(err, "failed to close a connection"))
-		}
-	}()
-
-	log.Info("starting an xDS stream ...")
-	stream, err := client.StartStream()
-	if err != nil {
-		return errors.Wrap(err, "failed to start an xDS stream")
-	}
-	defer func() {
-		log.Info("closing an xDS stream ...")
-		if err := stream.Close(); err != nil {
-			errs = multierr.Append(errs, errors.Wrapf(err, "failed to close an xDS stream"))
-		}
-	}()
-
-	log.Info("sending first discovery request on a new xDS stream ...")
-	err = stream.RequestAssignments(d.config.ClientName)
-	if err != nil {
-		return errors.Wrap(err, "failed to send a discovery request")
-	}
-
-	for {
-		select {
-		case <-ctx.Done():
-			return nil
-		default:
-		}
-
-		log.Info("waiting for a discovery response ...")
-		assignments, err := stream.WaitForAssignments()
-		if err != nil {
-			return errors.Wrap(err, "failed to receive a discovery response")
-		}
-		log.Info("received monitoring assignments", "len", len(assignments))
-		log.V(1).Info("received monitoring assignments", "assignments", assignments)
-
-		tgs, newSourceList := d.convertAll(assignments)
-		ch <- tgs
-		d.oldSourceList = newSourceList
-
-		if err := stream.ACK(); err != nil {
-			if err == io.EOF {
-				break
-			}
-			return errors.Wrap(err, "failed to ACK a discovery response")
-		}
-	}
-
-	return nil
-}
-
-func (d *discoverer) convertAll(assignments []*observability_proto.MonitoringAssignment) ([]*targetgroup.Group, map[string]bool) {
-	var tgs []*targetgroup.Group
-	newSourceList := make(map[string]bool)
-	for _, assignment := range assignments {
-		tg := d.convertOne(assignment)
-		tgs = append(tgs, tg)
-		newSourceList[tg.Source] = true
-	}
-
-	// when targetGroup disappear, we should send an update with an empty targetList
-	for key := range d.oldSourceList {
-		if !newSourceList[key] {
-			tgs = append(tgs, &targetgroup.Group{
-				Source: key,
-			})
-		}
-	}
-	return tgs, newSourceList
-}
-
-func (d *discoverer) convertOne(assignment *observability_proto.MonitoringAssignment) *targetgroup.Group {
-	tg := &targetgroup.Group{
-		Source: assignment.Name,
-	}
-	tg.Labels = d.convertLabels(assignment.Labels)
-	for _, target := range assignment.Targets {
-		tg.Targets = append(tg.Targets, d.convertLabels(target.Labels))
-	}
-	return tg
-}
-
-func (d *discoverer) convertLabels(labels map[string]string) model.LabelSet {
-	labelSet := model.LabelSet{}
-	for key, value := range labels {
-		name := strutil.SanitizeLabelName(key)
-		labelSet[model.LabelName(name)] = model.LabelValue(value)
-	}
-	return labelSet
 }

--- a/app/kuma-prometheus-sd/pkg/discovery/xds/xds_suite_test.go
+++ b/app/kuma-prometheus-sd/pkg/discovery/xds/xds_suite_test.go
@@ -1,0 +1,13 @@
+package xds_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+func TestXds(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Xds Suite")
+}


### PR DESCRIPTION
### Summary

* support `MonitoringAssignments` with arbitrary `Target` labels (rather than only `__address__`)

