### PR TITLE
kuma-api: support IPv6 in Dataplane resource

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 Changes:
 
+* feature: support IPv6 in Dataplane resource
+  [#567](https://github.com/Kong/kuma/pull/567)
 * feature: validate certificates that users want to use as a `provided` CA
   [#565](https://github.com/Kong/kuma/pull/565)
 * fix: add MADS port to K8S install script

--- a/api/mesh/v1alpha1/dataplane.pb.go
+++ b/api/mesh/v1alpha1/dataplane.pb.go
@@ -150,6 +150,10 @@ type Dataplane_Networking_Inbound struct {
 	// <DATAPLANE_IP>:<DATAPLANE_PORT>:<WORKLOAD_PORT>, which means
 	// that dataplane must listen on <DATAPLANE_IP>:<DATAPLANE_PORT>
 	// and must dispatch to 127.0.0.1:<WORKLOAD_PORT>.
+	//
+	// E.g.,
+	// "192.168.0.100:9090:8080" in case of IPv4 or
+	// "[2001:db8::1]:7070:6060" in case of IPv6.
 	Interface string `protobuf:"bytes,1,opt,name=interface,proto3" json:"interface,omitempty"`
 	// Tags associated with an application this dataplane is deployed next to,
 	// e.g. service=web, version=1.0.
@@ -202,9 +206,15 @@ func (m *Dataplane_Networking_Inbound) GetTags() map[string]string {
 // Outbound describes a service consumed by the dataplane.
 type Dataplane_Networking_Outbound struct {
 	// Interface describes networking rules for outgoing traffic.
-	// The value is a string formatted as <IP_ADDRESS>:<PORT>,
-	// which means that dataplane must listen on <IP_ADDRESS>:<PORT>
-	// and must be dispatch to <SERVICE>:<SERVICE_PORT>.
+	// The value is a string formatted as <DATAPLANE_IP>:<DATAPLANE_PORT>,
+	// which means that dataplane must listen on
+	// <DATAPLANE_IP>:<DATAPLANE_PORT> and must be dispatch to
+	// <SERVICE>:<SERVICE_PORT>.
+	//
+	// E.g.,
+	// "127.0.0.1:9090" in case of IPv4 or
+	// "[::1]:8080" in case of IPv6 or
+	// ":7070".
 	Interface string `protobuf:"bytes,1,opt,name=interface,proto3" json:"interface,omitempty"`
 	// Service name.
 	Service string `protobuf:"bytes,2,opt,name=service,proto3" json:"service,omitempty"`

--- a/api/mesh/v1alpha1/dataplane.proto
+++ b/api/mesh/v1alpha1/dataplane.proto
@@ -22,6 +22,10 @@ message Dataplane {
       // <DATAPLANE_IP>:<DATAPLANE_PORT>:<WORKLOAD_PORT>, which means
       // that dataplane must listen on <DATAPLANE_IP>:<DATAPLANE_PORT>
       // and must dispatch to 127.0.0.1:<WORKLOAD_PORT>.
+      //
+      // E.g.,
+      // "192.168.0.100:9090:8080" in case of IPv4 or
+      // "[2001:db8::1]:7070:6060" in case of IPv6.
       string interface = 1 [ (validate.rules).string.min_len = 2 ];
 
       // Tags associated with an application this dataplane is deployed next to,
@@ -34,9 +38,15 @@ message Dataplane {
     message Outbound {
 
       // Interface describes networking rules for outgoing traffic.
-      // The value is a string formatted as <IP_ADDRESS>:<PORT>,
-      // which means that dataplane must listen on <IP_ADDRESS>:<PORT>
-      // and must be dispatch to <SERVICE>:<SERVICE_PORT>.
+      // The value is a string formatted as <DATAPLANE_IP>:<DATAPLANE_PORT>,
+      // which means that dataplane must listen on
+      // <DATAPLANE_IP>:<DATAPLANE_PORT> and must be dispatch to
+      // <SERVICE>:<SERVICE_PORT>.
+      //
+      // E.g.,
+      // "127.0.0.1:9090" in case of IPv4 or
+      // "[::1]:8080" in case of IPv6 or
+      // ":7070".
       string interface = 1 [ (validate.rules).string.min_len = 2 ];
 
       // Service name.

--- a/api/mesh/v1alpha1/dataplane_helpers_test.go
+++ b/api/mesh/v1alpha1/dataplane_helpers_test.go
@@ -153,13 +153,37 @@ var _ = Describe("ParseInboundInterface(..)", func() {
 					WorkloadPort:  8080,
 				},
 			}),
+			Entry("IPv6 full", testCase{
+				input: "[2001:db8:85a3:8d3:1319:8a2e:370:7348]:80:8080",
+				expected: InboundInterface{
+					DataplaneIP:   "2001:db8:85a3:8d3:1319:8a2e:370:7348",
+					DataplanePort: 80,
+					WorkloadPort:  8080,
+				},
+			}),
+			Entry("IPv6 shortend", testCase{
+				input: "[2001:db8::1:0:0:1]:80:8080",
+				expected: InboundInterface{
+					DataplaneIP:   "2001:db8::1:0:0:1",
+					DataplanePort: 80,
+					WorkloadPort:  8080,
+				},
+			}),
+			Entry("IPv4", testCase{
+				input: "[1.2.3.4]:80:8080", // unexpected side-effect of Golang SDK
+				expected: InboundInterface{
+					DataplaneIP:   "1.2.3.4",
+					DataplanePort: 80,
+					WorkloadPort:  8080,
+				},
+			}),
 		)
 	})
 
 	Context("invalid input values", func() {
 		type testCase struct {
 			input       string
-			expectedErr gomega_types.GomegaMatcher
+			expectedErr string
 		}
 
 		DescribeTable("should fail on invalid input values",
@@ -167,33 +191,35 @@ var _ = Describe("ParseInboundInterface(..)", func() {
 				// when
 				iface, err := ParseInboundInterface(given.input)
 				// then
-				Expect(err.Error()).To(given.expectedErr)
+				Expect(err).To(HaveOccurred())
+				// then
+				Expect(err.Error()).To(Equal(given.expectedErr))
 				// and
 				Expect(iface).To(BeZero())
 			},
 			Entry("dataplane IP address is missing", testCase{
 				input:       ":80:8080",
-				expectedErr: MatchRegexp(`invalid format: expected .*, got ":80:8080"`),
+				expectedErr: `invalid DATAPLANE_IP in ":80:8080": "" is not a valid IP address`,
 			}),
 			Entry("dataplane IP address is not valid", testCase{
 				input:       "localhost:80:65536",
-				expectedErr: MatchRegexp(`invalid format: expected .*, got "localhost:80:65536"`),
+				expectedErr: `invalid DATAPLANE_IP in "localhost:80:65536": "localhost" is not a valid IP address`,
 			}),
 			Entry("service port is missing", testCase{
 				input:       "1.2.3.4::8080",
-				expectedErr: MatchRegexp(`invalid format: expected .*, got "1.2.3.4::8080"`),
+				expectedErr: `invalid DATAPLANE_PORT in "1.2.3.4::8080": "" is not a valid port number: strconv.ParseUint: parsing "": invalid syntax`,
 			}),
 			Entry("service port is out of range", testCase{
 				input:       "1.2.3.4:0:8080",
-				expectedErr: Equal(`invalid <DATAPLANE_PORT> in "1.2.3.4:0:8080": port number must be in the range [1, 65535] but got 0`),
+				expectedErr: `invalid DATAPLANE_PORT in "1.2.3.4:0:8080": port number must be in the range [1, 65535] but got 0`,
 			}),
 			Entry("application port is missing", testCase{
 				input:       "1.2.3.4:80:",
-				expectedErr: MatchRegexp(`invalid format: expected .*, got "1.2.3.4:80:"`),
+				expectedErr: `invalid WORKLOAD_PORT in "1.2.3.4:80:": "" is not a valid port number: strconv.ParseUint: parsing "": invalid syntax`,
 			}),
 			Entry("application port is out of range", testCase{
 				input:       "1.2.3.4:80:65536",
-				expectedErr: Equal(`invalid <WORKLOAD_PORT> in "1.2.3.4:80:65536": port number must be in the range [1, 65535] but got 65536`),
+				expectedErr: `invalid WORKLOAD_PORT in "1.2.3.4:80:65536": port number must be in the range [1, 65535] but got 65536`,
 			}),
 		)
 	})
@@ -230,31 +256,62 @@ var _ = Describe("ParseOutboundInterface(..)", func() {
 					DataplanePort: 18080,
 				},
 			}),
+			Entry("IPv6 full", testCase{
+				input: "[2001:db8:85a3:8d3:1319:8a2e:370:7348]:18080",
+				expected: OutboundInterface{
+					DataplaneIP:   "2001:db8:85a3:8d3:1319:8a2e:370:7348",
+					DataplanePort: 18080,
+				},
+			}),
+			Entry("IPv6 shortend", testCase{
+				input: "[2001:db8::1:0:0:1]:18080",
+				expected: OutboundInterface{
+					DataplaneIP:   "2001:db8::1:0:0:1",
+					DataplanePort: 18080,
+				},
+			}),
+			Entry("IPv4", testCase{
+				input: "[127.0.0.2]:18080", // unexpected side-effect of Golang SDK
+				expected: OutboundInterface{
+					DataplaneIP:   "127.0.0.2",
+					DataplanePort: 18080,
+				},
+			}),
 		)
 	})
 
 	Context("invalid input values", func() {
 		type testCase struct {
 			input       string
-			expectedErr gomega_types.GomegaMatcher
+			expectedErr string
 		}
 
 		DescribeTable("should fail on invalid input values",
 			func(given testCase) {
 				// when
-				iface, err := ParseInboundInterface(given.input)
+				iface, err := ParseOutboundInterface(given.input)
 				// then
-				Expect(err.Error()).To(given.expectedErr)
+				Expect(err).To(HaveOccurred())
+				// and
+				Expect(err.Error()).To(Equal(given.expectedErr))
 				// and
 				Expect(iface).To(BeZero())
 			},
 			Entry("dataplane IP address is not valid", testCase{
 				input:       "localhost:65536",
-				expectedErr: MatchRegexp(`invalid format: expected .*, got "localhost:65536"`),
+				expectedErr: `invalid DATAPLANE_IP in "localhost:65536": "localhost" is not a valid IP address`,
+			}),
+			Entry("dataplane IPv6 address is not valid", testCase{
+				input:       "[:65536",
+				expectedErr: `invalid format: expected "[ IPv4 | '[' IPv6 ']' ] ':' DATAPLANE_PORT", got "[:65536"`,
 			}),
 			Entry("port without colon", testCase{
 				input:       "18080",
-				expectedErr: MatchRegexp(`invalid format: expected .*, got "18080"`),
+				expectedErr: `invalid format: expected "[ IPv4 | '[' IPv6 ']' ] ':' DATAPLANE_PORT", got "18080"`,
+			}),
+			Entry("colon without port", testCase{
+				input:       ":",
+				expectedErr: `invalid DATAPLANE_PORT in ":": "" is not a valid port number: strconv.ParseUint: parsing "": invalid syntax`,
 			}),
 		)
 	})
@@ -324,7 +381,7 @@ var _ = Describe("Dataplane_Networking", func() {
 							{Interface: ":443:8443"},
 						},
 					},
-					expectedErr: MatchRegexp(`invalid format: expected .*, got ":443:8443"`),
+					expectedErr: Equal(`invalid DATAPLANE_IP in ":443:8443": "" is not a valid IP address`),
 				}),
 			)
 		})

--- a/pkg/core/resources/apis/mesh/dataplane_validator.go
+++ b/pkg/core/resources/apis/mesh/dataplane_validator.go
@@ -38,7 +38,7 @@ func validateNetworking(networking *mesh_proto.Dataplane_Networking) validators.
 func validateInbound(inbound *mesh_proto.Dataplane_Networking_Inbound) validators.ValidationError {
 	var result validators.ValidationError
 	if _, err := mesh_proto.ParseInboundInterface(inbound.Interface); err != nil {
-		result.AddViolation("interface", "invalid format: expected format is DATAPLANE_IP:DATAPLANE_PORT:WORKLOAD_PORT ex. 192.168.0.100:9090:8080")
+		result.AddViolation("interface", "invalid format: expected format is DATAPLANE_IP:DATAPLANE_PORT:WORKLOAD_PORT , e.g. 192.168.0.100:9090:8080 or [2001:db8::1]:7070:6060")
 	}
 	if _, exist := inbound.Tags[mesh_proto.ServiceTag]; !exist {
 		result.AddViolationAt(validators.RootedAt("tags").Key(mesh_proto.ServiceTag), `tag has to exist`)
@@ -54,7 +54,7 @@ func validateInbound(inbound *mesh_proto.Dataplane_Networking_Inbound) validator
 func validateOutbound(outbound *mesh_proto.Dataplane_Networking_Outbound) validators.ValidationError {
 	var result validators.ValidationError
 	if _, err := mesh_proto.ParseOutboundInterface(outbound.Interface); err != nil {
-		result.AddViolation("interface", "invalid format: expected format is IP_ADDRESS:PORT where IP_ADDRESS is optional. ex. 192.168.0.100:9090 or :9090")
+		result.AddViolation("interface", "invalid format: expected format is DATAPLANE_IP:DATAPLANE_PORT where DATAPLANE_IP is optional. E.g. 127.0.0.1:9090, :9090, [::1]:8080")
 	}
 	if outbound.Service == "" {
 		result.AddViolation("service", "cannot be empty")

--- a/pkg/core/resources/apis/mesh/dataplane_validator_test.go
+++ b/pkg/core/resources/apis/mesh/dataplane_validator_test.go
@@ -104,7 +104,7 @@ var _ = Describe("Dataplane", func() {
 				Violations: []validators.Violation{
 					{
 						Field:   "networking.inbound[0].interface",
-						Message: `invalid format: expected format is DATAPLANE_IP:DATAPLANE_PORT:WORKLOAD_PORT ex. 192.168.0.100:9090:8080`,
+						Message: `invalid format: expected format is DATAPLANE_IP:DATAPLANE_PORT:WORKLOAD_PORT , e.g. 192.168.0.100:9090:8080 or [2001:db8::1]:7070:6060`,
 					},
 				},
 			},
@@ -118,7 +118,7 @@ var _ = Describe("Dataplane", func() {
 				Violations: []validators.Violation{
 					{
 						Field:   "networking.inbound[0].interface",
-						Message: `invalid format: expected format is DATAPLANE_IP:DATAPLANE_PORT:WORKLOAD_PORT ex. 192.168.0.100:9090:8080`,
+						Message: `invalid format: expected format is DATAPLANE_IP:DATAPLANE_PORT:WORKLOAD_PORT , e.g. 192.168.0.100:9090:8080 or [2001:db8::1]:7070:6060`,
 					},
 				},
 			},
@@ -260,7 +260,7 @@ var _ = Describe("Dataplane", func() {
 				Violations: []validators.Violation{
 					{
 						Field:   "networking.inbound[0].interface",
-						Message: "invalid format: expected format is DATAPLANE_IP:DATAPLANE_PORT:WORKLOAD_PORT ex. 192.168.0.100:9090:8080",
+						Message: "invalid format: expected format is DATAPLANE_IP:DATAPLANE_PORT:WORKLOAD_PORT , e.g. 192.168.0.100:9090:8080 or [2001:db8::1]:7070:6060",
 					},
 					{
 						Field:   "networking.inbound[0].tags[\"service\"]",
@@ -272,7 +272,7 @@ var _ = Describe("Dataplane", func() {
 					},
 					{
 						Field:   "networking.outbound[0].interface",
-						Message: "invalid format: expected format is IP_ADDRESS:PORT where IP_ADDRESS is optional. ex. 192.168.0.100:9090 or :9090",
+						Message: "invalid format: expected format is DATAPLANE_IP:DATAPLANE_PORT where DATAPLANE_IP is optional. E.g. 127.0.0.1:9090, :9090, [::1]:8080",
 					},
 					{
 						Field:   "networking.outbound[0].service",


### PR DESCRIPTION
### Summary

* support IPv6 in `Dataplane` resource

