### PR TITLE
ci: exclude `clang-format` from CI builds due to temporary issues with LLVM's APT repository

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -216,21 +216,22 @@ jobs:
     - run:
         name: "Install all development tools"
         command: make dev/tools
-    - run:
-        name: "Install check tools (clang-format, ...)"
-        command: |
-          # see https://apt.llvm.org/
+    # TODO(yskopets): uncomment once LLVM apt repository is functional again
+    # - run:
+    #     name: "Install check tools (clang-format, ...)"
+    #     command: |
+    #       # see https://apt.llvm.org/
 
-          cat  >>/etc/apt/sources.list \<<EOF
+    #       cat  >>/etc/apt/sources.list \<<EOF
 
-          deb http://apt.llvm.org/stretch/ llvm-toolchain-stretch main
-          deb-src http://apt.llvm.org/stretch/ llvm-toolchain-stretch main
+    #       deb http://apt.llvm.org/stretch/ llvm-toolchain-stretch main
+    #       deb-src http://apt.llvm.org/stretch/ llvm-toolchain-stretch main
 
-          EOF
+    #       EOF
 
-          wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key|apt-key add -
+    #       wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key|apt-key add -
 
-          apt update && apt install -y clang-format-10
+    #       apt update && apt install -y clang-format-10
     - run:
         name: "Run code generators (go generate, protoc, ...) and code checks (go fmt, go vet, ...)"
         command: make check


### PR DESCRIPTION
### Summary

* exclude `clang-format` from CI builds due to temporary issues with LLVM's APT repository

