### PR TITLE
kuma-cp: make maximum number of open connections to Postgres configurable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # CHANGELOG
 
+## [master]
+
+Changes:
+
+* feature: make maximum number of open connections to Postgres configurable
+  [#557](https://github.com/Kong/kuma/pull/557)
+
 ## [0.3.2]
 
 > Released on 2020/01/10

--- a/pkg/api-server/config_ws_test.go
+++ b/pkg/api-server/config_ws_test.go
@@ -137,6 +137,7 @@ var _ = Describe("Config WS", func() {
               "connectionTimeout": 5,
               "dbName": "kuma",
               "host": "127.0.0.1",
+              "maxOpenConnections": 0,
               "password": "*****",
               "port": 15432,
               "tls": {

--- a/pkg/config/app/kuma-cp/kuma-cp.defaults.yaml
+++ b/pkg/config/app/kuma-cp/kuma-cp.defaults.yaml
@@ -25,6 +25,9 @@ store:
     dbName: kuma # ENV: KUMA_STORE_POSTGRES_DB_NAME
     # Connection Timeout to the DB in seconds
     connectionTimeout: 5 # ENV: KUMA_STORE_POSTGRES_CONNECTION_TIMEOUT
+    # Maximum number of open connections to the database
+    # `0` value means number of open connections is unlimited
+    maxOpenConnections: 0 # ENV: KUMA_STORE_POSTGRES_MAX_OPEN_CONNECTIONS
     # TLS settings
     tls:
       # Mode of TLS connection. Available values (disable, require, verify-ca, verify-full)

--- a/pkg/config/loader_test.go
+++ b/pkg/config/loader_test.go
@@ -80,6 +80,7 @@ var _ = Describe("Config loader", func() {
 			Expect(cfg.Store.Postgres.Password).To(Equal("kuma"))
 			Expect(cfg.Store.Postgres.DbName).To(Equal("kuma"))
 			Expect(cfg.Store.Postgres.ConnectionTimeout).To(Equal(10))
+			Expect(cfg.Store.Postgres.MaxOpenConnections).To(Equal(300))
 
 			Expect(cfg.Store.Postgres.TLS.Mode).To(Equal(postgres.VerifyFull))
 			Expect(cfg.Store.Postgres.TLS.CertPath).To(Equal("/path/to/cert"))
@@ -135,6 +136,7 @@ store:
     password: kuma
     dbName: kuma
     connectionTimeout: 10
+    maxOpenConnections: 300
     tls:
       mode: verifyFull
       certPath: /path/to/cert
@@ -213,6 +215,7 @@ guiServer:
 				"KUMA_STORE_POSTGRES_PASSWORD":                                  "kuma",
 				"KUMA_STORE_POSTGRES_DB_NAME":                                   "kuma",
 				"KUMA_STORE_POSTGRES_CONNECTION_TIMEOUT":                        "10",
+				"KUMA_STORE_POSTGRES_MAX_OPEN_CONNECTIONS":                      "300",
 				"KUMA_STORE_POSTGRES_TLS_MODE":                                  "verifyFull",
 				"KUMA_STORE_POSTGRES_TLS_CERT_PATH":                             "/path/to/cert",
 				"KUMA_STORE_POSTGRES_TLS_KEY_PATH":                              "/path/to/key",

--- a/pkg/config/plugins/resources/postgres/config.go
+++ b/pkg/config/plugins/resources/postgres/config.go
@@ -21,6 +21,9 @@ type PostgresStoreConfig struct {
 	DbName string `yaml:"dbName" envconfig:"kuma_store_postgres_db_name"`
 	// Connection Timeout to the DB in seconds
 	ConnectionTimeout int `yaml:"connectionTimeout" envconfig:"kuma_store_postgres_connection_timeout"`
+	// Maximum number of open connections to the database
+	// `0` value means number of open connections is unlimited
+	MaxOpenConnections int `yaml:"maxOpenConnections" envconfig:"kuma_store_postgres_max_open_connections"`
 	// TLS settings
 	TLS TLSPostgresStoreConfig `yaml:"tls"`
 }
@@ -102,13 +105,14 @@ func (p *PostgresStoreConfig) Validate() error {
 
 func DefaultPostgresStoreConfig() *PostgresStoreConfig {
 	return &PostgresStoreConfig{
-		Host:              "127.0.0.1",
-		Port:              15432,
-		User:              "kuma",
-		Password:          "kuma",
-		DbName:            "kuma",
-		ConnectionTimeout: 5,
-		TLS:               DefaultTLSPostgresStoreConfig(),
+		Host:               "127.0.0.1",
+		Port:               15432,
+		User:               "kuma",
+		Password:           "kuma",
+		DbName:             "kuma",
+		ConnectionTimeout:  5,
+		MaxOpenConnections: 0, // number of open connections is unlimited
+		TLS:                DefaultTLSPostgresStoreConfig(),
 	}
 }
 

--- a/pkg/plugins/resources/postgres/store.go
+++ b/pkg/plugins/resources/postgres/store.go
@@ -4,14 +4,15 @@ import (
 	"context"
 	"database/sql"
 	"fmt"
+	"strconv"
+	"strings"
+
 	config "github.com/Kong/kuma/pkg/config/plugins/resources/postgres"
 	"github.com/Kong/kuma/pkg/core/resources/model"
 	"github.com/Kong/kuma/pkg/core/resources/store"
 	"github.com/Kong/kuma/pkg/util/proto"
 	_ "github.com/lib/pq"
 	"github.com/pkg/errors"
-	"strconv"
-	"strings"
 )
 
 const duplicateKeyErrorMsg = "duplicate key value violates unique constraint"
@@ -44,6 +45,8 @@ func connectToDb(cfg config.PostgresStoreConfig) (*sql.DB, error) {
 	if err != nil {
 		return nil, errors.Wrap(err, "cannot create connection to DB")
 	}
+
+	db.SetMaxOpenConns(cfg.MaxOpenConnections)
 
 	// check connection to DB, Open() does not check it.
 	if err := db.Ping(); err != nil {


### PR DESCRIPTION
### Summary

* make maximum number of open connections to Postgres configurable
