### PR TITLE
kuma-cp: generate HTTP-specific inbound listeners for services tagged with `protocol: http`

### DIFF
--- a/api/mesh/v1alpha1/dataplane_helpers.go
+++ b/api/mesh/v1alpha1/dataplane_helpers.go
@@ -12,8 +12,12 @@ import (
 )
 
 const (
+	// Mandatory tag that has a reserved meaning in Kuma.
 	ServiceTag     = "service"
 	ServiceUnknown = "unknown"
+	// Optional tag that has a reserved meaning in Kuma.
+	// If absent, Kuma will treat application's protocol as opaque TCP.
+	ProtocolTag = "protocol"
 )
 
 // ServiceTagValue represents the value of "service" tag.

--- a/pkg/core/resources/apis/mesh/dataplane_helpers.go
+++ b/pkg/core/resources/apis/mesh/dataplane_helpers.go
@@ -106,13 +106,14 @@ func (d *DataplaneResource) GetIP() string {
 	return ifaces[0].DataplaneIP
 }
 
-func (d *DataplaneResource) GetProtocol(idx int) Protocol {
+// GetProtocol returns a protocol of an inbound interface with a given index.
+func (d *DataplaneResource) GetProtocol(inboundIdx int) Protocol {
 	if d == nil {
-		return ProtocolTCP
+		return ProtocolUnknown
 	}
-	if idx < 0 || idx > len(d.Spec.Networking.GetInbound())-1 {
-		return ProtocolTCP
+	if inboundIdx < 0 || inboundIdx > len(d.Spec.Networking.GetInbound())-1 {
+		return ProtocolUnknown
 	}
-	iface := d.Spec.Networking.Inbound[idx]
+	iface := d.Spec.Networking.Inbound[inboundIdx]
 	return ParseProtocol(iface.Tags[mesh_proto.ProtocolTag])
 }

--- a/pkg/core/resources/apis/mesh/dataplane_helpers.go
+++ b/pkg/core/resources/apis/mesh/dataplane_helpers.go
@@ -2,11 +2,32 @@ package mesh
 
 import (
 	"net"
+	"strings"
 
 	"github.com/golang/protobuf/proto"
 
 	mesh_proto "github.com/Kong/kuma/api/mesh/v1alpha1"
 )
+
+// Protocol identifies a protocol supported by a service.
+type Protocol string
+
+const (
+	ProtocolUnknown = "<unknown>"
+	ProtocolTCP     = "tcp"
+	ProtocolHTTP    = "http"
+)
+
+func ParseProtocol(tag string) Protocol {
+	switch strings.ToLower(tag) {
+	case ProtocolHTTP:
+		return ProtocolHTTP
+	case ProtocolTCP:
+		return ProtocolTCP
+	default:
+		return ProtocolUnknown
+	}
+}
 
 var ipv4loopback = net.IPv4(127, 0, 0, 1)
 
@@ -83,4 +104,15 @@ func (d *DataplaneResource) GetIP() string {
 		return ""
 	}
 	return ifaces[0].DataplaneIP
+}
+
+func (d *DataplaneResource) GetProtocol(idx int) Protocol {
+	if d == nil {
+		return ProtocolTCP
+	}
+	if idx < 0 || idx > len(d.Spec.Networking.GetInbound())-1 {
+		return ProtocolTCP
+	}
+	iface := d.Spec.Networking.Inbound[idx]
+	return ParseProtocol(iface.Tags[mesh_proto.ProtocolTag])
 }

--- a/pkg/core/resources/apis/mesh/dataplane_helpers_test.go
+++ b/pkg/core/resources/apis/mesh/dataplane_helpers_test.go
@@ -7,12 +7,12 @@ import (
 	. "github.com/onsi/ginkgo/extensions/table"
 	. "github.com/onsi/gomega"
 
-	mesh_proto "github.com/Kong/kuma/api/mesh/v1alpha1"
 	. "github.com/Kong/kuma/pkg/core/resources/apis/mesh"
 
-	util_proto "github.com/Kong/kuma/pkg/util/proto"
+	mesh_proto "github.com/Kong/kuma/api/mesh/v1alpha1"
 
 	test_model "github.com/Kong/kuma/pkg/test/resources/model"
+	util_proto "github.com/Kong/kuma/pkg/util/proto"
 )
 
 var _ = Describe("Dataplane", func() {
@@ -408,6 +408,52 @@ var _ = Describe("Dataplane", func() {
                       service: backend-https
 `,
 				expected: "",
+			}),
+		)
+	})
+
+	Describe("ParseProtocol()", func() {
+
+		type testCase struct {
+			tag      string
+			expected Protocol
+		}
+
+		DescribeTable("should parse protocol from a tag",
+			func(given testCase) {
+				Expect(ParseProtocol(given.tag)).To(Equal(given.expected))
+			},
+			Entry("http", testCase{
+				tag:      "http",
+				expected: ProtocolHTTP,
+			}),
+			Entry("tcp", testCase{
+				tag:      "tcp",
+				expected: ProtocolTCP,
+			}),
+			Entry("http2", testCase{
+				tag:      "http2",
+				expected: ProtocolUnknown,
+			}),
+			Entry("grpc", testCase{
+				tag:      "grpc",
+				expected: ProtocolUnknown,
+			}),
+			Entry("mongo", testCase{
+				tag:      "mongo",
+				expected: ProtocolUnknown,
+			}),
+			Entry("mysql", testCase{
+				tag:      "mysql",
+				expected: ProtocolUnknown,
+			}),
+			Entry("unknown", testCase{
+				tag:      "unknown",
+				expected: ProtocolUnknown,
+			}),
+			Entry("empty", testCase{
+				tag:      "",
+				expected: ProtocolUnknown,
 			}),
 		)
 	})

--- a/pkg/core/xds/resource.go
+++ b/pkg/core/xds/resource.go
@@ -6,8 +6,6 @@ import (
 
 	envoy "github.com/envoyproxy/go-control-plane/envoy/api/v2"
 	envoy_cache "github.com/envoyproxy/go-control-plane/pkg/cache"
-
-	util_error "github.com/Kong/kuma/pkg/util/error"
 )
 
 // ResourcePayload is a convenience type alias.
@@ -23,18 +21,20 @@ type Resource struct {
 // ResourceList represents a list of generic xDS resources.
 type ResourceList []*Resource
 
-func (rs ResourceList) ToDeltaDiscoveryResponse() *envoy.DeltaDiscoveryResponse {
+func (rs ResourceList) ToDeltaDiscoveryResponse() (*envoy.DeltaDiscoveryResponse, error) {
 	resp := &envoy.DeltaDiscoveryResponse{}
 	for _, r := range rs {
 		pbany, err := ptypes.MarshalAny(r.Resource)
-		util_error.MustNot(err)
+		if err != nil {
+			return nil, err
+		}
 		resp.Resources = append(resp.Resources, &envoy.Resource{
 			Name:     r.Name,
 			Version:  r.Version,
 			Resource: pbany,
 		})
 	}
-	return resp
+	return resp, nil
 }
 
 func (rs ResourceList) ToIndex() map[string]ResourcePayload {

--- a/pkg/xds/envoy/clusters/clusters.go
+++ b/pkg/xds/envoy/clusters/clusters.go
@@ -32,7 +32,11 @@ func CreateLocalCluster(clusterName string, address string, port uint32) *v2.Clu
 	})
 }
 
-func CreateEdsCluster(ctx xds_context.Context, clusterName string, metadata *core_xds.DataplaneMetadata) *v2.Cluster {
+func CreateEdsCluster(ctx xds_context.Context, clusterName string, metadata *core_xds.DataplaneMetadata) (*v2.Cluster, error) {
+	tlsContext, err := envoy.CreateUpstreamTlsContext(ctx, metadata)
+	if err != nil {
+		return nil, err
+	}
 	return clusterWithAltStatName(&v2.Cluster{
 		Name:                 clusterName,
 		ConnectTimeout:       ptypes.DurationProto(defaultConnectTimeout),
@@ -44,8 +48,8 @@ func CreateEdsCluster(ctx xds_context.Context, clusterName string, metadata *cor
 				},
 			},
 		},
-		TlsContext: envoy.CreateUpstreamTlsContext(ctx, metadata),
-	})
+		TlsContext: tlsContext,
+	}), nil
 }
 
 func clusterWithAltStatName(cluster *v2.Cluster) *v2.Cluster {

--- a/pkg/xds/envoy/clusters/clusters_test.go
+++ b/pkg/xds/envoy/clusters/clusters_test.go
@@ -79,12 +79,15 @@ var _ = Describe("Clusters", func() {
 		DescribeTable("should generate 'EDS' Cluster",
 			func(given testCase) {
 				// when
-				resource := CreateEdsCluster(given.ctx, "192.168.0.1:8080", &given.metadata)
-
+				resource, err := CreateEdsCluster(given.ctx, "192.168.0.1:8080", &given.metadata)
 				// then
-				actual, err := util_proto.ToYAML(resource)
-
 				Expect(err).ToNot(HaveOccurred())
+
+				// when
+				actual, err := util_proto.ToYAML(resource)
+				// then
+				Expect(err).ToNot(HaveOccurred())
+
 				Expect(actual).To(MatchYAML(given.expected))
 			},
 			Entry("without mTLS", testCase{

--- a/pkg/xds/envoy/listeners/http_connection_manager_configurer.go
+++ b/pkg/xds/envoy/listeners/http_connection_manager_configurer.go
@@ -1,0 +1,50 @@
+package listeners
+
+import (
+	"github.com/golang/protobuf/ptypes"
+
+	v2 "github.com/envoyproxy/go-control-plane/envoy/api/v2"
+	envoy_listener "github.com/envoyproxy/go-control-plane/envoy/api/v2/listener"
+	envoy_hcm "github.com/envoyproxy/go-control-plane/envoy/config/filter/network/http_connection_manager/v2"
+	envoy_wellknown "github.com/envoyproxy/go-control-plane/pkg/wellknown"
+
+	util_error "github.com/Kong/kuma/pkg/util/error"
+	util_xds "github.com/Kong/kuma/pkg/util/xds"
+)
+
+func HttpConnectionManager(statsName string) ListenerBuilderOpt {
+	return ListenerBuilderOptFunc(func(config *ListenerBuilderConfig) {
+		config.Add(&HttpConnectionManagerConfigurer{
+			statsName: statsName,
+		})
+	})
+}
+
+type HttpConnectionManagerConfigurer struct {
+	statsName string
+}
+
+func (c *HttpConnectionManagerConfigurer) Configure(l *v2.Listener) error {
+	config := &envoy_hcm.HttpConnectionManager{
+		StatPrefix: util_xds.SanitizeMetric(c.statsName),
+		CodecType:  envoy_hcm.HttpConnectionManager_AUTO,
+		HttpFilters: []*envoy_hcm.HttpFilter{
+			{Name: envoy_wellknown.Router},
+		},
+		// notice that route configuration is left up to other configurers
+	}
+
+	pbst, err := ptypes.MarshalAny(config)
+	util_error.MustNot(err)
+
+	for i := range l.FilterChains {
+		l.FilterChains[i].Filters = append(l.FilterChains[i].Filters, &envoy_listener.Filter{
+			Name: envoy_wellknown.HTTPConnectionManager,
+			ConfigType: &envoy_listener.Filter_TypedConfig{
+				TypedConfig: pbst,
+			},
+		})
+	}
+
+	return nil
+}

--- a/pkg/xds/envoy/listeners/http_connection_manager_configurer.go
+++ b/pkg/xds/envoy/listeners/http_connection_manager_configurer.go
@@ -8,7 +8,6 @@ import (
 	envoy_hcm "github.com/envoyproxy/go-control-plane/envoy/config/filter/network/http_connection_manager/v2"
 	envoy_wellknown "github.com/envoyproxy/go-control-plane/pkg/wellknown"
 
-	util_error "github.com/Kong/kuma/pkg/util/error"
 	util_xds "github.com/Kong/kuma/pkg/util/xds"
 )
 
@@ -35,7 +34,9 @@ func (c *HttpConnectionManagerConfigurer) Configure(l *v2.Listener) error {
 	}
 
 	pbst, err := ptypes.MarshalAny(config)
-	util_error.MustNot(err)
+	if err != nil {
+		return err
+	}
 
 	for i := range l.FilterChains {
 		l.FilterChains[i].Filters = append(l.FilterChains[i].Filters, &envoy_listener.Filter{

--- a/pkg/xds/envoy/listeners/http_connection_manager_configurer_test.go
+++ b/pkg/xds/envoy/listeners/http_connection_manager_configurer_test.go
@@ -1,0 +1,61 @@
+package listeners_test
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/ginkgo/extensions/table"
+	. "github.com/onsi/gomega"
+
+	. "github.com/Kong/kuma/pkg/xds/envoy/listeners"
+
+	util_proto "github.com/Kong/kuma/pkg/util/proto"
+)
+
+var _ = Describe("HttpConnectionManagerConfigurer", func() {
+
+	type testCase struct {
+		listenerName    string
+		listenerAddress string
+		listenerPort    uint32
+		statsName       string
+		expected        string
+	}
+
+	DescribeTable("should generate proper Envoy config",
+		func(given testCase) {
+			// when
+			listener, err := NewListenerBuilder().
+				Configure(InboundListener(given.listenerName, given.listenerAddress, given.listenerPort)).
+				Configure(HttpConnectionManager(given.statsName)).
+				Build()
+			// then
+			Expect(err).ToNot(HaveOccurred())
+
+			// when
+			actual, err := util_proto.ToYAML(listener)
+			Expect(err).ToNot(HaveOccurred())
+			// and
+			Expect(actual).To(MatchYAML(given.expected))
+		},
+		Entry("basic http_connection_manager", testCase{
+			listenerName:    "inbound:192.168.0.1:8080",
+			listenerAddress: "192.168.0.1",
+			listenerPort:    8080,
+			statsName:       "localhost:8080",
+			expected: `
+            name: inbound:192.168.0.1:8080
+            address:
+              socketAddress:
+                address: 192.168.0.1
+                portValue: 8080
+            filterChains:
+            - filters:
+              - name: envoy.http_connection_manager
+                typedConfig:
+                  '@type': type.googleapis.com/envoy.config.filter.network.http_connection_manager.v2.HttpConnectionManager
+                  statPrefix: localhost_8080
+                  httpFilters:
+                  - name: envoy.router
+`,
+		}),
+	)
+})

--- a/pkg/xds/envoy/listeners/http_inbound_route_configurer.go
+++ b/pkg/xds/envoy/listeners/http_inbound_route_configurer.go
@@ -1,0 +1,62 @@
+package listeners
+
+import (
+	"github.com/golang/protobuf/proto"
+	wrappers "github.com/golang/protobuf/ptypes/wrappers"
+
+	v2 "github.com/envoyproxy/go-control-plane/envoy/api/v2"
+	envoy_route "github.com/envoyproxy/go-control-plane/envoy/api/v2/route"
+	envoy_hcm "github.com/envoyproxy/go-control-plane/envoy/config/filter/network/http_connection_manager/v2"
+	envoy_wellknown "github.com/envoyproxy/go-control-plane/pkg/wellknown"
+)
+
+func HttpInboundRoute(cluster ClusterInfo) ListenerBuilderOpt {
+	return ListenerBuilderOptFunc(func(config *ListenerBuilderConfig) {
+		config.Add(&HttpInboundRouteConfigurer{
+			cluster: cluster,
+		})
+	})
+}
+
+type HttpInboundRouteConfigurer struct {
+	// Cluster to forward traffic to.
+	cluster ClusterInfo
+}
+
+func (c *HttpInboundRouteConfigurer) Configure(l *v2.Listener) error {
+	config := &v2.RouteConfiguration{
+		Name: "inbound",
+		VirtualHosts: []*envoy_route.VirtualHost{{
+			Name:    "local_service",
+			Domains: []string{"*"},
+			Routes: []*envoy_route.Route{{
+				Match: &envoy_route.RouteMatch{
+					PathSpecifier: &envoy_route.RouteMatch_Prefix{
+						Prefix: "/",
+					},
+				},
+				Action: &envoy_route.Route_Route{
+					Route: &envoy_route.RouteAction{
+						ClusterSpecifier: &envoy_route.RouteAction_Cluster{
+							Cluster: c.cluster.Name,
+						},
+					},
+				},
+			}},
+		}},
+		ValidateClusters: &wrappers.BoolValue{
+			Value: true,
+		},
+	}
+
+	return UpdateFilterConfig(l, envoy_wellknown.HTTPConnectionManager, func(filterConfig proto.Message) error {
+		hcm, ok := filterConfig.(*envoy_hcm.HttpConnectionManager)
+		if !ok {
+			return NewUnexpectedFilterConfigTypeError(filterConfig, &envoy_hcm.HttpConnectionManager{})
+		}
+		hcm.RouteSpecifier = &envoy_hcm.HttpConnectionManager_RouteConfig{
+			RouteConfig: config,
+		}
+		return nil
+	})
+}

--- a/pkg/xds/envoy/listeners/http_inbound_route_configurer_test.go
+++ b/pkg/xds/envoy/listeners/http_inbound_route_configurer_test.go
@@ -1,0 +1,76 @@
+package listeners_test
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/ginkgo/extensions/table"
+	. "github.com/onsi/gomega"
+
+	. "github.com/Kong/kuma/pkg/xds/envoy/listeners"
+
+	util_proto "github.com/Kong/kuma/pkg/util/proto"
+)
+
+var _ = Describe("HttpInboundRouteConfigurer", func() {
+
+	type testCase struct {
+		listenerName    string
+		listenerAddress string
+		listenerPort    uint32
+		statsName       string
+		cluster         ClusterInfo
+		expected        string
+	}
+
+	DescribeTable("should generate proper Envoy config",
+		func(given testCase) {
+			// when
+			listener, err := NewListenerBuilder().
+				Configure(InboundListener(given.listenerName, given.listenerAddress, given.listenerPort)).
+				Configure(HttpConnectionManager(given.statsName)).
+				Configure(HttpInboundRoute(given.cluster)).
+				Build()
+			// then
+			Expect(err).ToNot(HaveOccurred())
+
+			// when
+			actual, err := util_proto.ToYAML(listener)
+			Expect(err).ToNot(HaveOccurred())
+			// and
+			Expect(actual).To(MatchYAML(given.expected))
+		},
+		Entry("basic http_connection_manager with a single destination cluster", testCase{
+			listenerName:    "inbound:192.168.0.1:8080",
+			listenerAddress: "192.168.0.1",
+			listenerPort:    8080,
+			statsName:       "localhost:8080",
+			cluster:         ClusterInfo{Name: "localhost:8080", Weight: 200},
+			expected: `
+            name: inbound:192.168.0.1:8080
+            address:
+              socketAddress:
+                address: 192.168.0.1
+                portValue: 8080
+            filterChains:
+            - filters:
+              - name: envoy.http_connection_manager
+                typedConfig:
+                  '@type': type.googleapis.com/envoy.config.filter.network.http_connection_manager.v2.HttpConnectionManager
+                  httpFilters:
+                  - name: envoy.router
+                  routeConfig:
+                    name: inbound
+                    validateClusters: true
+                    virtualHosts:
+                    - domains:
+                      - '*'
+                      name: local_service
+                      routes:
+                      - match:
+                          prefix: /
+                        route:
+                          cluster: localhost:8080
+                  statPrefix: localhost_8080
+`,
+		}),
+	)
+})

--- a/pkg/xds/envoy/listeners/prometheus_endpoint_configurer.go
+++ b/pkg/xds/envoy/listeners/prometheus_endpoint_configurer.go
@@ -9,7 +9,6 @@ import (
 	envoy_hcm "github.com/envoyproxy/go-control-plane/envoy/config/filter/network/http_connection_manager/v2"
 	envoy_wellknown "github.com/envoyproxy/go-control-plane/pkg/wellknown"
 
-	util_error "github.com/Kong/kuma/pkg/util/error"
 	util_xds "github.com/Kong/kuma/pkg/util/xds"
 )
 
@@ -59,7 +58,9 @@ func (c *PrometheusEndpointConfigurer) Configure(l *v2.Listener) error {
 		},
 	}
 	pbst, err := ptypes.MarshalAny(config)
-	util_error.MustNot(err)
+	if err != nil {
+		return err
+	}
 
 	for i := range l.FilterChains {
 		l.FilterChains[i].Filters = append(l.FilterChains[i].Filters, &envoy_listener.Filter{

--- a/pkg/xds/envoy/listeners/server_mtls_configurer.go
+++ b/pkg/xds/envoy/listeners/server_mtls_configurer.go
@@ -24,7 +24,11 @@ type ServerSideMTLSConfigurer struct {
 
 func (c *ServerSideMTLSConfigurer) Configure(l *v2.Listener) error {
 	for i := range l.FilterChains {
-		l.FilterChains[i].TlsContext = envoy.CreateDownstreamTlsContext(c.ctx, c.metadata)
+		tlsContext, err := envoy.CreateDownstreamTlsContext(c.ctx, c.metadata)
+		if err != nil {
+			return err
+		}
+		l.FilterChains[i].TlsContext = tlsContext
 	}
 
 	return nil

--- a/pkg/xds/envoy/listeners/tcp_proxy_configurer.go
+++ b/pkg/xds/envoy/listeners/tcp_proxy_configurer.go
@@ -8,7 +8,6 @@ import (
 	envoy_tcp "github.com/envoyproxy/go-control-plane/envoy/config/filter/network/tcp_proxy/v2"
 	envoy_wellknown "github.com/envoyproxy/go-control-plane/pkg/wellknown"
 
-	util_error "github.com/Kong/kuma/pkg/util/error"
 	util_xds "github.com/Kong/kuma/pkg/util/xds"
 )
 
@@ -56,7 +55,9 @@ func (c *TcpProxyConfigurer) Configure(l *v2.Listener) error {
 		}
 	}
 	pbst, err := ptypes.MarshalAny(config)
-	util_error.MustNot(err)
+	if err != nil {
+		return err
+	}
 
 	for i := range l.FilterChains {
 		l.FilterChains[i].Filters = append(l.FilterChains[i].Filters, &envoy_listener.Filter{

--- a/pkg/xds/envoy/listeners/util.go
+++ b/pkg/xds/envoy/listeners/util.go
@@ -8,8 +8,6 @@ import (
 
 	v2 "github.com/envoyproxy/go-control-plane/envoy/api/v2"
 	envoy_listener "github.com/envoyproxy/go-control-plane/envoy/api/v2/listener"
-
-	util_error "github.com/Kong/kuma/pkg/util/error"
 )
 
 func UpdateFilterConfig(l *v2.Listener, filterName string, updateFunc func(proto.Message) error) error {
@@ -29,7 +27,9 @@ func UpdateFilterConfig(l *v2.Listener, filterName string, updateFunc func(proto
 				}
 
 				pbst, err := ptypes.MarshalAny(dany.Message)
-				util_error.MustNot(err)
+				if err != nil {
+					return err
+				}
 
 				filter.ConfigType = &envoy_listener.Filter_TypedConfig{
 					TypedConfig: pbst,

--- a/pkg/xds/envoy/tls_test.go
+++ b/pkg/xds/envoy/tls_test.go
@@ -29,8 +29,10 @@ var _ = Describe("CreateDownstreamTlsContext()", func() {
 			metadata := &core_xds.DataplaneMetadata{}
 
 			// when
-			snippet := CreateDownstreamTlsContext(ctx, metadata)
+			snippet, err := CreateDownstreamTlsContext(ctx, metadata)
 			// then
+			Expect(err).ToNot(HaveOccurred())
+			// and
 			Expect(snippet).To(BeNil())
 		})
 	})
@@ -62,8 +64,10 @@ var _ = Describe("CreateDownstreamTlsContext()", func() {
 				}
 
 				// when
-				snippet := CreateDownstreamTlsContext(ctx, given.metadata)
-				// and
+				snippet, err := CreateDownstreamTlsContext(ctx, given.metadata)
+				// then
+				Expect(err).ToNot(HaveOccurred())
+				// when
 				actual, err := util_proto.ToYAML(snippet)
 				// then
 				Expect(err).ToNot(HaveOccurred())
@@ -205,8 +209,10 @@ var _ = Describe("CreateUpstreamTlsContext()", func() {
 			metadata := &core_xds.DataplaneMetadata{}
 
 			// when
-			snippet := CreateUpstreamTlsContext(ctx, metadata)
+			snippet, err := CreateUpstreamTlsContext(ctx, metadata)
 			// then
+			Expect(err).ToNot(HaveOccurred())
+			// and
 			Expect(snippet).To(BeNil())
 		})
 	})
@@ -238,8 +244,10 @@ var _ = Describe("CreateUpstreamTlsContext()", func() {
 				}
 
 				// when
-				snippet := CreateUpstreamTlsContext(ctx, given.metadata)
-				// and
+				snippet, err := CreateUpstreamTlsContext(ctx, given.metadata)
+				// then
+				Expect(err).ToNot(HaveOccurred())
+				// when
 				actual, err := util_proto.ToYAML(snippet)
 				// then
 				Expect(err).ToNot(HaveOccurred())

--- a/pkg/xds/generator/inbound_proxy_generator_test.go
+++ b/pkg/xds/generator/inbound_proxy_generator_test.go
@@ -98,9 +98,13 @@ var _ = Describe("InboundProxyGenerator", func() {
 			// then
 			Expect(err).ToNot(HaveOccurred())
 
+			// when
+			resp, err := model.ResourceList(rs).ToDeltaDiscoveryResponse()
 			// then
-			resp := model.ResourceList(rs).ToDeltaDiscoveryResponse()
+			Expect(err).ToNot(HaveOccurred())
+			// when
 			actual, err := util_proto.ToYAML(resp)
+			// then
 			Expect(err).ToNot(HaveOccurred())
 
 			expected, err := ioutil.ReadFile(filepath.Join("testdata", "inbound-proxy", given.envoyConfigFile))

--- a/pkg/xds/generator/outbound_proxy_generator_test.go
+++ b/pkg/xds/generator/outbound_proxy_generator_test.go
@@ -118,9 +118,13 @@ var _ = Describe("OutboundProxyGenerator", func() {
 			// then
 			Expect(err).ToNot(HaveOccurred())
 
+			// when
+			resp, err := model.ResourceList(rs).ToDeltaDiscoveryResponse()
 			// then
-			resp := model.ResourceList(rs).ToDeltaDiscoveryResponse()
+			Expect(err).ToNot(HaveOccurred())
+			// when
 			actual, err := util_proto.ToYAML(resp)
+			// then
 			Expect(err).ToNot(HaveOccurred())
 
 			expected, err := ioutil.ReadFile(filepath.Join("testdata", "outbound-proxy", given.expected))
@@ -278,9 +282,13 @@ var _ = Describe("OutboundProxyGenerator", func() {
 		// then
 		Expect(err).ToNot(HaveOccurred())
 
+		// when
+		resp, err := model.ResourceList(rs).ToDeltaDiscoveryResponse()
 		// then
-		resp := model.ResourceList(rs).ToDeltaDiscoveryResponse()
+		Expect(err).ToNot(HaveOccurred())
+		// when
 		actual, err := util_proto.ToYAML(resp)
+		// then
 		Expect(err).ToNot(HaveOccurred())
 
 		expected, err := ioutil.ReadFile(filepath.Join("testdata", "outbound-proxy", "cluster-dots.envoy.golden.yaml"))

--- a/pkg/xds/generator/prometheus_endpoint_generator_test.go
+++ b/pkg/xds/generator/prometheus_endpoint_generator_test.go
@@ -172,11 +172,15 @@ var _ = Describe("PrometheusEndpointGenerator", func() {
 			// then
 			Expect(err).ToNot(HaveOccurred())
 
+			// when
+			resp, err := model.ResourceList(rs).ToDeltaDiscoveryResponse()
 			// then
-			resp := model.ResourceList(rs).ToDeltaDiscoveryResponse()
-			actual, err := util_proto.ToYAML(resp)
-
 			Expect(err).ToNot(HaveOccurred())
+			// when
+			actual, err := util_proto.ToYAML(resp)
+			// then
+			Expect(err).ToNot(HaveOccurred())
+
 			Expect(actual).To(MatchYAML(given.expected))
 		},
 		Entry("should support a Dataplane without custom metrics configuration", testCase{

--- a/pkg/xds/generator/proxy_template_profile_source_test.go
+++ b/pkg/xds/generator/proxy_template_profile_source_test.go
@@ -123,9 +123,13 @@ var _ = Describe("ProxyTemplateProfileSource", func() {
 			// then
 			Expect(err).ToNot(HaveOccurred())
 
+			// when
+			resp, err := model.ResourceList(rs).ToDeltaDiscoveryResponse()
 			// then
-			resp := model.ResourceList(rs).ToDeltaDiscoveryResponse()
+			Expect(err).ToNot(HaveOccurred())
+			// when
 			actual, err := util_proto.ToYAML(resp)
+			// then
 			Expect(err).ToNot(HaveOccurred())
 
 			expected, err := ioutil.ReadFile(filepath.Join("testdata", "profile-source", given.envoyConfigFile))

--- a/pkg/xds/generator/proxy_template_profile_source_test.go
+++ b/pkg/xds/generator/proxy_template_profile_source_test.go
@@ -141,6 +141,8 @@ var _ = Describe("ProxyTemplateProfileSource", func() {
             networking:
               inbound:
                 - interface: 192.168.0.1:80:8080
+                  tags:
+                    service: backend
               outbound:
               - interface: :54321
                 service: db
@@ -159,6 +161,8 @@ var _ = Describe("ProxyTemplateProfileSource", func() {
             networking:
               inbound:
                 - interface: 192.168.0.1:80:8080
+                  tags:
+                    service: backend
               outbound:
               - interface: :54321
                 service: db
@@ -183,6 +187,9 @@ var _ = Describe("ProxyTemplateProfileSource", func() {
             networking:
               inbound:
                 - interface: 192.168.0.1:80:8080
+                  tags:
+                    service: backend
+                    protocol: http
               outbound:
               - interface: :54321
                 service: db
@@ -205,6 +212,9 @@ var _ = Describe("ProxyTemplateProfileSource", func() {
             networking:
               inbound:
                 - interface: 192.168.0.1:80:8080
+                  tags:
+                    service: backend
+                    protocol: http
               outbound:
               - interface: :54321
                 service: db

--- a/pkg/xds/generator/proxy_template_raw_source_test.go
+++ b/pkg/xds/generator/proxy_template_raw_source_test.go
@@ -209,11 +209,15 @@ var _ = Describe("ProxyTemplateRawSource", func() {
 			// then
 			Expect(err).ToNot(HaveOccurred())
 
+			// when
+			resp, err := model.ResourceList(rs).ToDeltaDiscoveryResponse()
 			// then
-			resp := model.ResourceList(rs).ToDeltaDiscoveryResponse()
-			actual, err := util_proto.ToYAML(resp)
-
 			Expect(err).ToNot(HaveOccurred())
+			// when
+			actual, err := util_proto.ToYAML(resp)
+			// then
+			Expect(err).ToNot(HaveOccurred())
+
 			Expect(actual).To(MatchYAML(given.expected))
 		},
 			Entry("should support empty resource list", testCase{

--- a/pkg/xds/generator/proxy_template_test.go
+++ b/pkg/xds/generator/proxy_template_test.go
@@ -155,9 +155,13 @@ var _ = Describe("TemplateProxyGenerator", func() {
 				// then
 				Expect(err).ToNot(HaveOccurred())
 
+				// when
+				resp, err := model.ResourceList(rs).ToDeltaDiscoveryResponse()
 				// then
-				resp := model.ResourceList(rs).ToDeltaDiscoveryResponse()
+				Expect(err).ToNot(HaveOccurred())
+				// when
 				actual, err := util_proto.ToYAML(resp)
+				// then
 				Expect(err).ToNot(HaveOccurred())
 
 				expected, err := ioutil.ReadFile(filepath.Join("testdata", "template-proxy", given.envoyConfigFile))

--- a/pkg/xds/generator/testdata/inbound-proxy/3-dataplane.input.yaml
+++ b/pkg/xds/generator/testdata/inbound-proxy/3-dataplane.input.yaml
@@ -1,3 +1,6 @@
 networking:
   inbound:
     - interface: 192.168.0.1:80:8080
+      tags:
+        service: backend1
+        protocol: http

--- a/pkg/xds/generator/testdata/inbound-proxy/3-envoy-config.golden.yaml
+++ b/pkg/xds/generator/testdata/inbound-proxy/3-envoy-config.golden.yaml
@@ -38,10 +38,23 @@ resources:
                           principalName:
                             exact: spiffe://default/web1
                 statPrefix: inbound_192_168_0_1_80.
-            - name: envoy.tcp_proxy
+            - name: envoy.http_connection_manager
               typedConfig:
-                '@type': type.googleapis.com/envoy.config.filter.network.tcp_proxy.v2.TcpProxy
-                cluster: localhost:8080
+                '@type': type.googleapis.com/envoy.config.filter.network.http_connection_manager.v2.HttpConnectionManager
+                httpFilters:
+                - name: envoy.router
+                routeConfig:
+                  name: inbound
+                  validateClusters: true
+                  virtualHosts:
+                  - domains:
+                    - '*'
+                    name: local_service
+                    routes:
+                    - match:
+                        prefix: /
+                      route:
+                        cluster: localhost:8080
                 statPrefix: localhost_8080
           tlsContext:
             commonTlsContext:

--- a/pkg/xds/generator/testdata/inbound-proxy/4-dataplane.input.yaml
+++ b/pkg/xds/generator/testdata/inbound-proxy/4-dataplane.input.yaml
@@ -3,3 +3,6 @@ networking:
     redirectPort: 15001
   inbound:
     - interface: 192.168.0.1:80:8080
+      tags:
+        service: backend1
+        protocol: http

--- a/pkg/xds/generator/testdata/inbound-proxy/4-envoy-config.golden.yaml
+++ b/pkg/xds/generator/testdata/inbound-proxy/4-envoy-config.golden.yaml
@@ -40,10 +40,23 @@ resources:
                           principalName:
                             exact: spiffe://default/web1
                 statPrefix: inbound_192_168_0_1_80.
-            - name: envoy.tcp_proxy
+            - name: envoy.http_connection_manager
               typedConfig:
-                '@type': type.googleapis.com/envoy.config.filter.network.tcp_proxy.v2.TcpProxy
-                cluster: localhost:8080
+                '@type': type.googleapis.com/envoy.config.filter.network.http_connection_manager.v2.HttpConnectionManager
+                httpFilters:
+                - name: envoy.router
+                routeConfig:
+                  name: inbound
+                  validateClusters: true
+                  virtualHosts:
+                  - domains:
+                    - '*'
+                    name: local_service
+                    routes:
+                    - match:
+                        prefix: /
+                      route:
+                        cluster: localhost:8080
                 statPrefix: localhost_8080
           tlsContext:
             commonTlsContext:

--- a/pkg/xds/generator/testdata/inbound-proxy/5-dataplane.input.yaml
+++ b/pkg/xds/generator/testdata/inbound-proxy/5-dataplane.input.yaml
@@ -1,4 +1,9 @@
 networking:
   inbound:
     - interface: 192.168.0.1:80:8080
+      tags:
+        service: backend1
+        protocol: http
     - interface: 192.168.0.1:443:8443
+      tags:
+        service: backend2

--- a/pkg/xds/generator/testdata/inbound-proxy/5-envoy-config.golden.yaml
+++ b/pkg/xds/generator/testdata/inbound-proxy/5-envoy-config.golden.yaml
@@ -37,10 +37,23 @@ resources:
                           principalName:
                             exact: spiffe://default/web1
                 statPrefix: inbound_192_168_0_1_80.
-            - name: envoy.tcp_proxy
+            - name: envoy.http_connection_manager
               typedConfig:
-                '@type': type.googleapis.com/envoy.config.filter.network.tcp_proxy.v2.TcpProxy
-                cluster: localhost:8080
+                '@type': type.googleapis.com/envoy.config.filter.network.http_connection_manager.v2.HttpConnectionManager
+                httpFilters:
+                - name: envoy.router
+                routeConfig:
+                  name: inbound
+                  validateClusters: true
+                  virtualHosts:
+                  - domains:
+                    - '*'
+                    name: local_service
+                    routes:
+                    - match:
+                        prefix: /
+                      route:
+                        cluster: localhost:8080
                 statPrefix: localhost_8080
           tlsContext:
             commonTlsContext:

--- a/pkg/xds/generator/testdata/inbound-proxy/6-dataplane.input.yaml
+++ b/pkg/xds/generator/testdata/inbound-proxy/6-dataplane.input.yaml
@@ -3,4 +3,9 @@ networking:
     redirectPort: 15001
   inbound:
     - interface: 192.168.0.1:80:8080
+      tags:
+        service: backend1
+        protocol: http
     - interface: 192.168.0.1:443:8443
+      tags:
+        service: backend2

--- a/pkg/xds/generator/testdata/inbound-proxy/6-envoy-config.golden.yaml
+++ b/pkg/xds/generator/testdata/inbound-proxy/6-envoy-config.golden.yaml
@@ -39,10 +39,23 @@ resources:
                           principalName:
                             exact: spiffe://default/web1
                 statPrefix: inbound_192_168_0_1_80.
-            - name: envoy.tcp_proxy
+            - name: envoy.http_connection_manager
               typedConfig:
-                '@type': type.googleapis.com/envoy.config.filter.network.tcp_proxy.v2.TcpProxy
-                cluster: localhost:8080
+                '@type': type.googleapis.com/envoy.config.filter.network.http_connection_manager.v2.HttpConnectionManager
+                httpFilters:
+                - name: envoy.router
+                routeConfig:
+                  name: inbound
+                  validateClusters: true
+                  virtualHosts:
+                  - domains:
+                    - '*'
+                    name: local_service
+                    routes:
+                    - match:
+                        prefix: /
+                      route:
+                        cluster: localhost:8080
                 statPrefix: localhost_8080
           tlsContext:
             commonTlsContext:

--- a/pkg/xds/generator/testdata/inbound-proxy/7-dataplane.input.yaml
+++ b/pkg/xds/generator/testdata/inbound-proxy/7-dataplane.input.yaml
@@ -1,6 +1,16 @@
 networking:
   inbound:
     - interface: 192.168.0.1:80:8080
+      tags:
+        service: backend1
+        protocol: http
     - interface: 192.168.0.1:443:8443
+      tags:
+        service: backend2
     - interface: 192.168.0.2:80:8080
+      tags:
+        service: backend3
+        protocol: http
     - interface: 192.168.0.2:443:8443
+      tags:
+        service: backend4

--- a/pkg/xds/generator/testdata/inbound-proxy/7-envoy-config.golden.yaml
+++ b/pkg/xds/generator/testdata/inbound-proxy/7-envoy-config.golden.yaml
@@ -37,10 +37,23 @@ resources:
                           principalName:
                             exact: spiffe://default/web1
                 statPrefix: inbound_192_168_0_1_80.
-            - name: envoy.tcp_proxy
+            - name: envoy.http_connection_manager
               typedConfig:
-                '@type': type.googleapis.com/envoy.config.filter.network.tcp_proxy.v2.TcpProxy
-                cluster: localhost:8080
+                '@type': type.googleapis.com/envoy.config.filter.network.http_connection_manager.v2.HttpConnectionManager
+                httpFilters:
+                - name: envoy.router
+                routeConfig:
+                  name: inbound
+                  validateClusters: true
+                  virtualHosts:
+                  - domains:
+                    - '*'
+                    name: local_service
+                    routes:
+                    - match:
+                        prefix: /
+                      route:
+                        cluster: localhost:8080
                 statPrefix: localhost_8080
           tlsContext:
             commonTlsContext:
@@ -151,10 +164,23 @@ resources:
                 '@type': type.googleapis.com/envoy.config.filter.network.rbac.v2.RBAC
                 rules: {}
                 statPrefix: inbound_192_168_0_2_80.
-            - name: envoy.tcp_proxy
+            - name: envoy.http_connection_manager
               typedConfig:
-                '@type': type.googleapis.com/envoy.config.filter.network.tcp_proxy.v2.TcpProxy
-                cluster: localhost:8080
+                '@type': type.googleapis.com/envoy.config.filter.network.http_connection_manager.v2.HttpConnectionManager
+                httpFilters:
+                - name: envoy.router
+                routeConfig:
+                  name: inbound
+                  validateClusters: true
+                  virtualHosts:
+                  - domains:
+                    - '*'
+                    name: local_service
+                    routes:
+                    - match:
+                        prefix: /
+                      route:
+                        cluster: localhost:8080
                 statPrefix: localhost_8080
           tlsContext:
             commonTlsContext:

--- a/pkg/xds/generator/testdata/inbound-proxy/8-dataplane.input.yaml
+++ b/pkg/xds/generator/testdata/inbound-proxy/8-dataplane.input.yaml
@@ -3,6 +3,16 @@ networking:
     redirectPort: 15001
   inbound:
     - interface: 192.168.0.1:80:8080
+      tags:
+        service: backend1
+        protocol: http
     - interface: 192.168.0.1:443:8443
+      tags:
+        service: backend2
     - interface: 192.168.0.2:80:8080
+      tags:
+        service: backend3
+        protocol: http
     - interface: 192.168.0.2:443:8443
+      tags:
+        service: backend4

--- a/pkg/xds/generator/testdata/inbound-proxy/8-envoy-config.golden.yaml
+++ b/pkg/xds/generator/testdata/inbound-proxy/8-envoy-config.golden.yaml
@@ -39,10 +39,23 @@ resources:
                           principalName:
                             exact: spiffe://default/web1
                 statPrefix: inbound_192_168_0_1_80.
-            - name: envoy.tcp_proxy
+            - name: envoy.http_connection_manager
               typedConfig:
-                '@type': type.googleapis.com/envoy.config.filter.network.tcp_proxy.v2.TcpProxy
-                cluster: localhost:8080
+                '@type': type.googleapis.com/envoy.config.filter.network.http_connection_manager.v2.HttpConnectionManager
+                httpFilters:
+                - name: envoy.router
+                routeConfig:
+                  name: inbound
+                  validateClusters: true
+                  virtualHosts:
+                  - domains:
+                    - '*'
+                    name: local_service
+                    routes:
+                    - match:
+                        prefix: /
+                      route:
+                        cluster: localhost:8080
                 statPrefix: localhost_8080
           tlsContext:
             commonTlsContext:
@@ -157,10 +170,23 @@ resources:
                 '@type': type.googleapis.com/envoy.config.filter.network.rbac.v2.RBAC
                 rules: {}
                 statPrefix: inbound_192_168_0_2_80.
-            - name: envoy.tcp_proxy
+            - name: envoy.http_connection_manager
               typedConfig:
-                '@type': type.googleapis.com/envoy.config.filter.network.tcp_proxy.v2.TcpProxy
-                cluster: localhost:8080
+                '@type': type.googleapis.com/envoy.config.filter.network.http_connection_manager.v2.HttpConnectionManager
+                httpFilters:
+                - name: envoy.router
+                routeConfig:
+                  name: inbound
+                  validateClusters: true
+                  virtualHosts:
+                  - domains:
+                    - '*'
+                    name: local_service
+                    routes:
+                    - match:
+                        prefix: /
+                      route:
+                        cluster: localhost:8080
                 statPrefix: localhost_8080
           tlsContext:
             commonTlsContext:

--- a/pkg/xds/generator/testdata/profile-source/3-envoy-config.golden.yaml
+++ b/pkg/xds/generator/testdata/profile-source/3-envoy-config.golden.yaml
@@ -72,10 +72,23 @@ resources:
           '@type': type.googleapis.com/envoy.config.filter.network.rbac.v2.RBAC
           rules: {}
           statPrefix: inbound_192_168_0_1_80.
-      - name: envoy.tcp_proxy
+      - name: envoy.http_connection_manager
         typedConfig:
-          '@type': type.googleapis.com/envoy.config.filter.network.tcp_proxy.v2.TcpProxy
-          cluster: localhost:8080
+          '@type': type.googleapis.com/envoy.config.filter.network.http_connection_manager.v2.HttpConnectionManager
+          httpFilters:
+          - name: envoy.router
+          routeConfig:
+            name: inbound
+            validateClusters: true
+            virtualHosts:
+            - domains:
+              - '*'
+              name: local_service
+              routes:
+              - match:
+                  prefix: /
+                route:
+                  cluster: localhost:8080
           statPrefix: localhost_8080
       tlsContext:
         commonTlsContext:

--- a/pkg/xds/generator/testdata/profile-source/4-envoy-config.golden.yaml
+++ b/pkg/xds/generator/testdata/profile-source/4-envoy-config.golden.yaml
@@ -101,10 +101,23 @@ resources:
           '@type': type.googleapis.com/envoy.config.filter.network.rbac.v2.RBAC
           rules: {}
           statPrefix: inbound_192_168_0_1_80.
-      - name: envoy.tcp_proxy
+      - name: envoy.http_connection_manager
         typedConfig:
-          '@type': type.googleapis.com/envoy.config.filter.network.tcp_proxy.v2.TcpProxy
-          cluster: localhost:8080
+          '@type': type.googleapis.com/envoy.config.filter.network.http_connection_manager.v2.HttpConnectionManager
+          httpFilters:
+          - name: envoy.router
+          routeConfig:
+            name: inbound
+            validateClusters: true
+            virtualHosts:
+            - domains:
+              - '*'
+              name: local_service
+              routes:
+              - match:
+                  prefix: /
+                route:
+                  cluster: localhost:8080
           statPrefix: localhost_8080
       tlsContext:
         commonTlsContext:

--- a/pkg/xds/generator/transparent_proxy_generator_test.go
+++ b/pkg/xds/generator/transparent_proxy_generator_test.go
@@ -34,11 +34,15 @@ var _ = Describe("TransparentProxyGenerator", func() {
 			// then
 			Expect(err).ToNot(HaveOccurred())
 
+			// when
+			resp, err := model.ResourceList(rs).ToDeltaDiscoveryResponse()
 			// then
-			resp := model.ResourceList(rs).ToDeltaDiscoveryResponse()
-			actual, err := util_proto.ToYAML(resp)
-
 			Expect(err).ToNot(HaveOccurred())
+			// when
+			actual, err := util_proto.ToYAML(resp)
+			// then
+			Expect(err).ToNot(HaveOccurred())
+
 			Expect(actual).To(MatchYAML(given.expected))
 		},
 		Entry("transparent_proxying=false", testCase{

--- a/pkg/xds/server/snapshot_generator_test.go
+++ b/pkg/xds/server/snapshot_generator_test.go
@@ -107,9 +107,13 @@ var _ = Describe("Reconcile", func() {
 			// then
 			Expect(err).ToNot(HaveOccurred())
 
+			// when
+			resp, err := util_cache.ToDeltaDiscoveryResponse(s)
 			// then
-			resp := util_cache.ToDeltaDiscoveryResponse(s)
+			Expect(err).ToNot(HaveOccurred())
+			// when
 			actual, err := util_proto.ToYAML(resp)
+			// then
 			Expect(err).ToNot(HaveOccurred())
 
 			expected, err := ioutil.ReadFile(filepath.Join("testdata", "envoy-config.golden.yaml"))


### PR DESCRIPTION
## Summary

* generate HTTP-specific inbound listeners for services tagged with `protocol: http`
