### PR TITLE
Sanitize metrics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 Changes:
 
+* feature: sanitize metrics for StatsD and Prometheus
+  [#562](https://github.com/Kong/kuma/pull/562)
 * feature: reformat some Envoy metrics available in Prometheus
   [#558](https://github.com/Kong/kuma/pull/558)
 * feature: make maximum number of open connections to Postgres configurable

--- a/Makefile.e2e.mk
+++ b/Makefile.e2e.mk
@@ -332,7 +332,7 @@ wait/example/minikube: ## Minikube: Wait for demo setup to get ready
 
 wait/example/minikube/mtls: ## Minikube: Wait until incoming Listener and outgoing Cluster have been configured for mTLS
 	$(call kubectl_exec,kuma-demo,demo-client,demo-client) sh -c 'for i in `seq 1 10`; do echo -n "try #$$i: " ; if [[ $$( $(call envoy_active_mtls_listeners_count,inbound,3000) ) -eq 1 ]]; then echo "listener has been configured for mTLS "; exit 0; fi; sleep 1; done; echo -e "\nError: listener has not been configured for mTLS" ; exit 1'
-	$(call kubectl_exec,kuma-demo,demo-client,demo-client) sh -c 'for i in `seq 1 10`; do echo -n "try #$$i: " ; if [[ $$( $(call envoy_active_mtls_clusters_count,demo-app.kuma-demo.svc:8000) ) -eq 1 ]]; then echo "cluster has been configured for mTLS "; exit 0; fi; sleep 1; done; echo -e "\nError: cluster has not been configured for mTLS" ; exit 1'
+	$(call kubectl_exec,kuma-demo,demo-client,demo-client) sh -c 'for i in `seq 1 10`; do echo -n "try #$$i: " ; if [[ $$( $(call envoy_active_mtls_clusters_count,demo-app_kuma-demo_svc_8000) ) -eq 1 ]]; then echo "cluster has been configured for mTLS "; exit 0; fi; sleep 1; done; echo -e "\nError: cluster has not been configured for mTLS" ; exit 1'
 
 curl/example/minikube: ## Minikube: Make sample requests to demo setup
 	$(call kubectl_exec,kuma-demo,demo-client,demo-client) $(call curl_example_client)
@@ -352,7 +352,7 @@ verify/example/minikube/mtls: verify/example/minikube/mtls/outbound ## Minikube:
 
 verify/example/minikube/mtls/outbound:
 	@echo "Checking number of Outbound mTLS requests via Envoy ..."
-	test $$( $(call kubectl_exec,kuma-demo,demo-client,kuma-sidecar) wget -qO- http://localhost:9901/stats/prometheus | grep 'envoy_cluster_kuma_demo_svc_8000_ssl_handshake{envoy_cluster_name="demo-app"}' | awk '{print $$2}' | tr -d [:space:] ) -ge 5
+	test $$( $(call kubectl_exec,kuma-demo,demo-client,kuma-sidecar) wget -qO- http://localhost:9901/stats/prometheus | grep 'envoy_cluster_ssl_handshake{envoy_cluster_name="demo-app_kuma-demo_svc_8000"}' | awk '{print $$2}' | tr -d [:space:] ) -ge 5
 	@echo "Check passed!"
 
 kumactl/example/minikube:
@@ -404,7 +404,7 @@ wait/traffic-routing/minikube/mtls: ## Minikube: Wait until incoming Listener an
 	@echo "Waiting until incoming Listener and outgoing Cluster have been configured for mTLS ..."
 	@echo
 	$(call kubectl_exec,kuma-example,kuma-example-web,kuma-example-web) sh -c 'for i in `seq 1 10`; do echo -n "try #$$i: " ; if [[ $$( $(call envoy_active_mtls_listeners_count,inbound,6060) ) -eq 1 ]]; then echo "listener has been configured for mTLS "; exit 0; fi; sleep 1; done; echo -e "\nError: listener has not been configured for mTLS" ; exit 1'
-	$(call kubectl_exec,kuma-example,kuma-example-web,kuma-example-web) sh -c 'for i in `seq 1 10`; do echo -n "try #$$i: " ; if [[ $$( $(call envoy_active_mtls_clusters_count,kuma-example-backend.kuma-example.svc:7070) ) -eq 1 ]]; then echo "cluster has been configured for mTLS "; exit 0; fi; sleep 1; done; echo -e "\nError: cluster has not been configured for mTLS" ; exit 1'
+	$(call kubectl_exec,kuma-example,kuma-example-web,kuma-example-web) sh -c 'for i in `seq 1 10`; do echo -n "try #$$i: " ; if [[ $$( $(call envoy_active_mtls_clusters_count,kuma-example-backend_kuma-example_svc_7070) ) -eq 1 ]]; then echo "cluster has been configured for mTLS "; exit 0; fi; sleep 1; done; echo -e "\nError: cluster has not been configured for mTLS" ; exit 1'
 
 apply/traffic-routing/minikube/no-mtls: ## Minikube: disable mTLS
 	@echo
@@ -417,7 +417,7 @@ wait/traffic-routing/minikube/no-mtls: ## Minikube: Wait until mTLS has been dis
 	@echo "Waiting until mTLS has been disabled on incoming Listener and outgoing Cluster ..."
 	@echo
 	$(call kubectl_exec,kuma-example,kuma-example-web,kuma-example-web) sh -c 'for i in `seq 1 10`; do echo -n "try #$$i: " ; if [[ $$( $(call envoy_active_mtls_listeners_count,inbound,6060) ) -eq 0 ]]; then echo "listener is no longer configured for mTLS "; exit 0; fi; sleep 1; done; echo -e "\nError: listener is still configured for mTLS" ; exit 1'
-	$(call kubectl_exec,kuma-example,kuma-example-web,kuma-example-web) sh -c 'for i in `seq 1 10`; do echo -n "try #$$i: " ; if [[ $$( $(call envoy_active_mtls_clusters_count,kuma-example-backend.kuma-example.svc:7070) ) -eq 0 ]]; then echo "cluster is no longer configured for mTLS "; exit 0; fi; sleep 1; done; echo -e "\nError: cluster is still configured for mTLS" ; exit 1'
+	$(call kubectl_exec,kuma-example,kuma-example-web,kuma-example-web) sh -c 'for i in `seq 1 10`; do echo -n "try #$$i: " ; if [[ $$( $(call envoy_active_mtls_clusters_count,kuma-example-backend_kuma-example_svc_7070) ) -eq 0 ]]; then echo "cluster is no longer configured for mTLS "; exit 0; fi; sleep 1; done; echo -e "\nError: cluster is still configured for mTLS" ; exit 1'
 
 wait/traffic-routing/minikube: ## Minikube: Wait for example setup for TrafficRoute to get ready
 	@echo
@@ -442,8 +442,8 @@ wait/traffic-routing/minikube/web-to-backend-route: ## Minikube: Wait until cust
 	@echo
 	@echo "Waiting until custom 'web-to-backend' TrafficRoute is applied ..."
 	@echo
-	$(call kubectl_exec,kuma-example,kuma-example-web,kuma-example-web) sh -c 'for i in `seq 1 10`; do echo -n "try #$$i: " ; if [[ $$( $(call envoy_active_routing_listeners_count,outbound,7070,kuma-example-backend.kuma-example.svc:7070{version=v2}) ) -eq 1 ]]; then echo "listener is now configured for subset routing "; exit 0; fi; sleep 1; done; echo -e "\nError: listener has not been configured for subset routing" ; exit 1'
-	$(call kubectl_exec,kuma-example,kuma-example-web,kuma-example-web) sh -c 'for i in `seq 1 10`; do echo -n "try #$$i: " ; if [[ $$( $(call envoy_active_routing_clusters_count,kuma-example-backend.kuma-example.svc:7070{version=v2}) ) -eq 1 ]]; then echo "cluster is now configured for subset routing "; exit 0; fi; sleep 1; done; echo -e "\nError: cluster has not been configured for subset routing" ; exit 1'
+	$(call kubectl_exec,kuma-example,kuma-example-web,kuma-example-web) sh -c 'for i in `seq 1 10`; do echo -n "try #$$i: " ; if [[ $$( $(call envoy_active_routing_listeners_count,outbound,7070,kuma-example-backend_kuma-example_svc_7070{version=v2}) ) -eq 1 ]]; then echo "listener is now configured for subset routing "; exit 0; fi; sleep 1; done; echo -e "\nError: listener has not been configured for subset routing" ; exit 1'
+	$(call kubectl_exec,kuma-example,kuma-example-web,kuma-example-web) sh -c 'for i in `seq 1 10`; do echo -n "try #$$i: " ; if [[ $$( $(call envoy_active_routing_clusters_count,kuma-example-backend_kuma-example_svc_7070{version=v2}) ) -eq 1 ]]; then echo "cluster is now configured for subset routing "; exit 0; fi; sleep 1; done; echo -e "\nError: cluster has not been configured for subset routing" ; exit 1'
 
 verify/traffic-routing/minikube/web-to-backend-route: ## Minikube: Make sample requests to example setup for TrafficRoute
 	@echo
@@ -462,8 +462,8 @@ wait/traffic-routing/minikube/no-web-to-backend-route: ## Minikube: Wait until c
 	@echo
 	@echo "Waiting until custom 'web-to-backend' TrafficRoute is removed ..."
 	@echo
-	$(call kubectl_exec,kuma-example,kuma-example-web,kuma-example-web) sh -c 'for i in `seq 1 10`; do echo -n "try #$$i: " ; if [[ $$( $(call envoy_active_routing_listeners_count,outbound,7070,kuma-example-backend.kuma-example.svc:7070{version=v2}) ) -eq 0 ]]; then echo "listener is no longer configured for subset routing "; exit 0; fi; sleep 1; done; echo -e "\nError: listener is still configured for subset routing" ; exit 1'
-	$(call kubectl_exec,kuma-example,kuma-example-web,kuma-example-web) sh -c 'for i in `seq 1 10`; do echo -n "try #$$i: " ; if [[ $$( $(call envoy_active_routing_clusters_count,kuma-example-backend.kuma-example.svc:7070{version=v2}) ) -eq 0 ]]; then echo "cluster is no longer configured for subset routing "; exit 0; fi; sleep 1; done; echo -e "\nError: cluster is still configured for subset routing" ; exit 1'
+	$(call kubectl_exec,kuma-example,kuma-example-web,kuma-example-web) sh -c 'for i in `seq 1 10`; do echo -n "try #$$i: " ; if [[ $$( $(call envoy_active_routing_listeners_count,outbound,7070,kuma-example-backend_kuma-example_svc_7070{version=v2}) ) -eq 0 ]]; then echo "listener is no longer configured for subset routing "; exit 0; fi; sleep 1; done; echo -e "\nError: listener is still configured for subset routing" ; exit 1'
+	$(call kubectl_exec,kuma-example,kuma-example-web,kuma-example-web) sh -c 'for i in `seq 1 10`; do echo -n "try #$$i: " ; if [[ $$( $(call envoy_active_routing_clusters_count,kuma-example-backend_kuma-example_svc_7070{version=v2}) ) -eq 0 ]]; then echo "cluster is no longer configured for subset routing "; exit 0; fi; sleep 1; done; echo -e "\nError: cluster is still configured for subset routing" ; exit 1'
 
 undeploy/traffic-routing/minikube: ## Minikube: Undeploy example setup for TrafficRoute
 	@echo

--- a/Makefile.e2e.mk
+++ b/Makefile.e2e.mk
@@ -332,7 +332,7 @@ wait/example/minikube: ## Minikube: Wait for demo setup to get ready
 
 wait/example/minikube/mtls: ## Minikube: Wait until incoming Listener and outgoing Cluster have been configured for mTLS
 	$(call kubectl_exec,kuma-demo,demo-client,demo-client) sh -c 'for i in `seq 1 10`; do echo -n "try #$$i: " ; if [[ $$( $(call envoy_active_mtls_listeners_count,inbound,3000) ) -eq 1 ]]; then echo "listener has been configured for mTLS "; exit 0; fi; sleep 1; done; echo -e "\nError: listener has not been configured for mTLS" ; exit 1'
-	$(call kubectl_exec,kuma-demo,demo-client,demo-client) sh -c 'for i in `seq 1 10`; do echo -n "try #$$i: " ; if [[ $$( $(call envoy_active_mtls_clusters_count,demo-app_kuma-demo_svc_8000) ) -eq 1 ]]; then echo "cluster has been configured for mTLS "; exit 0; fi; sleep 1; done; echo -e "\nError: cluster has not been configured for mTLS" ; exit 1'
+	$(call kubectl_exec,kuma-demo,demo-client,demo-client) sh -c 'for i in `seq 1 10`; do echo -n "try #$$i: " ; if [[ $$( $(call envoy_active_mtls_clusters_count,demo-app.kuma-demo.svc:8000) ) -eq 1 ]]; then echo "cluster has been configured for mTLS "; exit 0; fi; sleep 1; done; echo -e "\nError: cluster has not been configured for mTLS" ; exit 1'
 
 curl/example/minikube: ## Minikube: Make sample requests to demo setup
 	$(call kubectl_exec,kuma-demo,demo-client,demo-client) $(call curl_example_client)
@@ -404,7 +404,7 @@ wait/traffic-routing/minikube/mtls: ## Minikube: Wait until incoming Listener an
 	@echo "Waiting until incoming Listener and outgoing Cluster have been configured for mTLS ..."
 	@echo
 	$(call kubectl_exec,kuma-example,kuma-example-web,kuma-example-web) sh -c 'for i in `seq 1 10`; do echo -n "try #$$i: " ; if [[ $$( $(call envoy_active_mtls_listeners_count,inbound,6060) ) -eq 1 ]]; then echo "listener has been configured for mTLS "; exit 0; fi; sleep 1; done; echo -e "\nError: listener has not been configured for mTLS" ; exit 1'
-	$(call kubectl_exec,kuma-example,kuma-example-web,kuma-example-web) sh -c 'for i in `seq 1 10`; do echo -n "try #$$i: " ; if [[ $$( $(call envoy_active_mtls_clusters_count,kuma-example-backend_kuma-example_svc_7070) ) -eq 1 ]]; then echo "cluster has been configured for mTLS "; exit 0; fi; sleep 1; done; echo -e "\nError: cluster has not been configured for mTLS" ; exit 1'
+	$(call kubectl_exec,kuma-example,kuma-example-web,kuma-example-web) sh -c 'for i in `seq 1 10`; do echo -n "try #$$i: " ; if [[ $$( $(call envoy_active_mtls_clusters_count,kuma-example-backend.kuma-example.svc:7070) ) -eq 1 ]]; then echo "cluster has been configured for mTLS "; exit 0; fi; sleep 1; done; echo -e "\nError: cluster has not been configured for mTLS" ; exit 1'
 
 apply/traffic-routing/minikube/no-mtls: ## Minikube: disable mTLS
 	@echo
@@ -417,7 +417,7 @@ wait/traffic-routing/minikube/no-mtls: ## Minikube: Wait until mTLS has been dis
 	@echo "Waiting until mTLS has been disabled on incoming Listener and outgoing Cluster ..."
 	@echo
 	$(call kubectl_exec,kuma-example,kuma-example-web,kuma-example-web) sh -c 'for i in `seq 1 10`; do echo -n "try #$$i: " ; if [[ $$( $(call envoy_active_mtls_listeners_count,inbound,6060) ) -eq 0 ]]; then echo "listener is no longer configured for mTLS "; exit 0; fi; sleep 1; done; echo -e "\nError: listener is still configured for mTLS" ; exit 1'
-	$(call kubectl_exec,kuma-example,kuma-example-web,kuma-example-web) sh -c 'for i in `seq 1 10`; do echo -n "try #$$i: " ; if [[ $$( $(call envoy_active_mtls_clusters_count,kuma-example-backend_kuma-example_svc_7070) ) -eq 0 ]]; then echo "cluster is no longer configured for mTLS "; exit 0; fi; sleep 1; done; echo -e "\nError: cluster is still configured for mTLS" ; exit 1'
+	$(call kubectl_exec,kuma-example,kuma-example-web,kuma-example-web) sh -c 'for i in `seq 1 10`; do echo -n "try #$$i: " ; if [[ $$( $(call envoy_active_mtls_clusters_count,kuma-example-backend.kuma-example.svc:7070) ) -eq 0 ]]; then echo "cluster is no longer configured for mTLS "; exit 0; fi; sleep 1; done; echo -e "\nError: cluster is still configured for mTLS" ; exit 1'
 
 wait/traffic-routing/minikube: ## Minikube: Wait for example setup for TrafficRoute to get ready
 	@echo
@@ -442,8 +442,8 @@ wait/traffic-routing/minikube/web-to-backend-route: ## Minikube: Wait until cust
 	@echo
 	@echo "Waiting until custom 'web-to-backend' TrafficRoute is applied ..."
 	@echo
-	$(call kubectl_exec,kuma-example,kuma-example-web,kuma-example-web) sh -c 'for i in `seq 1 10`; do echo -n "try #$$i: " ; if [[ $$( $(call envoy_active_routing_listeners_count,outbound,7070,kuma-example-backend_kuma-example_svc_7070{version=v2}) ) -eq 1 ]]; then echo "listener is now configured for subset routing "; exit 0; fi; sleep 1; done; echo -e "\nError: listener has not been configured for subset routing" ; exit 1'
-	$(call kubectl_exec,kuma-example,kuma-example-web,kuma-example-web) sh -c 'for i in `seq 1 10`; do echo -n "try #$$i: " ; if [[ $$( $(call envoy_active_routing_clusters_count,kuma-example-backend_kuma-example_svc_7070{version=v2}) ) -eq 1 ]]; then echo "cluster is now configured for subset routing "; exit 0; fi; sleep 1; done; echo -e "\nError: cluster has not been configured for subset routing" ; exit 1'
+	$(call kubectl_exec,kuma-example,kuma-example-web,kuma-example-web) sh -c 'for i in `seq 1 10`; do echo -n "try #$$i: " ; if [[ $$( $(call envoy_active_routing_listeners_count,outbound,7070,kuma-example-backend.kuma-example.svc:7070{version=v2}) ) -eq 1 ]]; then echo "listener is now configured for subset routing "; exit 0; fi; sleep 1; done; echo -e "\nError: listener has not been configured for subset routing" ; exit 1'
+	$(call kubectl_exec,kuma-example,kuma-example-web,kuma-example-web) sh -c 'for i in `seq 1 10`; do echo -n "try #$$i: " ; if [[ $$( $(call envoy_active_routing_clusters_count,kuma-example-backend.kuma-example.svc:7070{version=v2}) ) -eq 1 ]]; then echo "cluster is now configured for subset routing "; exit 0; fi; sleep 1; done; echo -e "\nError: cluster has not been configured for subset routing" ; exit 1'
 
 verify/traffic-routing/minikube/web-to-backend-route: ## Minikube: Make sample requests to example setup for TrafficRoute
 	@echo
@@ -462,8 +462,8 @@ wait/traffic-routing/minikube/no-web-to-backend-route: ## Minikube: Wait until c
 	@echo
 	@echo "Waiting until custom 'web-to-backend' TrafficRoute is removed ..."
 	@echo
-	$(call kubectl_exec,kuma-example,kuma-example-web,kuma-example-web) sh -c 'for i in `seq 1 10`; do echo -n "try #$$i: " ; if [[ $$( $(call envoy_active_routing_listeners_count,outbound,7070,kuma-example-backend_kuma-example_svc_7070{version=v2}) ) -eq 0 ]]; then echo "listener is no longer configured for subset routing "; exit 0; fi; sleep 1; done; echo -e "\nError: listener is still configured for subset routing" ; exit 1'
-	$(call kubectl_exec,kuma-example,kuma-example-web,kuma-example-web) sh -c 'for i in `seq 1 10`; do echo -n "try #$$i: " ; if [[ $$( $(call envoy_active_routing_clusters_count,kuma-example-backend_kuma-example_svc_7070{version=v2}) ) -eq 0 ]]; then echo "cluster is no longer configured for subset routing "; exit 0; fi; sleep 1; done; echo -e "\nError: cluster is still configured for subset routing" ; exit 1'
+	$(call kubectl_exec,kuma-example,kuma-example-web,kuma-example-web) sh -c 'for i in `seq 1 10`; do echo -n "try #$$i: " ; if [[ $$( $(call envoy_active_routing_listeners_count,outbound,7070,kuma-example-backend.kuma-example.svc:7070{version=v2}) ) -eq 0 ]]; then echo "listener is no longer configured for subset routing "; exit 0; fi; sleep 1; done; echo -e "\nError: listener is still configured for subset routing" ; exit 1'
+	$(call kubectl_exec,kuma-example,kuma-example-web,kuma-example-web) sh -c 'for i in `seq 1 10`; do echo -n "try #$$i: " ; if [[ $$( $(call envoy_active_routing_clusters_count,kuma-example-backend.kuma-example.svc:7070{version=v2}) ) -eq 0 ]]; then echo "cluster is no longer configured for subset routing "; exit 0; fi; sleep 1; done; echo -e "\nError: cluster is still configured for subset routing" ; exit 1'
 
 undeploy/traffic-routing/minikube: ## Minikube: Undeploy example setup for TrafficRoute
 	@echo

--- a/pkg/util/xds/metric_sanitizer.go
+++ b/pkg/util/xds/metric_sanitizer.go
@@ -7,7 +7,7 @@ import (
 
 var (
 	whitespaces  = regexp.MustCompile(`\s+`)
-	illegalChars = regexp.MustCompile(`[^a-zA-Z_\-0-9{}=]`)
+	illegalChars = regexp.MustCompile(`[^a-zA-Z_\-0-9]`)
 )
 
 func SanitizeMetric(metric string) string {

--- a/pkg/util/xds/metric_sanitizer.go
+++ b/pkg/util/xds/metric_sanitizer.go
@@ -2,17 +2,15 @@ package xds
 
 import (
 	"regexp"
-	"strings"
 )
 
 var (
-	whitespaces  = regexp.MustCompile(`\s+`)
 	illegalChars = regexp.MustCompile(`[^a-zA-Z_\-0-9]`)
 )
 
+// We need to sanitize metrics in order to  not break statsd and prometheus format.
+// StatsD only allow [a-zA-Z_\-0-9.] characters, everything else is removed
+// Extra dots breaks many regexes that converts statsd metric to prometheus one with tags
 func SanitizeMetric(metric string) string {
-	result := whitespaces.ReplaceAllString(metric, "_")
-	result = strings.ReplaceAll(result, "/", "_")
-	result = illegalChars.ReplaceAllString(result, "_")
-	return result
+	return illegalChars.ReplaceAllString(metric, "_")
 }

--- a/pkg/util/xds/metric_sanitizer.go
+++ b/pkg/util/xds/metric_sanitizer.go
@@ -1,0 +1,18 @@
+package xds
+
+import (
+	"regexp"
+	"strings"
+)
+
+var (
+	whitespaces  = regexp.MustCompile(`\s+`)
+	illegalChars = regexp.MustCompile(`[^a-zA-Z_\-0-9{}=]`)
+)
+
+func SanitizeMetric(metric string) string {
+	result := whitespaces.ReplaceAllString(metric, "_")
+	result = strings.ReplaceAll(result, "/", "_")
+	result = illegalChars.ReplaceAllString(result, "_")
+	return result
+}

--- a/pkg/util/xds/metric_sanitizer_test.go
+++ b/pkg/util/xds/metric_sanitizer_test.go
@@ -9,12 +9,12 @@ import (
 var _ = Describe("Metric sanitizer", func() {
 	It("should sanitize metrics", func() {
 		// given
-		metric := "some metric with chars :/_-0123{}"
+		metric := "some metric with chars :/_-0123{version=3.0}"
 
 		// when
 		sanitized := xds.SanitizeMetric(metric)
 
 		// then
-		Expect(sanitized).To(Equal("some_metric_with_chars____-0123{}"))
+		Expect(sanitized).To(Equal("some_metric_with_chars____-0123_version_3_0_"))
 	})
 })

--- a/pkg/util/xds/metric_sanitizer_test.go
+++ b/pkg/util/xds/metric_sanitizer_test.go
@@ -1,0 +1,20 @@
+package xds_test
+
+import (
+	"github.com/Kong/kuma/pkg/util/xds"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("Metric sanitizer", func() {
+	It("should sanitize metrics", func() {
+		// given
+		metric := "some metric with chars :/_-0123{}"
+
+		// when
+		sanitized := xds.SanitizeMetric(metric)
+
+		// then
+		Expect(sanitized).To(Equal("some_metric_with_chars____-0123{}"))
+	})
+})

--- a/pkg/xds/envoy/envoy.go
+++ b/pkg/xds/envoy/envoy.go
@@ -15,6 +15,7 @@ import (
 	mesh_core "github.com/Kong/kuma/pkg/core/resources/apis/mesh"
 	core_xds "github.com/Kong/kuma/pkg/core/xds"
 	util_error "github.com/Kong/kuma/pkg/util/error"
+	util_xds "github.com/Kong/kuma/pkg/util/xds"
 	xds_context "github.com/Kong/kuma/pkg/xds/context"
 	v2 "github.com/envoyproxy/go-control-plane/envoy/api/v2"
 	envoy_cluster "github.com/envoyproxy/go-control-plane/envoy/api/v2/cluster"
@@ -185,7 +186,7 @@ func CreateOutboundListener(ctx xds_context.Context, listenerName string, addres
 	}
 
 	config := &envoy_tcp.TcpProxy{
-		StatPrefix: statsName,
+		StatPrefix: util_xds.SanitizeMetric(statsName),
 		AccessLog:  accessLogs,
 	}
 	if len(clusters) == 1 {
@@ -241,7 +242,7 @@ func CreateOutboundListener(ctx xds_context.Context, listenerName string, addres
 
 func CreateInboundListener(ctx xds_context.Context, listenerName string, address string, port uint32, clusterName string, virtual bool, permissions *mesh_core.TrafficPermissionResourceList, metadata *core_xds.DataplaneMetadata) *v2.Listener {
 	config := &envoy_tcp.TcpProxy{
-		StatPrefix: clusterName,
+		StatPrefix: util_xds.SanitizeMetric(clusterName),
 		ClusterSpecifier: &envoy_tcp.TcpProxy_Cluster{
 			Cluster: clusterName,
 		},
@@ -289,7 +290,7 @@ func CreateInboundListener(ctx xds_context.Context, listenerName string, address
 
 func CreatePrometheusListener(ctx xds_context.Context, listenerName string, address string, port uint32, path string, clusterName string, virtual bool, metadata *core_xds.DataplaneMetadata) *v2.Listener {
 	config := &envoy_hcm.HttpConnectionManager{
-		StatPrefix: listenerName,
+		StatPrefix: util_xds.SanitizeMetric(listenerName),
 		CodecType:  envoy_hcm.HttpConnectionManager_AUTO,
 		HttpFilters: []*envoy_hcm.HttpFilter{{
 			Name: wellknown.Router,
@@ -423,7 +424,7 @@ func sdsSecretConfig(context xds_context.Context, name string, metadata *core_xd
 							TargetSpecifier: &envoy_core.GrpcService_GoogleGrpc_{
 								GoogleGrpc: withCallCredentials(&envoy_core.GrpcService_GoogleGrpc{
 									TargetUri:  context.ControlPlane.SdsLocation,
-									StatPrefix: "sds_" + name,
+									StatPrefix: util_xds.SanitizeMetric("sds_" + name),
 									ChannelCredentials: &envoy_core.GrpcService_GoogleGrpc_ChannelCredentials{
 										CredentialSpecifier: &envoy_core.GrpcService_GoogleGrpc_ChannelCredentials_SslCredentials{
 											SslCredentials: &envoy_core.GrpcService_GoogleGrpc_SslCredentials{
@@ -447,7 +448,7 @@ func sdsSecretConfig(context xds_context.Context, name string, metadata *core_xd
 
 func CreateCatchAllListener(ctx xds_context.Context, listenerName string, address string, port uint32, clusterName string) *v2.Listener {
 	config := &envoy_tcp.TcpProxy{
-		StatPrefix: clusterName,
+		StatPrefix: util_xds.SanitizeMetric(clusterName),
 		ClusterSpecifier: &envoy_tcp.TcpProxy_Cluster{
 			Cluster: clusterName,
 		},

--- a/pkg/xds/envoy/envoy_test.go
+++ b/pkg/xds/envoy/envoy_test.go
@@ -48,6 +48,7 @@ var _ = Describe("Envoy", func() {
 		// given
 		expected := `
         name: localhost:8080
+        altStatName: localhost_8080
         type: STATIC
         connectTimeout: 5s
         loadAssignment:
@@ -178,6 +179,7 @@ var _ = Describe("Envoy", func() {
                   edsConfig:
                     ads: {}
                 name: 192.168.0.1:8080
+                altStatName: "192_168_0_1_8080"
                 type: EDS
 `,
 			}),
@@ -204,6 +206,7 @@ var _ = Describe("Envoy", func() {
                   edsConfig:
                     ads: {}
                 name: 192.168.0.1:8080
+                altStatName: "192_168_0_1_8080"
                 tlsContext:
                   commonTlsContext:
                     tlsCertificateSdsSecretConfigs:
@@ -260,6 +263,7 @@ var _ = Describe("Envoy", func() {
                   edsConfig:
                     ads: {}
                 name: 192.168.0.1:8080
+                altStatName: "192_168_0_1_8080"
                 tlsContext:
                   commonTlsContext:
                     tlsCertificateSdsSecretConfigs:

--- a/pkg/xds/envoy/envoy_test.go
+++ b/pkg/xds/envoy/envoy_test.go
@@ -578,7 +578,7 @@ var _ = Describe("Envoy", func() {
                     typedConfig:
                       '@type': type.googleapis.com/envoy.config.filter.network.tcp_proxy.v2.TcpProxy
                       cluster: localhost:8080
-                      statPrefix: localhost:8080
+                      statPrefix: localhost_8080
 `,
 			}),
 			Entry("with transparent proxying", testCase{
@@ -601,7 +601,7 @@ var _ = Describe("Envoy", func() {
                     typedConfig:
                       '@type': type.googleapis.com/envoy.config.filter.network.tcp_proxy.v2.TcpProxy
                       cluster: localhost:8080
-                      statPrefix: localhost:8080
+                      statPrefix: localhost_8080
                 deprecatedV1:
                   bindToPort: false
 `,
@@ -642,12 +642,12 @@ var _ = Describe("Envoy", func() {
                       - authenticated:
                           principalName:
                             exact: spiffe://default/web1
-                statPrefix: inbound:192.168.0.1:8080.
+                statPrefix: inbound_192_168_0_1_8080.
             - name: envoy.tcp_proxy
               typedConfig:
                 '@type': type.googleapis.com/envoy.config.filter.network.tcp_proxy.v2.TcpProxy
                 cluster: localhost:8080
-                statPrefix: localhost:8080
+                statPrefix: localhost_8080
             tlsContext:
               commonTlsContext:
                 tlsCertificateSdsSecretConfigs:
@@ -719,12 +719,12 @@ var _ = Describe("Envoy", func() {
                       - authenticated:
                           principalName:
                             exact: spiffe://default/web1
-                statPrefix: inbound:192.168.0.1:8080.
+                statPrefix: inbound_192_168_0_1_8080.
             - name: envoy.tcp_proxy
               typedConfig:
                 '@type': type.googleapis.com/envoy.config.filter.network.tcp_proxy.v2.TcpProxy
                 cluster: localhost:8080
-                statPrefix: localhost:8080
+                statPrefix: localhost_8080
             tlsContext:
               commonTlsContext:
                 tlsCertificateSdsSecretConfigs:

--- a/pkg/xds/envoy/rbac.go
+++ b/pkg/xds/envoy/rbac.go
@@ -5,6 +5,7 @@ import (
 	"github.com/Kong/kuma/api/mesh/v1alpha1"
 	mesh_core "github.com/Kong/kuma/pkg/core/resources/apis/mesh"
 	util_error "github.com/Kong/kuma/pkg/util/error"
+	util_xds "github.com/Kong/kuma/pkg/util/xds"
 	envoy_listener "github.com/envoyproxy/go-control-plane/envoy/api/v2/listener"
 	rbac "github.com/envoyproxy/go-control-plane/envoy/config/filter/network/rbac/v2"
 	rbac_config "github.com/envoyproxy/go-control-plane/envoy/config/rbac/v2"
@@ -38,7 +39,7 @@ func createRbacRule(listenerName string, permissions *mesh_core.TrafficPermissio
 			Action:   rbac_config.RBAC_ALLOW,
 			Policies: policies,
 		},
-		StatPrefix: fmt.Sprintf("%s.", listenerName), // we include dot to change "inbound:127.0.0.1:21011rbac.allowed" metric to "inbound:127.0.0.1:21011.rbac.allowed"
+		StatPrefix: fmt.Sprintf("%s.", util_xds.SanitizeMetric(listenerName)), // we include dot to change "inbound:127.0.0.1:21011rbac.allowed" metric to "inbound:127.0.0.1:21011.rbac.allowed"
 	}
 }
 

--- a/pkg/xds/generator/outbound_proxy_generator_test.go
+++ b/pkg/xds/generator/outbound_proxy_generator_test.go
@@ -213,7 +213,7 @@ var _ = Describe("OutboundProxyGenerator", func() {
 		}),
 	)
 
-	It("Sanitize cluster names", func() {
+	It("Add sanitized alternative cluster name for stats", func() {
 		// setup
 		gen := &generator.OutboundProxyGenerator{}
 		dp := `

--- a/pkg/xds/generator/prometheus_endpoint_generator_test.go
+++ b/pkg/xds/generator/prometheus_endpoint_generator_test.go
@@ -225,6 +225,7 @@ var _ = Describe("PrometheusEndpointGenerator", func() {
                             address: 127.0.0.1
                             portValue: 9902
                 name: kuma:envoy:admin
+                altStatName: kuma_envoy_admin
                 type: STATIC
             - name: kuma:metrics:prometheus
               resource:
@@ -309,6 +310,7 @@ var _ = Describe("PrometheusEndpointGenerator", func() {
                             address: 127.0.0.1
                             portValue: 9902
                 name: kuma:envoy:admin
+                altStatName: kuma_envoy_admin
                 type: STATIC
             - name: kuma:metrics:prometheus
               resource:

--- a/pkg/xds/generator/prometheus_endpoint_generator_test.go
+++ b/pkg/xds/generator/prometheus_endpoint_generator_test.go
@@ -251,7 +251,7 @@ var _ = Describe("PrometheusEndpointGenerator", func() {
                             route:
                               cluster: kuma:envoy:admin
                               prefixRewrite: /stats/prometheus
-                      statPrefix: kuma:metrics:prometheus
+                      statPrefix: kuma_metrics_prometheus
                 name: kuma:metrics:prometheus
 `,
 		}),
@@ -335,7 +335,7 @@ var _ = Describe("PrometheusEndpointGenerator", func() {
                             route:
                               cluster: kuma:envoy:admin
                               prefixRewrite: /stats/prometheus
-                      statPrefix: kuma:metrics:prometheus
+                      statPrefix: kuma_metrics_prometheus
                 name: kuma:metrics:prometheus
 `,
 		}),

--- a/pkg/xds/generator/proxy_template.go
+++ b/pkg/xds/generator/proxy_template.go
@@ -12,7 +12,6 @@ import (
 	"github.com/Kong/kuma/pkg/core/validators"
 	model "github.com/Kong/kuma/pkg/core/xds"
 	util_envoy "github.com/Kong/kuma/pkg/util/envoy"
-	util_xds "github.com/Kong/kuma/pkg/util/xds"
 	xds_context "github.com/Kong/kuma/pkg/xds/context"
 	"github.com/Kong/kuma/pkg/xds/envoy"
 )
@@ -230,10 +229,8 @@ func destinationClusterName(service string, selector map[string]string) string {
 		pairs = append(pairs, fmt.Sprintf("%s=%s", key, value))
 	}
 	if len(pairs) == 0 {
-		// we need to replace . in cluster name to _ to have consistent metrics across all the environments.
-		// Otherwise on K8S we would have backend.kuma-system.svc_1234 which breaks prometheus metrics converter.
-		return util_xds.SanitizeMetric(service)
+		return service
 	}
 	sort.Strings(pairs)
-	return util_xds.SanitizeMetric(fmt.Sprintf("%s{%s}", service, strings.Join(pairs, ",")))
+	return fmt.Sprintf("%s{%s}", service, strings.Join(pairs, ","))
 }

--- a/pkg/xds/generator/testdata/inbound-proxy/3-envoy-config.golden.yaml
+++ b/pkg/xds/generator/testdata/inbound-proxy/3-envoy-config.golden.yaml
@@ -36,12 +36,12 @@ resources:
                       - authenticated:
                           principalName:
                             exact: spiffe://default/web1
-                statPrefix: inbound:192.168.0.1:80.
+                statPrefix: inbound_192_168_0_1_80.
             - name: envoy.tcp_proxy
               typedConfig:
                 '@type': type.googleapis.com/envoy.config.filter.network.tcp_proxy.v2.TcpProxy
                 cluster: localhost:8080
-                statPrefix: localhost:8080
+                statPrefix: localhost_8080
           tlsContext:
             commonTlsContext:
               tlsCertificateSdsSecretConfigs:

--- a/pkg/xds/generator/testdata/inbound-proxy/3-envoy-config.golden.yaml
+++ b/pkg/xds/generator/testdata/inbound-proxy/3-envoy-config.golden.yaml
@@ -13,6 +13,7 @@ resources:
                       address: 127.0.0.1
                       portValue: 8080
       name: localhost:8080
+      altStatName: localhost_8080
       type: STATIC
   - name: inbound:192.168.0.1:80
     resource:

--- a/pkg/xds/generator/testdata/inbound-proxy/4-envoy-config.golden.yaml
+++ b/pkg/xds/generator/testdata/inbound-proxy/4-envoy-config.golden.yaml
@@ -38,12 +38,12 @@ resources:
                       - authenticated:
                           principalName:
                             exact: spiffe://default/web1
-                statPrefix: inbound:192.168.0.1:80.
+                statPrefix: inbound_192_168_0_1_80.
             - name: envoy.tcp_proxy
               typedConfig:
                 '@type': type.googleapis.com/envoy.config.filter.network.tcp_proxy.v2.TcpProxy
                 cluster: localhost:8080
-                statPrefix: localhost:8080
+                statPrefix: localhost_8080
           tlsContext:
             commonTlsContext:
               tlsCertificateSdsSecretConfigs:

--- a/pkg/xds/generator/testdata/inbound-proxy/4-envoy-config.golden.yaml
+++ b/pkg/xds/generator/testdata/inbound-proxy/4-envoy-config.golden.yaml
@@ -13,6 +13,7 @@ resources:
                       address: 127.0.0.1
                       portValue: 8080
       name: localhost:8080
+      altStatName: localhost_8080
       type: STATIC
   - name: inbound:192.168.0.1:80
     resource:

--- a/pkg/xds/generator/testdata/inbound-proxy/5-envoy-config.golden.yaml
+++ b/pkg/xds/generator/testdata/inbound-proxy/5-envoy-config.golden.yaml
@@ -13,6 +13,7 @@ resources:
                       address: 127.0.0.1
                       portValue: 8080
       name: localhost:8080
+      altStatName: localhost_8080
       type: STATIC
   - name: inbound:192.168.0.1:80
     resource:
@@ -85,6 +86,7 @@ resources:
                       address: 127.0.0.1
                       portValue: 8443
       name: localhost:8443
+      altStatName: localhost_8443
       type: STATIC
   - name: inbound:192.168.0.1:443
     resource:

--- a/pkg/xds/generator/testdata/inbound-proxy/5-envoy-config.golden.yaml
+++ b/pkg/xds/generator/testdata/inbound-proxy/5-envoy-config.golden.yaml
@@ -35,12 +35,12 @@ resources:
                       - authenticated:
                           principalName:
                             exact: spiffe://default/web1
-                statPrefix: inbound:192.168.0.1:80.
+                statPrefix: inbound_192_168_0_1_80.
             - name: envoy.tcp_proxy
               typedConfig:
                 '@type': type.googleapis.com/envoy.config.filter.network.tcp_proxy.v2.TcpProxy
                 cluster: localhost:8080
-                statPrefix: localhost:8080
+                statPrefix: localhost_8080
           tlsContext:
             commonTlsContext:
               tlsCertificateSdsSecretConfigs:
@@ -99,12 +99,12 @@ resources:
               typedConfig:
                 '@type': type.googleapis.com/envoy.config.filter.network.rbac.v2.RBAC
                 rules: {}
-                statPrefix: inbound:192.168.0.1:443.
+                statPrefix: inbound_192_168_0_1_443.
             - name: envoy.tcp_proxy
               typedConfig:
                 '@type': type.googleapis.com/envoy.config.filter.network.tcp_proxy.v2.TcpProxy
                 cluster: localhost:8443
-                statPrefix: localhost:8443
+                statPrefix: localhost_8443
           tlsContext:
             commonTlsContext:
               tlsCertificateSdsSecretConfigs:

--- a/pkg/xds/generator/testdata/inbound-proxy/6-envoy-config.golden.yaml
+++ b/pkg/xds/generator/testdata/inbound-proxy/6-envoy-config.golden.yaml
@@ -13,6 +13,7 @@ resources:
                       address: 127.0.0.1
                       portValue: 8080
       name: localhost:8080
+      altStatName: localhost_8080
       type: STATIC
   - name: inbound:192.168.0.1:80
     resource:
@@ -87,6 +88,7 @@ resources:
                       address: 127.0.0.1
                       portValue: 8443
       name: localhost:8443
+      altStatName: localhost_8443
       type: STATIC
   - name: inbound:192.168.0.1:443
     resource:

--- a/pkg/xds/generator/testdata/inbound-proxy/6-envoy-config.golden.yaml
+++ b/pkg/xds/generator/testdata/inbound-proxy/6-envoy-config.golden.yaml
@@ -37,12 +37,12 @@ resources:
                       - authenticated:
                           principalName:
                             exact: spiffe://default/web1
-                statPrefix: inbound:192.168.0.1:80.
+                statPrefix: inbound_192_168_0_1_80.
             - name: envoy.tcp_proxy
               typedConfig:
                 '@type': type.googleapis.com/envoy.config.filter.network.tcp_proxy.v2.TcpProxy
                 cluster: localhost:8080
-                statPrefix: localhost:8080
+                statPrefix: localhost_8080
           tlsContext:
             commonTlsContext:
               tlsCertificateSdsSecretConfigs:
@@ -103,12 +103,12 @@ resources:
               typedConfig:
                 '@type': type.googleapis.com/envoy.config.filter.network.rbac.v2.RBAC
                 rules: {}
-                statPrefix: inbound:192.168.0.1:443.
+                statPrefix: inbound_192_168_0_1_443.
             - name: envoy.tcp_proxy
               typedConfig:
                 '@type': type.googleapis.com/envoy.config.filter.network.tcp_proxy.v2.TcpProxy
                 cluster: localhost:8443
-                statPrefix: localhost:8443
+                statPrefix: localhost_8443
           tlsContext:
             commonTlsContext:
               tlsCertificateSdsSecretConfigs:

--- a/pkg/xds/generator/testdata/inbound-proxy/7-envoy-config.golden.yaml
+++ b/pkg/xds/generator/testdata/inbound-proxy/7-envoy-config.golden.yaml
@@ -13,6 +13,7 @@ resources:
                       address: 127.0.0.1
                       portValue: 8080
       name: localhost:8080
+      altStatName: localhost_8080
       type: STATIC
   - name: inbound:192.168.0.1:80
     resource:
@@ -85,6 +86,7 @@ resources:
                       address: 127.0.0.1
                       portValue: 8443
       name: localhost:8443
+      altStatName: localhost_8443
       type: STATIC
   - name: inbound:192.168.0.1:443
     resource:

--- a/pkg/xds/generator/testdata/inbound-proxy/7-envoy-config.golden.yaml
+++ b/pkg/xds/generator/testdata/inbound-proxy/7-envoy-config.golden.yaml
@@ -35,12 +35,12 @@ resources:
                       - authenticated:
                           principalName:
                             exact: spiffe://default/web1
-                statPrefix: inbound:192.168.0.1:80.
+                statPrefix: inbound_192_168_0_1_80.
             - name: envoy.tcp_proxy
               typedConfig:
                 '@type': type.googleapis.com/envoy.config.filter.network.tcp_proxy.v2.TcpProxy
                 cluster: localhost:8080
-                statPrefix: localhost:8080
+                statPrefix: localhost_8080
           tlsContext:
             commonTlsContext:
               tlsCertificateSdsSecretConfigs:
@@ -99,12 +99,12 @@ resources:
               typedConfig:
                 '@type': type.googleapis.com/envoy.config.filter.network.rbac.v2.RBAC
                 rules: {}
-                statPrefix: inbound:192.168.0.1:443.
+                statPrefix: inbound_192_168_0_1_443.
             - name: envoy.tcp_proxy
               typedConfig:
                 '@type': type.googleapis.com/envoy.config.filter.network.tcp_proxy.v2.TcpProxy
                 cluster: localhost:8443
-                statPrefix: localhost:8443
+                statPrefix: localhost_8443
           tlsContext:
             commonTlsContext:
               tlsCertificateSdsSecretConfigs:
@@ -148,12 +148,12 @@ resources:
               typedConfig:
                 '@type': type.googleapis.com/envoy.config.filter.network.rbac.v2.RBAC
                 rules: {}
-                statPrefix: inbound:192.168.0.2:80.
+                statPrefix: inbound_192_168_0_2_80.
             - name: envoy.tcp_proxy
               typedConfig:
                 '@type': type.googleapis.com/envoy.config.filter.network.tcp_proxy.v2.TcpProxy
                 cluster: localhost:8080
-                statPrefix: localhost:8080
+                statPrefix: localhost_8080
           tlsContext:
             commonTlsContext:
               tlsCertificateSdsSecretConfigs:
@@ -197,12 +197,12 @@ resources:
               typedConfig:
                 '@type': type.googleapis.com/envoy.config.filter.network.rbac.v2.RBAC
                 rules: {}
-                statPrefix: inbound:192.168.0.2:443.
+                statPrefix: inbound_192_168_0_2_443.
             - name: envoy.tcp_proxy
               typedConfig:
                 '@type': type.googleapis.com/envoy.config.filter.network.tcp_proxy.v2.TcpProxy
                 cluster: localhost:8443
-                statPrefix: localhost:8443
+                statPrefix: localhost_8443
           tlsContext:
             commonTlsContext:
               tlsCertificateSdsSecretConfigs:

--- a/pkg/xds/generator/testdata/inbound-proxy/8-envoy-config.golden.yaml
+++ b/pkg/xds/generator/testdata/inbound-proxy/8-envoy-config.golden.yaml
@@ -37,12 +37,12 @@ resources:
                       - authenticated:
                           principalName:
                             exact: spiffe://default/web1
-                statPrefix: inbound:192.168.0.1:80.
+                statPrefix: inbound_192_168_0_1_80.
             - name: envoy.tcp_proxy
               typedConfig:
                 '@type': type.googleapis.com/envoy.config.filter.network.tcp_proxy.v2.TcpProxy
                 cluster: localhost:8080
-                statPrefix: localhost:8080
+                statPrefix: localhost_8080
           tlsContext:
             commonTlsContext:
               tlsCertificateSdsSecretConfigs:
@@ -103,12 +103,12 @@ resources:
               typedConfig:
                 '@type': type.googleapis.com/envoy.config.filter.network.rbac.v2.RBAC
                 rules: {}
-                statPrefix: inbound:192.168.0.1:443.
+                statPrefix: inbound_192_168_0_1_443.
             - name: envoy.tcp_proxy
               typedConfig:
                 '@type': type.googleapis.com/envoy.config.filter.network.tcp_proxy.v2.TcpProxy
                 cluster: localhost:8443
-                statPrefix: localhost:8443
+                statPrefix: localhost_8443
           tlsContext:
             commonTlsContext:
               tlsCertificateSdsSecretConfigs:
@@ -154,12 +154,12 @@ resources:
               typedConfig:
                 '@type': type.googleapis.com/envoy.config.filter.network.rbac.v2.RBAC
                 rules: {}
-                statPrefix: inbound:192.168.0.2:80.
+                statPrefix: inbound_192_168_0_2_80.
             - name: envoy.tcp_proxy
               typedConfig:
                 '@type': type.googleapis.com/envoy.config.filter.network.tcp_proxy.v2.TcpProxy
                 cluster: localhost:8080
-                statPrefix: localhost:8080
+                statPrefix: localhost_8080
           tlsContext:
             commonTlsContext:
               tlsCertificateSdsSecretConfigs:
@@ -205,12 +205,12 @@ resources:
               typedConfig:
                 '@type': type.googleapis.com/envoy.config.filter.network.rbac.v2.RBAC
                 rules: {}
-                statPrefix: inbound:192.168.0.2:443.
+                statPrefix: inbound_192_168_0_2_443.
             - name: envoy.tcp_proxy
               typedConfig:
                 '@type': type.googleapis.com/envoy.config.filter.network.tcp_proxy.v2.TcpProxy
                 cluster: localhost:8443
-                statPrefix: localhost:8443
+                statPrefix: localhost_8443
           tlsContext:
             commonTlsContext:
               tlsCertificateSdsSecretConfigs:

--- a/pkg/xds/generator/testdata/inbound-proxy/8-envoy-config.golden.yaml
+++ b/pkg/xds/generator/testdata/inbound-proxy/8-envoy-config.golden.yaml
@@ -13,6 +13,7 @@ resources:
                       address: 127.0.0.1
                       portValue: 8080
       name: localhost:8080
+      altStatName: localhost_8080
       type: STATIC
   - name: inbound:192.168.0.1:80
     resource:
@@ -87,6 +88,7 @@ resources:
                       address: 127.0.0.1
                       portValue: 8443
       name: localhost:8443
+      altStatName: localhost_8443
       type: STATIC
   - name: inbound:192.168.0.1:443
     resource:

--- a/pkg/xds/generator/testdata/outbound-proxy/07.envoy.golden.yaml
+++ b/pkg/xds/generator/testdata/outbound-proxy/07.envoy.golden.yaml
@@ -47,6 +47,7 @@ resources:
       edsConfig:
         ads: {}
     name: db{role=master}
+    altStatName: db_role_master_
     type: EDS
 - name: db{role=master}
   resource:
@@ -72,6 +73,7 @@ resources:
       edsConfig:
         ads: {}
     name: db{role=replica}
+    altStatName: db_role_replica_
     type: EDS
 - name: db{role=replica}
   resource:

--- a/pkg/xds/generator/testdata/outbound-proxy/08.envoy.golden.yaml
+++ b/pkg/xds/generator/testdata/outbound-proxy/08.envoy.golden.yaml
@@ -77,6 +77,7 @@ resources:
       edsConfig:
         ads: {}
     name: db{role=master}
+    altStatName: db_role_master_
     tlsContext:
       commonTlsContext:
         tlsCertificateSdsSecretConfigs:
@@ -130,6 +131,7 @@ resources:
       edsConfig:
         ads: {}
     name: db{role=replica}
+    altStatName: db_role_replica_
     tlsContext:
       commonTlsContext:
         tlsCertificateSdsSecretConfigs:

--- a/pkg/xds/generator/testdata/outbound-proxy/cluster-dots.envoy.golden.yaml
+++ b/pkg/xds/generator/testdata/outbound-proxy/cluster-dots.envoy.golden.yaml
@@ -1,0 +1,61 @@
+resources:
+  - name: backend_kuma-system
+    resource:
+      '@type': type.googleapis.com/envoy.api.v2.Cluster
+      connectTimeout: 5s
+      edsClusterConfig:
+        edsConfig:
+          ads: {}
+      name: backend_kuma-system
+      type: EDS
+  - name: backend_kuma-system
+    resource:
+      '@type': type.googleapis.com/envoy.api.v2.ClusterLoadAssignment
+      clusterName: backend_kuma-system
+      endpoints:
+        - {}
+  - name: outbound:127.0.0.1:18080
+    resource:
+      '@type': type.googleapis.com/envoy.api.v2.Listener
+      address:
+        socketAddress:
+          address: 127.0.0.1
+          portValue: 18080
+      filterChains:
+        - filters:
+            - name: envoy.tcp_proxy
+              typedConfig:
+                '@type': type.googleapis.com/envoy.config.filter.network.tcp_proxy.v2.TcpProxy
+                cluster: backend_kuma-system
+                statPrefix: backend_kuma-system
+      name: outbound:127.0.0.1:18080
+  - name: db{version=3_2_0}
+    resource:
+      '@type': type.googleapis.com/envoy.api.v2.Cluster
+      connectTimeout: 5s
+      edsClusterConfig:
+        edsConfig:
+          ads: {}
+      name: db{version=3_2_0}
+      type: EDS
+  - name: db{version=3_2_0}
+    resource:
+      '@type': type.googleapis.com/envoy.api.v2.ClusterLoadAssignment
+      clusterName: db{version=3_2_0}
+      endpoints:
+        - {}
+  - name: outbound:127.0.0.1:54321
+    resource:
+      '@type': type.googleapis.com/envoy.api.v2.Listener
+      address:
+        socketAddress:
+          address: 127.0.0.1
+          portValue: 54321
+      filterChains:
+        - filters:
+            - name: envoy.tcp_proxy
+              typedConfig:
+                '@type': type.googleapis.com/envoy.config.filter.network.tcp_proxy.v2.TcpProxy
+                cluster: db{version=3_2_0}
+                statPrefix: db_kuma-system
+      name: outbound:127.0.0.1:54321

--- a/pkg/xds/generator/testdata/outbound-proxy/cluster-dots.envoy.golden.yaml
+++ b/pkg/xds/generator/testdata/outbound-proxy/cluster-dots.envoy.golden.yaml
@@ -1,17 +1,18 @@
 resources:
-  - name: backend_kuma-system
+  - name: backend.kuma-system
     resource:
       '@type': type.googleapis.com/envoy.api.v2.Cluster
       connectTimeout: 5s
       edsClusterConfig:
         edsConfig:
           ads: {}
-      name: backend_kuma-system
+      name: backend.kuma-system
+      altStatName: backend_kuma-system
       type: EDS
-  - name: backend_kuma-system
+  - name: backend.kuma-system
     resource:
       '@type': type.googleapis.com/envoy.api.v2.ClusterLoadAssignment
-      clusterName: backend_kuma-system
+      clusterName: backend.kuma-system
       endpoints:
         - {}
   - name: outbound:127.0.0.1:18080
@@ -26,22 +27,23 @@ resources:
             - name: envoy.tcp_proxy
               typedConfig:
                 '@type': type.googleapis.com/envoy.config.filter.network.tcp_proxy.v2.TcpProxy
-                cluster: backend_kuma-system
+                cluster: backend.kuma-system
                 statPrefix: backend_kuma-system
       name: outbound:127.0.0.1:18080
-  - name: db{version=3_2_0}
+  - name: db{version=3.2.0}
     resource:
       '@type': type.googleapis.com/envoy.api.v2.Cluster
       connectTimeout: 5s
       edsClusterConfig:
         edsConfig:
           ads: {}
-      name: db{version=3_2_0}
+      name: db{version=3.2.0}
+      altStatName: db_version_3_2_0_
       type: EDS
-  - name: db{version=3_2_0}
+  - name: db{version=3.2.0}
     resource:
       '@type': type.googleapis.com/envoy.api.v2.ClusterLoadAssignment
-      clusterName: db{version=3_2_0}
+      clusterName: db{version=3.2.0}
       endpoints:
         - {}
   - name: outbound:127.0.0.1:54321
@@ -56,6 +58,6 @@ resources:
             - name: envoy.tcp_proxy
               typedConfig:
                 '@type': type.googleapis.com/envoy.config.filter.network.tcp_proxy.v2.TcpProxy
-                cluster: db{version=3_2_0}
+                cluster: db{version=3.2.0}
                 statPrefix: db_kuma-system
       name: outbound:127.0.0.1:54321

--- a/pkg/xds/generator/testdata/profile-source/1-envoy-config.golden.yaml
+++ b/pkg/xds/generator/testdata/profile-source/1-envoy-config.golden.yaml
@@ -27,12 +27,12 @@ resources:
               typedConfig:
                 '@type': type.googleapis.com/envoy.config.filter.network.rbac.v2.RBAC
                 rules: {}
-                statPrefix: inbound:192.168.0.1:80.
+                statPrefix: inbound_192_168_0_1_80.
             - name: envoy.tcp_proxy
               typedConfig:
                 '@type': type.googleapis.com/envoy.config.filter.network.tcp_proxy.v2.TcpProxy
                 cluster: localhost:8080
-                statPrefix: localhost:8080
+                statPrefix: localhost_8080
           tlsContext:
             commonTlsContext:
               tlsCertificateSdsSecretConfigs:

--- a/pkg/xds/generator/testdata/profile-source/1-envoy-config.golden.yaml
+++ b/pkg/xds/generator/testdata/profile-source/1-envoy-config.golden.yaml
@@ -13,6 +13,7 @@ resources:
                       address: 127.0.0.1
                       portValue: 8080
       name: localhost:8080
+      altStatName: localhost_8080
       type: STATIC
   - name: inbound:192.168.0.1:80
     resource:

--- a/pkg/xds/generator/testdata/profile-source/2-envoy-config.golden.yaml
+++ b/pkg/xds/generator/testdata/profile-source/2-envoy-config.golden.yaml
@@ -38,6 +38,7 @@ resources:
                       address: 127.0.0.1
                       portValue: 8080
       name: localhost:8080
+      altStatName: localhost_8080
       type: STATIC
   - name: inbound:192.168.0.1:80
     resource:

--- a/pkg/xds/generator/testdata/profile-source/2-envoy-config.golden.yaml
+++ b/pkg/xds/generator/testdata/profile-source/2-envoy-config.golden.yaml
@@ -54,12 +54,12 @@ resources:
               typedConfig:
                 '@type': type.googleapis.com/envoy.config.filter.network.rbac.v2.RBAC
                 rules: {}
-                statPrefix: inbound:192.168.0.1:80.
+                statPrefix: inbound_192_168_0_1_80.
             - name: envoy.tcp_proxy
               typedConfig:
                 '@type': type.googleapis.com/envoy.config.filter.network.tcp_proxy.v2.TcpProxy
                 cluster: localhost:8080
-                statPrefix: localhost:8080
+                statPrefix: localhost_8080
           tlsContext:
             commonTlsContext:
               tlsCertificateSdsSecretConfigs:

--- a/pkg/xds/generator/testdata/profile-source/3-envoy-config.golden.yaml
+++ b/pkg/xds/generator/testdata/profile-source/3-envoy-config.golden.yaml
@@ -39,7 +39,7 @@ resources:
                 route:
                   cluster: kuma:envoy:admin
                   prefixRewrite: /stats/prometheus
-          statPrefix: kuma:metrics:prometheus
+          statPrefix: kuma_metrics_prometheus
     name: kuma:metrics:prometheus
 - name: localhost:8080
   resource:
@@ -69,12 +69,12 @@ resources:
         typedConfig:
           '@type': type.googleapis.com/envoy.config.filter.network.rbac.v2.RBAC
           rules: {}
-          statPrefix: inbound:192.168.0.1:80.
+          statPrefix: inbound_192_168_0_1_80.
       - name: envoy.tcp_proxy
         typedConfig:
           '@type': type.googleapis.com/envoy.config.filter.network.tcp_proxy.v2.TcpProxy
           cluster: localhost:8080
-          statPrefix: localhost:8080
+          statPrefix: localhost_8080
       tlsContext:
         commonTlsContext:
           tlsCertificateSdsSecretConfigs:

--- a/pkg/xds/generator/testdata/profile-source/3-envoy-config.golden.yaml
+++ b/pkg/xds/generator/testdata/profile-source/3-envoy-config.golden.yaml
@@ -13,6 +13,7 @@ resources:
                 address: 127.0.0.1
                 portValue: 9902
     name: kuma:envoy:admin
+    altStatName: kuma_envoy_admin
     type: STATIC
 - name: kuma:metrics:prometheus
   resource:
@@ -55,6 +56,7 @@ resources:
                 address: 127.0.0.1
                 portValue: 8080
     name: localhost:8080
+    altStatName: localhost_8080
     type: STATIC
 - name: inbound:192.168.0.1:80
   resource:

--- a/pkg/xds/generator/testdata/profile-source/4-envoy-config.golden.yaml
+++ b/pkg/xds/generator/testdata/profile-source/4-envoy-config.golden.yaml
@@ -41,7 +41,7 @@ resources:
                 route:
                   cluster: kuma:envoy:admin
                   prefixRewrite: /stats/prometheus
-          statPrefix: kuma:metrics:prometheus
+          statPrefix: kuma_metrics_prometheus
     name: kuma:metrics:prometheus
 - name: catch_all
   resource:
@@ -98,12 +98,12 @@ resources:
         typedConfig:
           '@type': type.googleapis.com/envoy.config.filter.network.rbac.v2.RBAC
           rules: {}
-          statPrefix: inbound:192.168.0.1:80.
+          statPrefix: inbound_192_168_0_1_80.
       - name: envoy.tcp_proxy
         typedConfig:
           '@type': type.googleapis.com/envoy.config.filter.network.tcp_proxy.v2.TcpProxy
           cluster: localhost:8080
-          statPrefix: localhost:8080
+          statPrefix: localhost_8080
       tlsContext:
         commonTlsContext:
           tlsCertificateSdsSecretConfigs:

--- a/pkg/xds/generator/testdata/profile-source/4-envoy-config.golden.yaml
+++ b/pkg/xds/generator/testdata/profile-source/4-envoy-config.golden.yaml
@@ -13,6 +13,7 @@ resources:
                 address: 127.0.0.1
                 portValue: 9902
     name: kuma:envoy:admin
+    altStatName: kuma_envoy_admin
     type: STATIC
 - name: kuma:metrics:prometheus
   resource:
@@ -82,6 +83,7 @@ resources:
                 address: 127.0.0.1
                 portValue: 8080
     name: localhost:8080
+    altStatName: localhost_8080
     type: STATIC
 - name: inbound:192.168.0.1:80
   resource:

--- a/pkg/xds/generator/testdata/template-proxy/1-envoy-config.golden.yaml
+++ b/pkg/xds/generator/testdata/template-proxy/1-envoy-config.golden.yaml
@@ -38,6 +38,7 @@ resources:
                       address: 127.0.0.1
                       portValue: 8080
       name: localhost:8080
+      altStatName: localhost_8080
       type: STATIC
   - name: inbound:192.168.0.1:80
     resource:
@@ -104,5 +105,6 @@ resources:
                       address: 127.0.0.1
                       portValue: 8443
       name: localhost:8443
+      altStatName: localhost_8443
       type: STATIC
     version: raw-version

--- a/pkg/xds/generator/testdata/template-proxy/1-envoy-config.golden.yaml
+++ b/pkg/xds/generator/testdata/template-proxy/1-envoy-config.golden.yaml
@@ -54,12 +54,12 @@ resources:
               typedConfig:
                 '@type': type.googleapis.com/envoy.config.filter.network.rbac.v2.RBAC
                 rules: {}
-                statPrefix: inbound:192.168.0.1:80.
+                statPrefix: inbound_192_168_0_1_80.
             - name: envoy.tcp_proxy
               typedConfig:
                 '@type': type.googleapis.com/envoy.config.filter.network.tcp_proxy.v2.TcpProxy
                 cluster: localhost:8080
-                statPrefix: localhost:8080
+                statPrefix: localhost_8080
           tlsContext:
             commonTlsContext:
               tlsCertificateSdsSecretConfigs:

--- a/pkg/xds/generator/testdata/template-proxy/1-proxy-template.input.yaml
+++ b/pkg/xds/generator/testdata/template-proxy/1-proxy-template.input.yaml
@@ -17,4 +17,5 @@ conf:
                         address: 127.0.0.1
                         portValue: 8443
         name: localhost:8443
+        altStatName: localhost_8443
         type: STATIC

--- a/pkg/xds/server/testdata/envoy-config.golden.yaml
+++ b/pkg/xds/server/testdata/envoy-config.golden.yaml
@@ -13,6 +13,7 @@ resources:
                       address: 127.0.0.1
                       portValue: 8080
       name: localhost:8080
+      altStatName: localhost_8080
       type: STATIC
   - name: localhost:8443
     resource:
@@ -28,6 +29,7 @@ resources:
                       address: 127.0.0.1
                       portValue: 8443
       name: localhost:8443
+      altStatName: localhost_8443
       type: STATIC
   - name: pass_through
     resource:

--- a/pkg/xds/server/testdata/envoy-config.golden.yaml
+++ b/pkg/xds/server/testdata/envoy-config.golden.yaml
@@ -67,12 +67,12 @@ resources:
               typedConfig:
                 '@type': type.googleapis.com/envoy.config.filter.network.rbac.v2.RBAC
                 rules: {}
-                statPrefix: inbound:192.168.0.1:443.
+                statPrefix: inbound_192_168_0_1_443.
             - name: envoy.tcp_proxy
               typedConfig:
                 '@type': type.googleapis.com/envoy.config.filter.network.tcp_proxy.v2.TcpProxy
                 cluster: localhost:8443
-                statPrefix: localhost:8443
+                statPrefix: localhost_8443
           tlsContext:
             commonTlsContext:
               tlsCertificateSdsSecretConfigs:
@@ -126,12 +126,12 @@ resources:
                       - authenticated:
                           principalName:
                             exact: spiffe://default/web1
-                statPrefix: inbound:192.168.0.1:80.
+                statPrefix: inbound_192_168_0_1_80.
             - name: envoy.tcp_proxy
               typedConfig:
                 '@type': type.googleapis.com/envoy.config.filter.network.tcp_proxy.v2.TcpProxy
                 cluster: localhost:8080
-                statPrefix: localhost:8080
+                statPrefix: localhost_8080
           tlsContext:
             commonTlsContext:
               tlsCertificateSdsSecretConfigs:
@@ -177,12 +177,12 @@ resources:
               typedConfig:
                 '@type': type.googleapis.com/envoy.config.filter.network.rbac.v2.RBAC
                 rules: {}
-                statPrefix: inbound:192.168.0.2:443.
+                statPrefix: inbound_192_168_0_2_443.
             - name: envoy.tcp_proxy
               typedConfig:
                 '@type': type.googleapis.com/envoy.config.filter.network.tcp_proxy.v2.TcpProxy
                 cluster: localhost:8443
-                statPrefix: localhost:8443
+                statPrefix: localhost_8443
           tlsContext:
             commonTlsContext:
               tlsCertificateSdsSecretConfigs:
@@ -228,12 +228,12 @@ resources:
               typedConfig:
                 '@type': type.googleapis.com/envoy.config.filter.network.rbac.v2.RBAC
                 rules: {}
-                statPrefix: inbound:192.168.0.2:80.
+                statPrefix: inbound_192_168_0_2_80.
             - name: envoy.tcp_proxy
               typedConfig:
                 '@type': type.googleapis.com/envoy.config.filter.network.tcp_proxy.v2.TcpProxy
                 cluster: localhost:8080
-                statPrefix: localhost:8080
+                statPrefix: localhost_8080
           tlsContext:
             commonTlsContext:
               tlsCertificateSdsSecretConfigs:


### PR DESCRIPTION
### Summary

#### Prometheus

Convertion from statsd to prometheus breaks when we have clusters with dots.
Example:
statsd:
```
cluster.backend.kuma-demo.svc_3001.assignment_stale: 0
```
prometheus
```
envoy_cluster_kuma_demo_svc_3001_assignment_stale{envoy_cluster_name="backend"}
```

There were several ways to fix it.
1) We could introduce `._.` suffix to clusters so you can skip extra part on Statsd and then build proper regex for Prometheus. 
2) We can replace every `.` in cluster name with `_`.

We picked second solution since it's less error prone. So the metric with this fix looks like following:
statsd:
```
cluster.backend_kuma-demo_svc_3001.assignment_stale: 0
```
prometheus
```
envoy_cluster_assignment_stale{envoy_cluster_name="backend_kuma-demo_svc_3001"}
```

#### StatsD

We also have to sanitize metrics for StatsD as `:` and `|` chars are illegal.
Official func to sanitize metrics looks like this https://github.com/statsd/statsd/blob/master/stats.js#L167

I slightly modified it changing the illegal characters always to `_`.

Example files
[fix_configdump.txt](https://github.com/Kong/kuma/files/4123015/fix_configdump.txt)
[fix_prometheus.txt](https://github.com/Kong/kuma/files/4123016/fix_prometheus.txt)
[fix_statsd.txt](https://github.com/Kong/kuma/files/4123017/fix_statsd.txt)

For the cluster name. Instead of changing the name in every place I leveraged `alt_stat_name` field. I think this is less error prone since we reference cluster names in many places in the config.