### PR TITLE
feat(kuma-cp) support new format of Dataplane

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 Changes:
 
+* feature: support new format of the Dataplane including scraping metrics from Gateway Dataplane
+  [#578](https://github.com/Kong/kuma/pull/579)
 * feature: new Dataplane format
   [#578](https://github.com/Kong/kuma/pull/576)
 * feature: validate value of `protocol` tag on a Dataplane resource

--- a/api/mesh/v1alpha1/dataplane_helpers_test.go
+++ b/api/mesh/v1alpha1/dataplane_helpers_test.go
@@ -447,7 +447,7 @@ var _ = Describe("Dataplane_Networking", func() {
 								Port: 80,
 							},
 							{
-								Address:     "192.168.0.1",
+								Address:     "192.168.0.2",
 								Port:        443,
 								ServicePort: 8443,
 							},
@@ -455,7 +455,7 @@ var _ = Describe("Dataplane_Networking", func() {
 					},
 					expected: []InboundInterface{
 						{DataplaneIP: "192.168.0.1", DataplanePort: 80, WorkloadPort: 80},
-						{DataplaneIP: "192.168.0.1", DataplanePort: 443, WorkloadPort: 8443},
+						{DataplaneIP: "192.168.0.2", DataplanePort: 443, WorkloadPort: 8443},
 					},
 				}),
 			)

--- a/api/mesh/v1alpha1/dataplane_helpers_test.go
+++ b/api/mesh/v1alpha1/dataplane_helpers_test.go
@@ -319,6 +319,89 @@ var _ = Describe("ParseOutboundInterface(..)", func() {
 
 var _ = Describe("Dataplane_Networking", func() {
 
+	Describe("GetOutboundInterfaces()", func() {
+		Context("valid input values", func() {
+			type testCase struct {
+				input    *Dataplane_Networking
+				expected []OutboundInterface
+			}
+
+			DescribeTable("should parse valid input values",
+				func(given testCase) {
+					// when
+					ofaces, err := given.input.GetOutboundInterfaces()
+					// then
+					Expect(err).ToNot(HaveOccurred())
+					// and
+					Expect(ofaces).To(Equal(given.expected))
+				},
+				Entry("nil", testCase{
+					input:    nil,
+					expected: nil,
+				}),
+				Entry("empty", testCase{
+					input:    &Dataplane_Networking{},
+					expected: []OutboundInterface{},
+				}),
+				Entry("legacy - 2 outbound interfaces", testCase{
+					input: &Dataplane_Networking{
+						Outbound: []*Dataplane_Networking_Outbound{
+							{Interface: ":8080"},
+							{Interface: "192.168.0.1:443"},
+						},
+					},
+					expected: []OutboundInterface{
+						{DataplaneIP: "127.0.0.1", DataplanePort: 8080},
+						{DataplaneIP: "192.168.0.1", DataplanePort: 443},
+					},
+				}),
+				Entry("2 outbound interfaces", testCase{
+					input: &Dataplane_Networking{
+						Outbound: []*Dataplane_Networking_Outbound{
+							{
+								Port: 8080,
+							},
+							{
+								Address: "192.168.0.1",
+								Port:    443,
+							},
+						},
+					},
+					expected: []OutboundInterface{
+						{DataplaneIP: "127.0.0.1", DataplanePort: 8080},
+						{DataplaneIP: "192.168.0.1", DataplanePort: 443},
+					},
+				}),
+			)
+		})
+
+		Context("invalid input values", func() {
+			type testCase struct {
+				input       *Dataplane_Networking
+				expectedErr gomega_types.GomegaMatcher
+			}
+
+			DescribeTable("should fail on invalid input values",
+				func(given testCase) {
+					// when
+					ifaces, err := given.input.GetOutboundInterfaces()
+					// then
+					Expect(ifaces).To(BeNil())
+					// and
+					Expect(err.Error()).To(given.expectedErr)
+				},
+				Entry("dataplane IP address is missing", testCase{
+					input: &Dataplane_Networking{
+						Outbound: []*Dataplane_Networking_Outbound{
+							{Interface: ":443:8443"},
+						},
+					},
+					expectedErr: Equal(`invalid format: expected "[ IPv4 | '[' IPv6 ']' ] ':' DATAPLANE_PORT", got ":443:8443"`),
+				}),
+			)
+		})
+	})
+
 	Describe("GetInboundInterfaces()", func() {
 
 		Context("valid input values", func() {
@@ -344,7 +427,7 @@ var _ = Describe("Dataplane_Networking", func() {
 					input:    &Dataplane_Networking{},
 					expected: []InboundInterface{},
 				}),
-				Entry("2 inbound interfaces", testCase{
+				Entry("legacy - 2 inbound interfaces", testCase{
 					input: &Dataplane_Networking{
 						Inbound: []*Dataplane_Networking_Inbound{
 							{Interface: "192.168.0.1:80:8080"},
@@ -353,6 +436,25 @@ var _ = Describe("Dataplane_Networking", func() {
 					},
 					expected: []InboundInterface{
 						{DataplaneIP: "192.168.0.1", DataplanePort: 80, WorkloadPort: 8080},
+						{DataplaneIP: "192.168.0.1", DataplanePort: 443, WorkloadPort: 8443},
+					},
+				}),
+				Entry("2 inbound interfaces", testCase{
+					input: &Dataplane_Networking{
+						Address: "192.168.0.1",
+						Inbound: []*Dataplane_Networking_Inbound{
+							{
+								Port: 80,
+							},
+							{
+								Address:     "192.168.0.1",
+								Port:        443,
+								ServicePort: 8443,
+							},
+						},
+					},
+					expected: []InboundInterface{
+						{DataplaneIP: "192.168.0.1", DataplanePort: 80, WorkloadPort: 80},
 						{DataplaneIP: "192.168.0.1", DataplanePort: 443, WorkloadPort: 8443},
 					},
 				}),

--- a/pkg/core/permissions/matcher_test.go
+++ b/pkg/core/permissions/matcher_test.go
@@ -145,10 +145,15 @@ var _ = Describe("Matcher", func() {
 		}
 
 		// when
-		matchedPerms := MatchDataplaneTrafficPermissions(&dataplane, &permissions)
+		matchedPerms, err := MatchDataplaneTrafficPermissions(&dataplane, &permissions)
 
 		// then
-		backendMatches := matchedPerms.Get("192.168.0.1:8080:80")
+		Expect(err).ToNot(HaveOccurred())
+		backendMatches := matchedPerms.Get(mesh_proto.InboundInterface{
+			DataplaneIP:   "192.168.0.1",
+			DataplanePort: 8080,
+			WorkloadPort:  80,
+		})
 		expectedBackendMatches := core_mesh.TrafficPermissionResourceList{
 			Items: []*core_mesh.TrafficPermissionResource{
 				{
@@ -204,7 +209,11 @@ var _ = Describe("Matcher", func() {
 				},
 			},
 		}
-		webMatches := matchedPerms.Get("192.168.0.1:8090:90")
+		webMatches := matchedPerms.Get(mesh_proto.InboundInterface{
+			DataplaneIP:   "192.168.0.1",
+			DataplanePort: 8090,
+			WorkloadPort:  90,
+		})
 		Expect(*webMatches).To(Equal(expectedWebMatches))
 	})
 })

--- a/pkg/core/resources/apis/mesh/dataplane_helpers.go
+++ b/pkg/core/resources/apis/mesh/dataplane_helpers.go
@@ -56,11 +56,11 @@ func (d *DataplaneResource) UsesInboundInterface(address net.IP, port uint32) bo
 	if d == nil {
 		return false
 	}
-	for _, inbound := range d.Spec.Networking.GetInbound() {
-		iface, err := mesh_proto.ParseInboundInterface(inbound.Interface)
-		if err != nil {
-			continue
-		}
+	ifaces, err := d.Spec.Networking.GetInboundInterfaces()
+	if err != nil {
+		return false
+	}
+	for _, iface := range ifaces {
 		// compare against port and IP address of the dataplane
 		if port == iface.DataplanePort && overlap(address, net.ParseIP(iface.DataplaneIP)) {
 			return true
@@ -77,11 +77,11 @@ func (d *DataplaneResource) UsesOutboundInterface(address net.IP, port uint32) b
 	if d == nil {
 		return false
 	}
-	for _, outbound := range d.Spec.Networking.GetOutbound() {
-		oface, err := mesh_proto.ParseOutboundInterface(outbound.Interface)
-		if err != nil {
-			continue
-		}
+	ofaces, err := d.Spec.Networking.GetOutboundInterfaces()
+	if err != nil {
+		return false
+	}
+	for _, oface := range ofaces {
 		// compare against port and IP address of the dataplane
 		if port == oface.DataplanePort && overlap(address, net.ParseIP(oface.DataplaneIP)) {
 			return true
@@ -113,6 +113,10 @@ func (d *DataplaneResource) GetIP() string {
 	if d == nil {
 		return ""
 	}
+	if d.Spec.Networking.Address != "" {
+		return d.Spec.Networking.Address
+	}
+	// fallback to legacy format
 	ifaces, err := d.Spec.Networking.GetInboundInterfaces()
 	if err != nil {
 		return ""

--- a/pkg/core/resources/apis/mesh/dataplane_helpers.go
+++ b/pkg/core/resources/apis/mesh/dataplane_helpers.go
@@ -117,12 +117,12 @@ func (d *DataplaneResource) GetIP() string {
 		return d.Spec.Networking.Address
 	}
 	// fallback to legacy format
-	ifaces, err := d.Spec.Networking.GetInboundInterfaces()
+	if len(d.Spec.Networking.Inbound) == 0 {
+		return ""
+	}
+	iface, err := d.Spec.Networking.GetInboundInterfaceByIdx(0)
 	if err != nil {
 		return ""
 	}
-	if len(ifaces) == 0 {
-		return ""
-	}
-	return ifaces[0].DataplaneIP
+	return iface.DataplaneIP
 }

--- a/pkg/core/resources/apis/mesh/dataplane_helpers_test.go
+++ b/pkg/core/resources/apis/mesh/dataplane_helpers_test.go
@@ -412,12 +412,12 @@ var _ = Describe("Dataplane", func() {
 				dataplane: `
                 networking:
                   inbound:
-                  - interface: 192.168.0.1:80:8080
-                    tags:
-                      service: backend
                   - interface: x.y.z.0
                     tags:
                       service: backend-https
+                  - interface: 192.168.0.1:80:8080
+                    tags:
+                      service: backend
 `,
 				expected: "",
 			}),

--- a/pkg/core/resources/apis/mesh/dataplane_helpers_test.go
+++ b/pkg/core/resources/apis/mesh/dataplane_helpers_test.go
@@ -373,7 +373,18 @@ var _ = Describe("Dataplane", func() {
 `,
 				expected: "",
 			}),
-			Entry("dataplane with 1 inbound interface", testCase{
+			Entry("dataplane with address in networking", testCase{
+				dataplane: `
+                networking:
+                  address: 192.168.0.1
+                  inbound:
+                  - port: 8080
+                    tags:
+                      service: backend
+`,
+				expected: "192.168.0.1",
+			}),
+			Entry("legacy - dataplane with 1 inbound interface", testCase{
 				dataplane: `
                 networking:
                   inbound:
@@ -383,7 +394,7 @@ var _ = Describe("Dataplane", func() {
 `,
 				expected: "192.168.0.1",
 			}),
-			Entry("dataplane with 2 inbound interfaces", testCase{
+			Entry("legacy - dataplane with 2 inbound interfaces", testCase{
 				dataplane: `
                 networking:
                   inbound:

--- a/pkg/core/resources/apis/mesh/dataplane_helpers_test.go
+++ b/pkg/core/resources/apis/mesh/dataplane_helpers_test.go
@@ -379,6 +379,7 @@ var _ = Describe("Dataplane", func() {
                   address: 192.168.0.1
                   inbound:
                   - port: 8080
+                    address: 192.168.0.2
                     tags:
                       service: backend
 `,

--- a/pkg/mads/reconcile/snapshot_generator_test.go
+++ b/pkg/mads/reconcile/snapshot_generator_test.go
@@ -210,13 +210,13 @@ var _ = Describe("snapshotGenerator", func() {
 						},
 						Spec: mesh_proto.Dataplane{
 							Networking: &mesh_proto.Dataplane_Networking{
-								Inbound: []*mesh_proto.Dataplane_Networking_Inbound{{
-									Interface: "192.168.0.3:3000:3000",
+								Address: "192.168.0.3",
+								Gateway: &mesh_proto.Dataplane_Networking_Gateway{
 									Tags: map[string]string{
 										"service": "web",
 										"env":     "test",
 									},
-								}},
+								},
 							},
 							Metrics: &mesh_proto.Metrics{
 								Prometheus: &mesh_proto.Metrics_Prometheus{

--- a/pkg/plugins/discovery/k8s/controllers/pod_controller_test.go
+++ b/pkg/plugins/discovery/k8s/controllers/pod_controller_test.go
@@ -246,12 +246,13 @@ var _ = Describe("PodReconciler", func() {
             uid: ""
         spec:
           networking:
+            address: 192.168.0.1
             inbound:
-            - interface: 192.168.0.1:8080:8080
+            - port: 8080
               tags:
-                service: example.demo.svc:80
                 protocol: http
-            - interface: 192.168.0.1:6060:6060
+                service: example.demo.svc:80
+            - port: 6060
               tags:
                 service: example.demo.svc:6061
                 protocol: tcp
@@ -312,12 +313,13 @@ var _ = Describe("PodReconciler", func() {
             uid: ""
         spec:
           networking:
+            address: 192.168.0.1
             inbound:
-            - interface: 192.168.0.1:8080:8080
+            - port: 8080
               tags:
-                service: example.demo.svc:80
                 protocol: http
-            - interface: 192.168.0.1:6060:6060
+                service: example.demo.svc:80
+            - port: 6060
               tags:
                 service: example.demo.svc:6061
                 protocol: tcp

--- a/pkg/plugins/discovery/k8s/controllers/pod_converter_test.go
+++ b/pkg/plugins/discovery/k8s/controllers/pod_converter_test.go
@@ -136,7 +136,8 @@ var _ = Describe("PodToDataplane(..)", func() {
             metadata:
               creationTimestamp: null
             spec:
-              networking: {}
+              networking:
+                address: 192.168.0.1
 `,
 		}),
 		Entry("Pod with a Service but mismatching ports", testCase{
@@ -186,7 +187,8 @@ var _ = Describe("PodToDataplane(..)", func() {
             metadata:
               creationTimestamp: null
             spec:
-              networking: {}
+              networking:
+                address: 192.168.0.1
 `,
 		}),
 		Entry("Pod with 2 Services", testCase{
@@ -257,26 +259,27 @@ var _ = Describe("PodToDataplane(..)", func() {
               creationTimestamp: null
             spec:
               networking:
+                address: 192.168.0.1
                 inbound:
-                - interface: 192.168.0.1:8080:8080
+                - port: 8080
                   tags:
                     app: example
                     protocol: http
                     service: example.demo.svc:80
                     version: "0.1"
-                - interface: 192.168.0.1:8443:8443
+                - port: 8443
                   tags:
                     app: example
                     protocol: tcp
                     service: example.demo.svc:443
                     version: "0.1"
-                - interface: 192.168.0.1:7070:7070
+                - port: 7070
                   tags:
                     app: example
                     protocol: MONGO
                     service: sample.playground.svc:7071
                     version: "0.1"
-                - interface: 192.168.0.1:6060:6060
+                - port: 6060
                   tags:
                     app: example
                     protocol: tcp
@@ -315,13 +318,14 @@ var _ = Describe("PodToDataplane(..)", func() {
               namespace: playground
             spec:
               networking:
+                address: 10.244.0.25
                 inbound:
-                - interface: 10.244.0.25:80:80
+                - port: 80
                   tags:
                     app: test-app
                     pod-template-hash: 8646b8bbc8
                     service: test-app.playground.svc:80
-                - interface: 10.244.0.25:443:443
+                - port: 443
                   tags:
                     app: test-app
                     pod-template-hash: 8646b8bbc8
@@ -362,17 +366,20 @@ var _ = Describe("PodToDataplane(..)", func() {
               creationTimestamp: null
             spec:
               networking:
+                address: 192.168.0.1
                 inbound:
-                - interface: 192.168.0.1:8080:8080
+                - port: 8080
                   tags:
                     app: example
                     protocol: tcp
                     service: example.demo.svc:80
                     version: "0.1"
                 outbound:
-                - interface: 10.108.144.24:443
+                - address: 10.108.144.24
+                  port: 443
                   service: test-app.playground.svc:443
-                - interface: 10.108.144.24:80
+                - address: 10.108.144.24
+                  port: 80
                   service: test-app.playground.svc:80
 `,
 		}),
@@ -415,6 +422,7 @@ var _ = Describe("PodToDataplane(..)", func() {
               creationTimestamp: null
             spec:
               networking:
+                address: 192.168.0.1
                 gateway:
                   tags:
                     app: example
@@ -430,7 +438,8 @@ var _ = Describe("PodToDataplane(..)", func() {
             metadata:
               creationTimestamp: null
             spec:
-              networking: {}
+              networking:
+                address: 192.168.0.1
 `,
 		}),
 	)

--- a/pkg/xds/generator/inbound_proxy_generator_test.go
+++ b/pkg/xds/generator/inbound_proxy_generator_test.go
@@ -60,7 +60,11 @@ var _ = Describe("InboundProxyGenerator", func() {
 					Spec: dataplane,
 				},
 				TrafficPermissions: permissions.MatchedPermissions{
-					"192.168.0.1:80:8080": &mesh_core.TrafficPermissionResourceList{
+					mesh_proto.InboundInterface{
+						DataplaneIP:   "192.168.0.1",
+						DataplanePort: 80,
+						WorkloadPort:  8080,
+					}: &mesh_core.TrafficPermissionResourceList{
 						Items: []*mesh_core.TrafficPermissionResource{
 							{
 								Meta: &test_model.ResourceMeta{

--- a/pkg/xds/generator/outbound_proxy_generator_test.go
+++ b/pkg/xds/generator/outbound_proxy_generator_test.go
@@ -391,7 +391,7 @@ var _ = Describe("OutboundProxyGenerator", func() {
                     service: backend
 `,
 				chaos:              noExtraChaos,
-				expectedErrMatcher: HavePrefix(`dataplane.networking.outbound[0].interface: value is not valid: "127:not-a-port"`),
+				expectedErrMatcher: HavePrefix(`invalid DATAPLANE_IP in "127:not-a-port": "127" is not a valid IP address`),
 			}),
 			Entry("dataplane with an outbound interface that has no route", testCase{
 				ctx: plainCtx,

--- a/pkg/xds/server/snapshot_generator_test.go
+++ b/pkg/xds/server/snapshot_generator_test.go
@@ -69,7 +69,11 @@ var _ = Describe("Reconcile", func() {
 					Spec: dataplane,
 				},
 				TrafficPermissions: permissions.MatchedPermissions{
-					"192.168.0.1:80:8080": &mesh_core.TrafficPermissionResourceList{
+					mesh_proto.InboundInterface{
+						DataplaneIP:   "192.168.0.1",
+						DataplanePort: 80,
+						WorkloadPort:  8080,
+					}: &mesh_core.TrafficPermissionResourceList{
 						Items: []*mesh_core.TrafficPermissionResource{
 							&mesh_core.TrafficPermissionResource{
 								Meta: &test_model.ResourceMeta{


### PR DESCRIPTION
### Summary

Support the new format of the Dataplane across Kuma CP including scraping metrics from Gateway Dataplanes.