### PR TITLE
feat(kuma-cp) Reformat some Envoy metrics available in prometheus

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 Changes:
 
+* feature: reformat some Envoy metrics available in Prometheus
+  [#558](https://github.com/Kong/kuma/pull/558)
 * feature: make maximum number of open connections to Postgres configurable
   [#557](https://github.com/Kong/kuma/pull/557)
 

--- a/go.sum
+++ b/go.sum
@@ -115,7 +115,9 @@ github.com/fsnotify/fsnotify v1.4.7 h1:IXs+QLmnXW2CcXuY+8Mzv/fWEsPGWxqefPtCP5CnV
 github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMoQvtojpjFo=
 github.com/ghodss/yaml v1.0.0 h1:wQHKEahhL6wmXdzwWG11gIVCkOv05bNOh+Rxn0yngAk=
 github.com/ghodss/yaml v1.0.0/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=
+github.com/go-kit/kit v0.8.0 h1:Wz+5lgoB0kkuqLEc6NVmwRknTKP6dTGbSqvhZtBI/j0=
 github.com/go-kit/kit v0.8.0/go.mod h1:xBxKIO96dXMWWy0MnWVtmwkA9/13aqxPnvrjFYMA2as=
+github.com/go-logfmt/logfmt v0.3.0 h1:8HUsc87TaSWLKwrnumgC8/YconD2fJQsRJAsWaPg2ic=
 github.com/go-logfmt/logfmt v0.3.0/go.mod h1:Qt1PoO58o5twSAckw1HlFXLmHsOX5/0LbT9GBnD5lWE=
 github.com/go-logr/glogr v0.1.0 h1:5W02LkUIi+DaBwtWKYGxoX9gqVMo6i9ehwkhorjcP74=
 github.com/go-logr/glogr v0.1.0/go.mod h1:GDQ2+z9PAAX7+qBhL3FzAL2Nf8dxyliu0ppgJIX7YhU=

--- a/pkg/xds/bootstrap/template.go
+++ b/pkg/xds/bootstrap/template.go
@@ -46,7 +46,7 @@ stats_config:
   - tag_name: worker
     regex: '(worker_([0-9]+)\.)'
   - tag_name: listener
-    regex: '(.+?)rbac\.'
+    regex: '((.+?)\.)rbac\.'
 
 dynamic_resources:
   lds_config: {ads: {}}

--- a/pkg/xds/bootstrap/template.go
+++ b/pkg/xds/bootstrap/template.go
@@ -37,6 +37,17 @@ admin:
       port_value: {{ .AdminPort }}
 {{ end }}
 
+stats_config:
+  stats_tags:
+  - tag_name: name
+    regex: '^grpc\.((.+)\.)'
+  - tag_name: status
+    regex: '^grpc.*streams_closed(_([0-9]+))'
+  - tag_name: worker
+    regex: '(worker_([0-9]+)\.)'
+  - tag_name: listener
+    regex: '(.+?)rbac\.'
+
 dynamic_resources:
   lds_config: {ads: {}}
   cds_config: {ads: {}}

--- a/pkg/xds/bootstrap/testdata/bootstrap.k8s.golden.yaml
+++ b/pkg/xds/bootstrap/testdata/bootstrap.k8s.golden.yaml
@@ -11,6 +11,16 @@ dynamicResources:
 node:
   cluster: backend
   id: default.dp-1.default
+statsConfig:
+  statsTags:
+    - tagName: name
+      regex: '^grpc\.((.+)\.)'
+    - tagName: status
+      regex: '^grpc.*streams_closed(_([0-9]+))'
+    - tagName: worker
+      regex: '(worker_([0-9]+)\.)'
+    - tagName: listener
+      regex: '(.+?)rbac\.'
 staticResources:
   clusters:
     - connectTimeout: 1s

--- a/pkg/xds/bootstrap/testdata/bootstrap.k8s.golden.yaml
+++ b/pkg/xds/bootstrap/testdata/bootstrap.k8s.golden.yaml
@@ -20,7 +20,7 @@ statsConfig:
     - tagName: worker
       regex: '(worker_([0-9]+)\.)'
     - tagName: listener
-      regex: '(.+?)rbac\.'
+      regex: '((.+?)\.)rbac\.'
 staticResources:
   clusters:
     - connectTimeout: 1s

--- a/pkg/xds/bootstrap/testdata/bootstrap.overridden.golden.yaml
+++ b/pkg/xds/bootstrap/testdata/bootstrap.overridden.golden.yaml
@@ -29,7 +29,7 @@ statsConfig:
     - tagName: worker
       regex: '(worker_([0-9]+)\.)'
     - tagName: listener
-      regex: '(.+?)rbac\.'
+      regex: '((.+?)\.)rbac\.'
 staticResources:
   clusters:
     - connectTimeout: 1s

--- a/pkg/xds/bootstrap/testdata/bootstrap.overridden.golden.yaml
+++ b/pkg/xds/bootstrap/testdata/bootstrap.overridden.golden.yaml
@@ -20,6 +20,16 @@ node:
   metadata:
     dataplane.admin.port: "1234"
     dataplaneTokenPath: /tmp/token
+statsConfig:
+  statsTags:
+    - tagName: name
+      regex: '^grpc\.((.+)\.)'
+    - tagName: status
+      regex: '^grpc.*streams_closed(_([0-9]+))'
+    - tagName: worker
+      regex: '(worker_([0-9]+)\.)'
+    - tagName: listener
+      regex: '(.+?)rbac\.'
 staticResources:
   clusters:
     - connectTimeout: 1s

--- a/pkg/xds/bootstrap/testdata/bootstrap.universal.golden.yaml
+++ b/pkg/xds/bootstrap/testdata/bootstrap.universal.golden.yaml
@@ -11,6 +11,16 @@ dynamicResources:
 node:
   cluster: backend
   id: default.dp-1
+statsConfig:
+  statsTags:
+    - tagName: name
+      regex: '^grpc\.((.+)\.)'
+    - tagName: status
+      regex: '^grpc.*streams_closed(_([0-9]+))'
+    - tagName: worker
+      regex: '(worker_([0-9]+)\.)'
+    - tagName: listener
+      regex: '(.+?)rbac\.'
 staticResources:
   clusters:
     - connectTimeout: 1s

--- a/pkg/xds/bootstrap/testdata/bootstrap.universal.golden.yaml
+++ b/pkg/xds/bootstrap/testdata/bootstrap.universal.golden.yaml
@@ -20,7 +20,7 @@ statsConfig:
     - tagName: worker
       regex: '(worker_([0-9]+)\.)'
     - tagName: listener
-      regex: '(.+?)rbac\.'
+      regex: '((.+?)\.)rbac\.'
 staticResources:
   clusters:
     - connectTimeout: 1s

--- a/pkg/xds/bootstrap/testdata/generator.custom-config-minimal-request.golden.yaml
+++ b/pkg/xds/bootstrap/testdata/generator.custom-config-minimal-request.golden.yaml
@@ -28,7 +28,7 @@ statsConfig:
     - tagName: worker
       regex: '(worker_([0-9]+)\.)'
     - tagName: listener
-      regex: '(.+?)rbac\.'
+      regex: '((.+?)\.)rbac\.'
 staticResources:
   clusters:
   - connectTimeout: 2s

--- a/pkg/xds/bootstrap/testdata/generator.custom-config-minimal-request.golden.yaml
+++ b/pkg/xds/bootstrap/testdata/generator.custom-config-minimal-request.golden.yaml
@@ -19,6 +19,16 @@ node:
   id: mesh.name.namespace
   metadata:
     dataplane.admin.port: "9902"
+statsConfig:
+  statsTags:
+    - tagName: name
+      regex: '^grpc\.((.+)\.)'
+    - tagName: status
+      regex: '^grpc.*streams_closed(_([0-9]+))'
+    - tagName: worker
+      regex: '(worker_([0-9]+)\.)'
+    - tagName: listener
+      regex: '(.+?)rbac\.'
 staticResources:
   clusters:
   - connectTimeout: 2s

--- a/pkg/xds/bootstrap/testdata/generator.custom-config.golden.yaml
+++ b/pkg/xds/bootstrap/testdata/generator.custom-config.golden.yaml
@@ -20,6 +20,16 @@ node:
   metadata:
     dataplane.admin.port: "1234"
     dataplaneTokenPath: /tmp/token
+statsConfig:
+  statsTags:
+    - tagName: name
+      regex: '^grpc\.((.+)\.)'
+    - tagName: status
+      regex: '^grpc.*streams_closed(_([0-9]+))'
+    - tagName: worker
+      regex: '(worker_([0-9]+)\.)'
+    - tagName: listener
+      regex: '(.+?)rbac\.'
 staticResources:
   clusters:
   - connectTimeout: 2s

--- a/pkg/xds/bootstrap/testdata/generator.custom-config.golden.yaml
+++ b/pkg/xds/bootstrap/testdata/generator.custom-config.golden.yaml
@@ -29,7 +29,7 @@ statsConfig:
     - tagName: worker
       regex: '(worker_([0-9]+)\.)'
     - tagName: listener
-      regex: '(.+?)rbac\.'
+      regex: '((.+?)\.)rbac\.'
 staticResources:
   clusters:
   - connectTimeout: 2s

--- a/pkg/xds/bootstrap/testdata/generator.default-config-minimal-request.golden.yaml
+++ b/pkg/xds/bootstrap/testdata/generator.default-config-minimal-request.golden.yaml
@@ -11,6 +11,16 @@ dynamicResources:
 node:
   cluster: backend
   id: mesh.name.namespace
+statsConfig:
+  statsTags:
+    - tagName: name
+      regex: '^grpc\.((.+)\.)'
+    - tagName: status
+      regex: '^grpc.*streams_closed(_([0-9]+))'
+    - tagName: worker
+      regex: '(worker_([0-9]+)\.)'
+    - tagName: listener
+      regex: '(.+?)rbac\.'
 staticResources:
   clusters:
     - connectTimeout: 1s

--- a/pkg/xds/bootstrap/testdata/generator.default-config-minimal-request.golden.yaml
+++ b/pkg/xds/bootstrap/testdata/generator.default-config-minimal-request.golden.yaml
@@ -20,7 +20,7 @@ statsConfig:
     - tagName: worker
       regex: '(worker_([0-9]+)\.)'
     - tagName: listener
-      regex: '(.+?)rbac\.'
+      regex: '((.+?)\.)rbac\.'
 staticResources:
   clusters:
     - connectTimeout: 1s

--- a/pkg/xds/bootstrap/testdata/generator.default-config.golden.yaml
+++ b/pkg/xds/bootstrap/testdata/generator.default-config.golden.yaml
@@ -29,7 +29,7 @@ statsConfig:
     - tagName: worker
       regex: '(worker_([0-9]+)\.)'
     - tagName: listener
-      regex: '(.+?)rbac\.'
+      regex: '((.+?)\.)rbac\.'
 staticResources:
   clusters:
     - connectTimeout: 1s

--- a/pkg/xds/bootstrap/testdata/generator.default-config.golden.yaml
+++ b/pkg/xds/bootstrap/testdata/generator.default-config.golden.yaml
@@ -20,6 +20,16 @@ node:
   metadata:
     dataplane.admin.port: "1234"
     dataplaneTokenPath: /tmp/token
+statsConfig:
+  statsTags:
+    - tagName: name
+      regex: '^grpc\.((.+)\.)'
+    - tagName: status
+      regex: '^grpc.*streams_closed(_([0-9]+))'
+    - tagName: worker
+      regex: '(worker_([0-9]+)\.)'
+    - tagName: listener
+      regex: '(.+?)rbac\.'
 staticResources:
   clusters:
     - connectTimeout: 1s

--- a/pkg/xds/envoy/envoy_test.go
+++ b/pkg/xds/envoy/envoy_test.go
@@ -642,7 +642,7 @@ var _ = Describe("Envoy", func() {
                       - authenticated:
                           principalName:
                             exact: spiffe://default/web1
-                statPrefix: inbound:192.168.0.1:8080
+                statPrefix: inbound:192.168.0.1:8080.
             - name: envoy.tcp_proxy
               typedConfig:
                 '@type': type.googleapis.com/envoy.config.filter.network.tcp_proxy.v2.TcpProxy
@@ -719,7 +719,7 @@ var _ = Describe("Envoy", func() {
                       - authenticated:
                           principalName:
                             exact: spiffe://default/web1
-                statPrefix: inbound:192.168.0.1:8080
+                statPrefix: inbound:192.168.0.1:8080.
             - name: envoy.tcp_proxy
               typedConfig:
                 '@type': type.googleapis.com/envoy.config.filter.network.tcp_proxy.v2.TcpProxy

--- a/pkg/xds/generator/testdata/inbound-proxy/3-envoy-config.golden.yaml
+++ b/pkg/xds/generator/testdata/inbound-proxy/3-envoy-config.golden.yaml
@@ -36,7 +36,7 @@ resources:
                       - authenticated:
                           principalName:
                             exact: spiffe://default/web1
-                statPrefix: inbound:192.168.0.1:80
+                statPrefix: inbound:192.168.0.1:80.
             - name: envoy.tcp_proxy
               typedConfig:
                 '@type': type.googleapis.com/envoy.config.filter.network.tcp_proxy.v2.TcpProxy

--- a/pkg/xds/generator/testdata/inbound-proxy/4-envoy-config.golden.yaml
+++ b/pkg/xds/generator/testdata/inbound-proxy/4-envoy-config.golden.yaml
@@ -38,7 +38,7 @@ resources:
                       - authenticated:
                           principalName:
                             exact: spiffe://default/web1
-                statPrefix: inbound:192.168.0.1:80
+                statPrefix: inbound:192.168.0.1:80.
             - name: envoy.tcp_proxy
               typedConfig:
                 '@type': type.googleapis.com/envoy.config.filter.network.tcp_proxy.v2.TcpProxy

--- a/pkg/xds/generator/testdata/inbound-proxy/5-envoy-config.golden.yaml
+++ b/pkg/xds/generator/testdata/inbound-proxy/5-envoy-config.golden.yaml
@@ -35,7 +35,7 @@ resources:
                       - authenticated:
                           principalName:
                             exact: spiffe://default/web1
-                statPrefix: inbound:192.168.0.1:80
+                statPrefix: inbound:192.168.0.1:80.
             - name: envoy.tcp_proxy
               typedConfig:
                 '@type': type.googleapis.com/envoy.config.filter.network.tcp_proxy.v2.TcpProxy
@@ -99,7 +99,7 @@ resources:
               typedConfig:
                 '@type': type.googleapis.com/envoy.config.filter.network.rbac.v2.RBAC
                 rules: {}
-                statPrefix: inbound:192.168.0.1:443
+                statPrefix: inbound:192.168.0.1:443.
             - name: envoy.tcp_proxy
               typedConfig:
                 '@type': type.googleapis.com/envoy.config.filter.network.tcp_proxy.v2.TcpProxy

--- a/pkg/xds/generator/testdata/inbound-proxy/6-envoy-config.golden.yaml
+++ b/pkg/xds/generator/testdata/inbound-proxy/6-envoy-config.golden.yaml
@@ -37,7 +37,7 @@ resources:
                       - authenticated:
                           principalName:
                             exact: spiffe://default/web1
-                statPrefix: inbound:192.168.0.1:80
+                statPrefix: inbound:192.168.0.1:80.
             - name: envoy.tcp_proxy
               typedConfig:
                 '@type': type.googleapis.com/envoy.config.filter.network.tcp_proxy.v2.TcpProxy
@@ -103,7 +103,7 @@ resources:
               typedConfig:
                 '@type': type.googleapis.com/envoy.config.filter.network.rbac.v2.RBAC
                 rules: {}
-                statPrefix: inbound:192.168.0.1:443
+                statPrefix: inbound:192.168.0.1:443.
             - name: envoy.tcp_proxy
               typedConfig:
                 '@type': type.googleapis.com/envoy.config.filter.network.tcp_proxy.v2.TcpProxy

--- a/pkg/xds/generator/testdata/inbound-proxy/7-envoy-config.golden.yaml
+++ b/pkg/xds/generator/testdata/inbound-proxy/7-envoy-config.golden.yaml
@@ -35,7 +35,7 @@ resources:
                       - authenticated:
                           principalName:
                             exact: spiffe://default/web1
-                statPrefix: inbound:192.168.0.1:80
+                statPrefix: inbound:192.168.0.1:80.
             - name: envoy.tcp_proxy
               typedConfig:
                 '@type': type.googleapis.com/envoy.config.filter.network.tcp_proxy.v2.TcpProxy
@@ -99,7 +99,7 @@ resources:
               typedConfig:
                 '@type': type.googleapis.com/envoy.config.filter.network.rbac.v2.RBAC
                 rules: {}
-                statPrefix: inbound:192.168.0.1:443
+                statPrefix: inbound:192.168.0.1:443.
             - name: envoy.tcp_proxy
               typedConfig:
                 '@type': type.googleapis.com/envoy.config.filter.network.tcp_proxy.v2.TcpProxy
@@ -148,7 +148,7 @@ resources:
               typedConfig:
                 '@type': type.googleapis.com/envoy.config.filter.network.rbac.v2.RBAC
                 rules: {}
-                statPrefix: inbound:192.168.0.2:80
+                statPrefix: inbound:192.168.0.2:80.
             - name: envoy.tcp_proxy
               typedConfig:
                 '@type': type.googleapis.com/envoy.config.filter.network.tcp_proxy.v2.TcpProxy
@@ -197,7 +197,7 @@ resources:
               typedConfig:
                 '@type': type.googleapis.com/envoy.config.filter.network.rbac.v2.RBAC
                 rules: {}
-                statPrefix: inbound:192.168.0.2:443
+                statPrefix: inbound:192.168.0.2:443.
             - name: envoy.tcp_proxy
               typedConfig:
                 '@type': type.googleapis.com/envoy.config.filter.network.tcp_proxy.v2.TcpProxy

--- a/pkg/xds/generator/testdata/inbound-proxy/8-envoy-config.golden.yaml
+++ b/pkg/xds/generator/testdata/inbound-proxy/8-envoy-config.golden.yaml
@@ -37,7 +37,7 @@ resources:
                       - authenticated:
                           principalName:
                             exact: spiffe://default/web1
-                statPrefix: inbound:192.168.0.1:80
+                statPrefix: inbound:192.168.0.1:80.
             - name: envoy.tcp_proxy
               typedConfig:
                 '@type': type.googleapis.com/envoy.config.filter.network.tcp_proxy.v2.TcpProxy
@@ -103,7 +103,7 @@ resources:
               typedConfig:
                 '@type': type.googleapis.com/envoy.config.filter.network.rbac.v2.RBAC
                 rules: {}
-                statPrefix: inbound:192.168.0.1:443
+                statPrefix: inbound:192.168.0.1:443.
             - name: envoy.tcp_proxy
               typedConfig:
                 '@type': type.googleapis.com/envoy.config.filter.network.tcp_proxy.v2.TcpProxy
@@ -154,7 +154,7 @@ resources:
               typedConfig:
                 '@type': type.googleapis.com/envoy.config.filter.network.rbac.v2.RBAC
                 rules: {}
-                statPrefix: inbound:192.168.0.2:80
+                statPrefix: inbound:192.168.0.2:80.
             - name: envoy.tcp_proxy
               typedConfig:
                 '@type': type.googleapis.com/envoy.config.filter.network.tcp_proxy.v2.TcpProxy
@@ -205,7 +205,7 @@ resources:
               typedConfig:
                 '@type': type.googleapis.com/envoy.config.filter.network.rbac.v2.RBAC
                 rules: {}
-                statPrefix: inbound:192.168.0.2:443
+                statPrefix: inbound:192.168.0.2:443.
             - name: envoy.tcp_proxy
               typedConfig:
                 '@type': type.googleapis.com/envoy.config.filter.network.tcp_proxy.v2.TcpProxy

--- a/pkg/xds/generator/testdata/profile-source/1-envoy-config.golden.yaml
+++ b/pkg/xds/generator/testdata/profile-source/1-envoy-config.golden.yaml
@@ -27,7 +27,7 @@ resources:
               typedConfig:
                 '@type': type.googleapis.com/envoy.config.filter.network.rbac.v2.RBAC
                 rules: {}
-                statPrefix: inbound:192.168.0.1:80
+                statPrefix: inbound:192.168.0.1:80.
             - name: envoy.tcp_proxy
               typedConfig:
                 '@type': type.googleapis.com/envoy.config.filter.network.tcp_proxy.v2.TcpProxy

--- a/pkg/xds/generator/testdata/profile-source/2-envoy-config.golden.yaml
+++ b/pkg/xds/generator/testdata/profile-source/2-envoy-config.golden.yaml
@@ -54,7 +54,7 @@ resources:
               typedConfig:
                 '@type': type.googleapis.com/envoy.config.filter.network.rbac.v2.RBAC
                 rules: {}
-                statPrefix: inbound:192.168.0.1:80
+                statPrefix: inbound:192.168.0.1:80.
             - name: envoy.tcp_proxy
               typedConfig:
                 '@type': type.googleapis.com/envoy.config.filter.network.tcp_proxy.v2.TcpProxy

--- a/pkg/xds/generator/testdata/profile-source/3-envoy-config.golden.yaml
+++ b/pkg/xds/generator/testdata/profile-source/3-envoy-config.golden.yaml
@@ -69,7 +69,7 @@ resources:
         typedConfig:
           '@type': type.googleapis.com/envoy.config.filter.network.rbac.v2.RBAC
           rules: {}
-          statPrefix: inbound:192.168.0.1:80
+          statPrefix: inbound:192.168.0.1:80.
       - name: envoy.tcp_proxy
         typedConfig:
           '@type': type.googleapis.com/envoy.config.filter.network.tcp_proxy.v2.TcpProxy

--- a/pkg/xds/generator/testdata/profile-source/4-envoy-config.golden.yaml
+++ b/pkg/xds/generator/testdata/profile-source/4-envoy-config.golden.yaml
@@ -98,7 +98,7 @@ resources:
         typedConfig:
           '@type': type.googleapis.com/envoy.config.filter.network.rbac.v2.RBAC
           rules: {}
-          statPrefix: inbound:192.168.0.1:80
+          statPrefix: inbound:192.168.0.1:80.
       - name: envoy.tcp_proxy
         typedConfig:
           '@type': type.googleapis.com/envoy.config.filter.network.tcp_proxy.v2.TcpProxy

--- a/pkg/xds/generator/testdata/template-proxy/1-envoy-config.golden.yaml
+++ b/pkg/xds/generator/testdata/template-proxy/1-envoy-config.golden.yaml
@@ -54,7 +54,7 @@ resources:
               typedConfig:
                 '@type': type.googleapis.com/envoy.config.filter.network.rbac.v2.RBAC
                 rules: {}
-                statPrefix: inbound:192.168.0.1:80
+                statPrefix: inbound:192.168.0.1:80.
             - name: envoy.tcp_proxy
               typedConfig:
                 '@type': type.googleapis.com/envoy.config.filter.network.tcp_proxy.v2.TcpProxy

--- a/pkg/xds/server/testdata/envoy-config.golden.yaml
+++ b/pkg/xds/server/testdata/envoy-config.golden.yaml
@@ -67,7 +67,7 @@ resources:
               typedConfig:
                 '@type': type.googleapis.com/envoy.config.filter.network.rbac.v2.RBAC
                 rules: {}
-                statPrefix: inbound:192.168.0.1:443
+                statPrefix: inbound:192.168.0.1:443.
             - name: envoy.tcp_proxy
               typedConfig:
                 '@type': type.googleapis.com/envoy.config.filter.network.tcp_proxy.v2.TcpProxy
@@ -126,7 +126,7 @@ resources:
                       - authenticated:
                           principalName:
                             exact: spiffe://default/web1
-                statPrefix: inbound:192.168.0.1:80
+                statPrefix: inbound:192.168.0.1:80.
             - name: envoy.tcp_proxy
               typedConfig:
                 '@type': type.googleapis.com/envoy.config.filter.network.tcp_proxy.v2.TcpProxy
@@ -177,7 +177,7 @@ resources:
               typedConfig:
                 '@type': type.googleapis.com/envoy.config.filter.network.rbac.v2.RBAC
                 rules: {}
-                statPrefix: inbound:192.168.0.2:443
+                statPrefix: inbound:192.168.0.2:443.
             - name: envoy.tcp_proxy
               typedConfig:
                 '@type': type.googleapis.com/envoy.config.filter.network.tcp_proxy.v2.TcpProxy
@@ -228,7 +228,7 @@ resources:
               typedConfig:
                 '@type': type.googleapis.com/envoy.config.filter.network.rbac.v2.RBAC
                 rules: {}
-                statPrefix: inbound:192.168.0.2:80
+                statPrefix: inbound:192.168.0.2:80.
             - name: envoy.tcp_proxy
               typedConfig:
                 '@type': type.googleapis.com/envoy.config.filter.network.tcp_proxy.v2.TcpProxy


### PR DESCRIPTION
### Summary

Some metrics like this
```
# TYPE envoy_inbound_192_168_16_2_39081rbac_shadow_denied counter
envoy_inbound_192_168_16_2_39081rbac_shadow_denied{} 0
```
need some tuning so it will become usable, like this
```
envoy_rbac_shadow_denied{listener=inbound_192_168_16_2_39081}
```

I attach current metrics for statsd and prometheus output with the change
[example_prometheus_metrics.txt](https://github.com/Kong/kuma/files/4098539/example_prometheus_metrics.txt)
[example_statsd_metrics.txt](https://github.com/Kong/kuma/files/4098540/example_statsd_metrics.txt)
