### PR TITLE
kuma-cp: support `<port>.service.kuma.io/protocol` annotation on k8s as a way for users to indicate protocol of a service

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 Changes:
 
+* feature: support `<port>.service.kuma.io/protocol` annotation on k8s as a way for users to indicate protocol of a service
+  [#575](https://github.com/Kong/kuma/pull/575)
 * feature: generate HTTP-specific inbound listeners for services tagged with `protocol: http`
   [#574](https://github.com/Kong/kuma/pull/574)
 * feature: support IPv6 in Dataplane resource

--- a/pkg/plugins/discovery/k8s/controllers/pod_controller_test.go
+++ b/pkg/plugins/discovery/k8s/controllers/pod_controller_test.go
@@ -81,6 +81,9 @@ var _ = Describe("PodReconciler", func() {
 				ObjectMeta: kube_meta.ObjectMeta{
 					Namespace: "demo",
 					Name:      "example",
+					Annotations: map[string]string{
+						"80.service.kuma.io/protocol": "http",
+					},
 				},
 				Spec: kube_core.ServiceSpec{
 					Ports: []kube_core.ServicePort{
@@ -247,9 +250,11 @@ var _ = Describe("PodReconciler", func() {
             - interface: 192.168.0.1:8080:8080
               tags:
                 service: example.demo.svc:80
+                protocol: http
             - interface: 192.168.0.1:6060:6060
               tags:
                 service: example.demo.svc:6061
+                protocol: tcp
 `))
 	})
 
@@ -311,9 +316,11 @@ var _ = Describe("PodReconciler", func() {
             - interface: 192.168.0.1:8080:8080
               tags:
                 service: example.demo.svc:80
+                protocol: http
             - interface: 192.168.0.1:6060:6060
               tags:
                 service: example.demo.svc:6061
+                protocol: tcp
 `))
 	})
 })

--- a/tools/e2e/examples/docker-compose/kuma-example-installer.sh
+++ b/tools/e2e/examples/docker-compose/kuma-example-installer.sh
@@ -92,7 +92,9 @@ networking:
   inbound:
   - interface: {{ IP }}:{{ PUBLIC_PORT }}:{{ LOCAL_PORT }}
     tags:
-      service: kuma-example-app"
+      service: kuma-example-app
+      protocol: http
+"
 
 #
 # Create Dataplane for `kuma-example-client` service
@@ -143,6 +145,7 @@ networking:
   - interface: {{ IP }}:{{ PUBLIC_PORT }}:{{ LOCAL_PORT }}
     tags:
       service: kuma-example-backend
+      protocol: http
       version: v1
       env: prod"
 
@@ -159,5 +162,6 @@ networking:
   - interface: {{ IP }}:{{ PUBLIC_PORT }}:{{ LOCAL_PORT }}
     tags:
       service: kuma-example-backend
+      protocol: http
       version: v2
       env: intg"

--- a/tools/e2e/examples/minikube/kuma-demo/kuma-demo.yaml
+++ b/tools/e2e/examples/minikube/kuma-demo/kuma-demo.yaml
@@ -29,6 +29,8 @@ kind: Service
 metadata:
   name: demo-app
   namespace: kuma-demo
+  annotations:
+    8080.service.kuma.io/protocol: http
 spec:
   ports:
   - port: 8000

--- a/tools/e2e/examples/minikube/kuma-routing/kuma-routing.yaml
+++ b/tools/e2e/examples/minikube/kuma-routing/kuma-routing.yaml
@@ -88,6 +88,8 @@ kind: Service
 metadata:
   name: kuma-example-backend
   namespace: kuma-example
+  annotations:
+    7070.service.kuma.io/protocol: http
 spec:
   ports:
   - port: 7070


### PR DESCRIPTION
### Summary

* support `<port>.service.kuma.io/protocol` annotation on k8s as a way for users to indicate protocol of a service

