### PR TITLE
kuma-cp: validate value of `protocol` tag on a Dataplane resource

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 Changes:
 
+* feature: validate value of `protocol` tag on a Dataplane resource
+  [#576](https://github.com/Kong/kuma/pull/576)
 * feature: support `<port>.service.kuma.io/protocol` annotation on k8s as a way for users to indicate protocol of a service
   [#575](https://github.com/Kong/kuma/pull/575)
 * feature: generate HTTP-specific inbound listeners for services tagged with `protocol: http`

--- a/pkg/core/resources/apis/mesh/dataplane_helpers.go
+++ b/pkg/core/resources/apis/mesh/dataplane_helpers.go
@@ -29,6 +29,23 @@ func ParseProtocol(tag string) Protocol {
 	}
 }
 
+// ProtocolList represents a list of Protocols.
+type ProtocolList []Protocol
+
+func (l ProtocolList) Strings() []string {
+	values := make([]string, len(l))
+	for i := range l {
+		values[i] = string(l[i])
+	}
+	return values
+}
+
+// SupportedProtocols is a list of supported protocols that will be communicated to a user.
+var SupportedProtocols = ProtocolList{
+	ProtocolHTTP,
+	ProtocolTCP,
+}
+
 var ipv4loopback = net.IPv4(127, 0, 0, 1)
 
 func (d *DataplaneResource) UsesInterface(address net.IP, port uint32) bool {

--- a/pkg/core/resources/apis/mesh/dataplane_validator.go
+++ b/pkg/core/resources/apis/mesh/dataplane_validator.go
@@ -1,6 +1,8 @@
 package mesh
 
 import (
+	"fmt"
+
 	mesh_proto "github.com/Kong/kuma/api/mesh/v1alpha1"
 	"github.com/Kong/kuma/pkg/core/validators"
 )
@@ -42,6 +44,11 @@ func validateInbound(inbound *mesh_proto.Dataplane_Networking_Inbound) validator
 	}
 	if _, exist := inbound.Tags[mesh_proto.ServiceTag]; !exist {
 		result.AddViolationAt(validators.RootedAt("tags").Key(mesh_proto.ServiceTag), `tag has to exist`)
+	}
+	if value, exist := inbound.Tags[mesh_proto.ProtocolTag]; exist {
+		if ParseProtocol(value) == ProtocolUnknown {
+			result.AddViolationAt(validators.RootedAt("tags").Key(mesh_proto.ProtocolTag), fmt.Sprintf("tag %q has an invalid value %q. %s", mesh_proto.ProtocolTag, value, AllowedValuesHint(SupportedProtocols.Strings()...)))
+		}
 	}
 	for name, value := range inbound.Tags {
 		if value == "" {

--- a/pkg/core/resources/apis/mesh/dataplane_validator_test.go
+++ b/pkg/core/resources/apis/mesh/dataplane_validator_test.go
@@ -56,6 +56,14 @@ var _ = Describe("Dataplane", func() {
 		Entry("dataplane with inbounds", func() core_mesh.DataplaneResource {
 			return validDataplane
 		}),
+		Entry("dataplane with inbounds and no `protocol` tag", func() core_mesh.DataplaneResource {
+			delete(validDataplane.Spec.Networking.Inbound[0].Tags, "protocol")
+			return validDataplane
+		}),
+		Entry("dataplane with inbounds and a valid `protocol` tag", func() core_mesh.DataplaneResource {
+			validDataplane.Spec.Networking.Inbound[0].Tags["protocol"] = "http"
+			return validDataplane
+		}),
 		Entry("dataplane with gateway", func() core_mesh.DataplaneResource {
 			return core_mesh.DataplaneResource{
 				Meta: &model.ResourceMeta{
@@ -179,6 +187,38 @@ var _ = Describe("Dataplane", func() {
 					{
 						Field:   `networking.inbound[0].tags["version"]`,
 						Message: `tag value cannot be empty`,
+					},
+				},
+			},
+		}),
+		Entry("inbound: `protocol` tag with an empty value", testCase{
+			dataplane: func() core_mesh.DataplaneResource {
+				validDataplane.Spec.Networking.Inbound[0].Tags["protocol"] = ""
+				return validDataplane
+			},
+			validationResult: &validators.ValidationError{
+				Violations: []validators.Violation{
+					{
+						Field:   `networking.inbound[0].tags["protocol"]`,
+						Message: `tag "protocol" has an invalid value "". Allowed values: http, tcp`,
+					},
+					{
+						Field:   `networking.inbound[0].tags["protocol"]`,
+						Message: `tag value cannot be empty`,
+					},
+				},
+			},
+		}),
+		Entry("inbound: `protocol` tag with unsupported value", testCase{
+			dataplane: func() core_mesh.DataplaneResource {
+				validDataplane.Spec.Networking.Inbound[0].Tags["protocol"] = "not-yet-supported-protocol"
+				return validDataplane
+			},
+			validationResult: &validators.ValidationError{
+				Violations: []validators.Violation{
+					{
+						Field:   `networking.inbound[0].tags["protocol"]`,
+						Message: `tag "protocol" has an invalid value "not-yet-supported-protocol". Allowed values: http, tcp`,
 					},
 				},
 			},

--- a/pkg/core/resources/apis/mesh/validators.go
+++ b/pkg/core/resources/apis/mesh/validators.go
@@ -3,6 +3,7 @@ package mesh
 import (
 	"fmt"
 	"sort"
+	"strings"
 
 	mesh_proto "github.com/Kong/kuma/api/mesh/v1alpha1"
 	"github.com/Kong/kuma/pkg/core/validators"
@@ -121,4 +122,12 @@ func ValidateThreshold(path validators.PathBuilder, threshold uint32) (err valid
 		err.AddViolationAt(path, "must have a positive value")
 	}
 	return
+}
+
+func AllowedValuesHint(values ...string) string {
+	options := strings.Join(values, ", ")
+	if len(values) == 0 {
+		options = "(none)"
+	}
+	return fmt.Sprintf("Allowed values: %s", options)
 }

--- a/pkg/core/resources/apis/mesh/validators_test.go
+++ b/pkg/core/resources/apis/mesh/validators_test.go
@@ -1,0 +1,39 @@
+package mesh_test
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/ginkgo/extensions/table"
+	. "github.com/onsi/gomega"
+
+	. "github.com/Kong/kuma/pkg/core/resources/apis/mesh"
+)
+
+var _ = Describe("AllowedValuesHint()", func() {
+
+	type testCase struct {
+		values   []string
+		expected string
+	}
+
+	DescribeTable("should generate a proper hint",
+		func(given testCase) {
+			Expect(AllowedValuesHint(given.values...)).To(Equal(given.expected))
+		},
+		Entry("nil list", testCase{
+			values:   nil,
+			expected: `Allowed values: (none)`,
+		}),
+		Entry("empty list", testCase{
+			values:   []string{},
+			expected: `Allowed values: (none)`,
+		}),
+		Entry("one-item list", testCase{
+			values:   []string{"http"},
+			expected: `Allowed values: http`,
+		}),
+		Entry("multi-item list", testCase{
+			values:   []string{"grpc", "http", "http2", "mongo", "mysql", "redis", "tcp"},
+			expected: `Allowed values: grpc, http, http2, mongo, mysql, redis, tcp`,
+		}),
+	)
+})


### PR DESCRIPTION
### Summary

* validate value of `protocol` tag on a Dataplane resource
