### PR TITLE
chore(kuma-cp) use new dp format across the project

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 Changes:
 
+* chore: use new Dataplane format across the project
+  [#578](https://github.com/Kong/kuma/pull/580)
 * feature: support new format of the Dataplane including scraping metrics from Gateway Dataplane
   [#578](https://github.com/Kong/kuma/pull/579)
 * feature: new Dataplane format

--- a/api/mesh/v1alpha1/dataplane_test.go
+++ b/api/mesh/v1alpha1/dataplane_test.go
@@ -19,6 +19,7 @@ var _ = Describe("Dataplane", func() {
           inbound:
           - port: 80
             servicePort: 8080
+            address: 2.2.2.2
             tags:
               service: mobile
               version: "0.1"
@@ -46,6 +47,7 @@ var _ = Describe("Dataplane", func() {
 		Expect(dataplane.Networking.Inbound).To(HaveLen(1))
 		Expect(dataplane.Networking.Inbound[0].Port).To(Equal(uint32(80)))
 		Expect(dataplane.Networking.Inbound[0].ServicePort).To(Equal(uint32(8080)))
+		Expect(dataplane.Networking.Inbound[0].Address).To(Equal("2.2.2.2"))
 		Expect(dataplane.Networking.Inbound[0].Tags).To(HaveLen(3))
 		Expect(dataplane.Networking.Inbound[0].Tags).To(HaveKeyWithValue("service", "mobile"))
 		Expect(dataplane.Networking.Inbound[0].Tags).To(HaveKeyWithValue("version", "0.1"))

--- a/api/mesh/v1alpha1/dataplane_test.go
+++ b/api/mesh/v1alpha1/dataplane_test.go
@@ -15,16 +15,18 @@ var _ = Describe("Dataplane", func() {
 		// given
 		input := `
         networking:
+          address: 1.1.1.1
           inbound:
-          - interface: 1.1.1.1:80:8080
+          - port: 80
+            servicePort: 8080
             tags:
               service: mobile
               version: "0.1"
               env: production
           outbound:
-          - interface: :30000
+          - port: 30000
             service: postgres
-          - interface: :50000
+          - port: 50000
             service: redis.default.svc
 `
 		// when
@@ -39,17 +41,20 @@ var _ = Describe("Dataplane", func() {
 		Expect(err).ToNot(HaveOccurred())
 
 		// and
+		Expect(dataplane.Networking.Address).To(Equal("1.1.1.1"))
+		// and
 		Expect(dataplane.Networking.Inbound).To(HaveLen(1))
-		Expect(dataplane.Networking.Inbound[0].Interface).To(Equal("1.1.1.1:80:8080"))
+		Expect(dataplane.Networking.Inbound[0].Port).To(Equal(uint32(80)))
+		Expect(dataplane.Networking.Inbound[0].ServicePort).To(Equal(uint32(8080)))
 		Expect(dataplane.Networking.Inbound[0].Tags).To(HaveLen(3))
 		Expect(dataplane.Networking.Inbound[0].Tags).To(HaveKeyWithValue("service", "mobile"))
 		Expect(dataplane.Networking.Inbound[0].Tags).To(HaveKeyWithValue("version", "0.1"))
 		Expect(dataplane.Networking.Inbound[0].Tags).To(HaveKeyWithValue("env", "production"))
 		// and
 		Expect(dataplane.Networking.Outbound).To(HaveLen(2))
-		Expect(dataplane.Networking.Outbound[0].Interface).To(Equal(":30000"))
+		Expect(dataplane.Networking.Outbound[0].Port).To(Equal(uint32(30000)))
 		Expect(dataplane.Networking.Outbound[0].Service).To(Equal("postgres"))
-		Expect(dataplane.Networking.Outbound[1].Interface).To(Equal(":50000"))
+		Expect(dataplane.Networking.Outbound[1].Port).To(Equal(uint32(50000)))
 		Expect(dataplane.Networking.Outbound[1].Service).To(Equal("redis.default.svc"))
 	})
 })

--- a/app/kumactl/cmd/apply/apply_test.go
+++ b/app/kumactl/cmd/apply/apply_test.go
@@ -54,14 +54,18 @@ var _ = Describe("kumactl apply", func() {
 		Expect(resource.Meta.GetName()).To(Equal("sample"))
 		Expect(resource.Meta.GetMesh()).To(Equal("default"))
 		// and
+		Expect(resource.Spec.Networking.Address).To(Equal("2.2.2.2"))
+		//and
 		Expect(resource.Spec.Networking.Inbound).To(HaveLen(1))
-		Expect(resource.Spec.Networking.Inbound[0].Interface).To(Equal("1.1.1.1:80:8080"))
+		Expect(resource.Spec.Networking.Inbound[0].Address).To(Equal("1.1.1.1"))
+		Expect(resource.Spec.Networking.Inbound[0].Port).To(Equal(uint32(80)))
+		Expect(resource.Spec.Networking.Inbound[0].ServicePort).To(Equal(uint32(8080)))
 		Expect(resource.Spec.Networking.Inbound[0].Tags).To(HaveKeyWithValue("service", "web"))
 		Expect(resource.Spec.Networking.Inbound[0].Tags).To(HaveKeyWithValue("version", "1.0"))
 		Expect(resource.Spec.Networking.Inbound[0].Tags).To(HaveKeyWithValue("env", "production"))
 		// and
 		Expect(resource.Spec.Networking.Outbound).To(HaveLen(1))
-		Expect(resource.Spec.Networking.Outbound[0].Interface).To(Equal(":30000"))
+		Expect(resource.Spec.Networking.Outbound[0].Port).To(Equal(uint32(3000)))
 		Expect(resource.Spec.Networking.Outbound[0].Service).To(Equal("postgres"))
 	}
 
@@ -128,9 +132,11 @@ var _ = Describe("kumactl apply", func() {
 		newResource := mesh.DataplaneResource{
 			Spec: v1alpha1.Dataplane{
 				Networking: &v1alpha1.Dataplane_Networking{
+					Address: "8.8.8.8",
 					Inbound: []*v1alpha1.Dataplane_Networking_Inbound{
 						{
-							Interface: "8.8.8.8:443:8443",
+							Port:        443,
+							ServicePort: 8443,
 							Tags: map[string]string{
 								"service": "default",
 								"version": "default",

--- a/app/kumactl/cmd/apply/testdata/apply-dataplane.yaml
+++ b/app/kumactl/cmd/apply/testdata/apply-dataplane.yaml
@@ -2,12 +2,15 @@ name: sample
 mesh: default
 type: Dataplane
 networking:
+  address: 2.2.2.2
   inbound:
-  - interface: 1.1.1.1:80:8080
+  - address: 1.1.1.1
+    port: 80
+    servicePort: 8080
     tags:
       service: web
       version: "1.0"
       env: production
   outbound:
-  - interface: :30000
+  - port: 3000
     service: postgres

--- a/app/kumactl/cmd/get/get_dataplanes_test.go
+++ b/app/kumactl/cmd/get/get_dataplanes_test.go
@@ -40,16 +40,19 @@ var _ = Describe("kumactl get dataplanes", func() {
 				},
 				Spec: mesh_proto.Dataplane{
 					Networking: &mesh_proto.Dataplane_Networking{
+						Address: "127.0.0.1",
 						Inbound: []*mesh_proto.Dataplane_Networking_Inbound{
 							{
-								Interface: "127.0.0.1:8080:80",
+								Port:        8080,
+								ServicePort: 80,
 								Tags: map[string]string{
 									"service": "mobile",
 									"version": "v1",
 								},
 							},
 							{
-								Interface: "127.0.0.1:8090:90",
+								Port:        8090,
+								ServicePort: 90,
 								Tags: map[string]string{
 									"service": "metrics",
 									"version": "v1",
@@ -66,9 +69,11 @@ var _ = Describe("kumactl get dataplanes", func() {
 				},
 				Spec: mesh_proto.Dataplane{
 					Networking: &mesh_proto.Dataplane_Networking{
+						Address: "127.0.0.2",
 						Inbound: []*mesh_proto.Dataplane_Networking_Inbound{
 							{
-								Interface: "127.0.0.2:8080:80",
+								Port:        8080,
+								ServicePort: 80,
 								Tags: map[string]string{
 									"service": "web",
 									"version": "v2",

--- a/app/kumactl/cmd/get/testdata/get-dataplanes.golden.json
+++ b/app/kumactl/cmd/get/testdata/get-dataplanes.golden.json
@@ -4,16 +4,19 @@
         "mesh": "default",
         "name": "experiment",
         "networking": {
+          "address": "127.0.0.1",
           "inbound": [
             {
-              "interface": "127.0.0.1:8080:80",
+              "port": 8080,
+              "servicePort": 80,
               "tags": {
                 "service": "mobile",
                 "version": "v1"
               }
             },
             {
-              "interface": "127.0.0.1:8090:90",
+              "port": 8090,
+              "servicePort": 90,
               "tags": {
                 "service": "metrics",
                 "version": "v1"
@@ -27,9 +30,11 @@
         "mesh": "default",
         "name": "example",
         "networking": {
+          "address": "127.0.0.2",
           "inbound": [
             {
-              "interface": "127.0.0.2:8080:80",
+              "port": 8080,
+              "servicePort": 80,
               "tags": {
                 "service": "web",
                 "version": "v2"

--- a/app/kumactl/cmd/get/testdata/get-dataplanes.golden.yaml
+++ b/app/kumactl/cmd/get/testdata/get-dataplanes.golden.yaml
@@ -2,12 +2,15 @@ items:
 - mesh: default
   name: experiment
   networking:
+    address: 127.0.0.1
     inbound:
-    - interface: 127.0.0.1:8080:80
+    - port: 8080
+      servicePort: 80
       tags:
         service: mobile
         version: v1
-    - interface: 127.0.0.1:8090:90
+    - port: 8090
+      servicePort: 90
       tags:
         service: metrics
         version: v1
@@ -15,8 +18,10 @@ items:
 - mesh: default
   name: example
   networking:
+    address: 127.0.0.2
     inbound:
-    - interface: 127.0.0.2:8080:80
+    - port: 8080
+      servicePort: 80
       tags:
         service: web
         version: v2

--- a/app/kumactl/cmd/inspect/inspect_dataplanes_test.go
+++ b/app/kumactl/cmd/inspect/inspect_dataplanes_test.go
@@ -149,7 +149,7 @@ var _ = Describe("kumactl inspect dataplanes", func() {
 		}
 	})
 
-	Describe("GetDataplanesCmd", func() {
+	Describe("InspectDataplanesCmd", func() {
 
 		var rootCtx *kumactl_cmd.RootContext
 		var rootCmd *cobra.Command
@@ -187,9 +187,8 @@ var _ = Describe("kumactl inspect dataplanes", func() {
 			func(given testCase) {
 				// given
 				rootCmd.SetArgs(append([]string{
-					"inspect", "dataplanes",
 					"--config-file", filepath.Join("..", "testdata", "sample-kumactl.config.yaml"),
-					"get", "dataplanes"}, given.outputFormat))
+					"inspect", "dataplanes"}, given.outputFormat))
 
 				// when
 				err := rootCmd.Execute()
@@ -233,9 +232,8 @@ var _ = Describe("kumactl inspect dataplanes", func() {
 			It("tags should be passed to the client", func() {
 				// given
 				rootCmd.SetArgs([]string{
-					"inspect", "dataplanes",
 					"--config-file", filepath.Join("..", "testdata", "sample-kumactl.config.yaml"),
-					"get", "dataplanes", "--tag", "service=mobile", "--tag", "version=v1"})
+					"inspect", "dataplanes", "--tag", "service=mobile", "--tag", "version=v1"})
 
 				// when
 				err := rootCmd.Execute()

--- a/app/kumactl/cmd/inspect/inspect_dataplanes_test.go
+++ b/app/kumactl/cmd/inspect/inspect_dataplanes_test.go
@@ -59,16 +59,19 @@ var _ = Describe("kumactl inspect dataplanes", func() {
 				Spec: mesh_proto.DataplaneOverview{
 					Dataplane: &mesh_proto.Dataplane{
 						Networking: &mesh_proto.Dataplane_Networking{
+							Address: "127.0.0.1",
 							Inbound: []*mesh_proto.Dataplane_Networking_Inbound{
 								{
-									Interface: "127.0.0.1:8080:80",
+									Port:        8080,
+									ServicePort: 80,
 									Tags: map[string]string{
 										"service": "mobile",
 										"version": "v1",
 									},
 								},
 								{
-									Interface: "127.0.0.1:8090:90",
+									Port:        8090,
+									ServicePort: 90,
 									Tags: map[string]string{
 										"service": "metrics",
 										"version": "v1",
@@ -113,9 +116,11 @@ var _ = Describe("kumactl inspect dataplanes", func() {
 				Spec: mesh_proto.DataplaneOverview{
 					Dataplane: &mesh_proto.Dataplane{
 						Networking: &mesh_proto.Dataplane_Networking{
+							Address: "127.0.0.1",
 							Inbound: []*mesh_proto.Dataplane_Networking_Inbound{
 								{
-									Interface: "127.0.0.1:8080:80",
+									Port:        8080,
+									ServicePort: 80,
 									Tags: map[string]string{
 										"service": "example",
 									},
@@ -182,6 +187,7 @@ var _ = Describe("kumactl inspect dataplanes", func() {
 			func(given testCase) {
 				// given
 				rootCmd.SetArgs(append([]string{
+					"inspect", "dataplanes",
 					"--config-file", filepath.Join("..", "testdata", "sample-kumactl.config.yaml"),
 					"get", "dataplanes"}, given.outputFormat))
 
@@ -227,6 +233,7 @@ var _ = Describe("kumactl inspect dataplanes", func() {
 			It("tags should be passed to the client", func() {
 				// given
 				rootCmd.SetArgs([]string{
+					"inspect", "dataplanes",
 					"--config-file", filepath.Join("..", "testdata", "sample-kumactl.config.yaml"),
 					"get", "dataplanes", "--tag", "service=mobile", "--tag", "version=v1"})
 

--- a/app/kumactl/cmd/inspect/inspect_suite_test.go
+++ b/app/kumactl/cmd/inspect/inspect_suite_test.go
@@ -1,0 +1,13 @@
+package inspect_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+func TestGetCmd(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Inspect Cmd Suite")
+}

--- a/app/kumactl/cmd/inspect/testdata/inspect-dataplanes.golden.json
+++ b/app/kumactl/cmd/inspect/testdata/inspect-dataplanes.golden.json
@@ -3,16 +3,19 @@
     {
       "dataplane": {
         "networking": {
+          "address": "127.0.0.1",
           "inbound": [
             {
-              "interface": "127.0.0.1:8080:80",
+              "port": 8080,
+              "servicePort": 80,
               "tags": {
                 "service": "mobile",
                 "version": "v1"
               }
             },
             {
-              "interface": "127.0.0.1:8090:90",
+              "port": 8090,
+              "servicePort": 90,
               "tags": {
                 "service": "metrics",
                 "version": "v1"
@@ -31,11 +34,7 @@
               "total": {
                 "responsesSent": "10",
                 "responsesRejected": "1"
-              },
-              "cds": {},
-              "eds": {},
-              "lds": {},
-              "rds": {}
+              }
             }
           },
           {
@@ -46,11 +45,7 @@
               "total": {
                 "responsesSent": "20",
                 "responsesRejected": "2"
-              },
-              "cds": {},
-              "eds": {},
-              "lds": {},
-              "rds": {}
+              }
             }
           }
         ]
@@ -62,9 +57,11 @@
     {
       "dataplane": {
         "networking": {
+          "address": "127.0.0.1",
           "inbound": [
             {
-              "interface": "127.0.0.1:8080:80",
+              "port": 8080,
+              "servicePort": 80,
               "tags": {
                 "service": "example"
               }
@@ -76,36 +73,15 @@
         "subscriptions": [
           {
             "id": "1",
-            "controlPlaneInstanceId": "node-001",
-            "status": {
-              "total": {},
-              "cds": {},
-              "eds": {},
-              "lds": {},
-              "rds": {}
-            }
+            "controlPlaneInstanceId": "node-001"
           },
           {
             "id": "2",
-            "controlPlaneInstanceId": "node-002",
-            "status": {
-              "total": {},
-              "cds": {},
-              "eds": {},
-              "lds": {},
-              "rds": {}
-            }
+            "controlPlaneInstanceId": "node-002"
           },
           {
             "id": "3",
-            "controlPlaneInstanceId": "node-003",
-            "status": {
-              "total": {},
-              "cds": {},
-              "eds": {},
-              "lds": {},
-              "rds": {}
-            }
+            "controlPlaneInstanceId": "node-003"
           }
         ]
       },

--- a/app/kumactl/cmd/inspect/testdata/inspect-dataplanes.golden.yaml
+++ b/app/kumactl/cmd/inspect/testdata/inspect-dataplanes.golden.yaml
@@ -1,12 +1,15 @@
 items:
   - dataplane:
       networking:
+        address: 127.0.0.1
         inbound:
-          - interface: 127.0.0.1:8080:80
+          - port: 8080
+            servicePort: 80
             tags:
               service: mobile
               version: v1
-          - interface: 127.0.0.1:8090:90
+          - port: 8090
+            servicePort: 90
             tags:
               service: metrics
               version: v1
@@ -16,10 +19,6 @@ items:
           controlPlaneInstanceId: node-001
           id: "1"
           status:
-            cds: {}
-            eds: {}
-            lds: {}
-            rds: {}
             total:
               responsesRejected: "1"
               responsesSent: "10"
@@ -27,10 +26,6 @@ items:
           controlPlaneInstanceId: node-002
           id: "2"
           status:
-            cds: {}
-            eds: {}
-            lds: {}
-            rds: {}
             total:
               responsesRejected: "2"
               responsesSent: "20"
@@ -39,36 +34,20 @@ items:
     type: DataplaneOverview
   - dataplane:
       networking:
+        address: 127.0.0.1
         inbound:
-          - interface: 127.0.0.1:8080:80
+          - port: 8080
+            servicePort: 80
             tags:
               service: example
     dataplaneInsight:
       subscriptions:
         - controlPlaneInstanceId: node-001
           id: "1"
-          status:
-            cds: {}
-            eds: {}
-            lds: {}
-            rds: {}
-            total: {}
         - controlPlaneInstanceId: node-002
           id: "2"
-          status:
-            cds: {}
-            eds: {}
-            lds: {}
-            rds: {}
-            total: {}
         - controlPlaneInstanceId: node-003
           id: "3"
-          status:
-            cds: {}
-            eds: {}
-            lds: {}
-            rds: {}
-            total: {}
     mesh: default
     name: example
     type: DataplaneOverview

--- a/app/kumactl/pkg/resources/testdata/list-dataplane-overviews.json
+++ b/app/kumactl/pkg/resources/testdata/list-dataplane-overviews.json
@@ -6,9 +6,11 @@
             "name": "one",
             "dataplane": {
                 "networking": {
+                    "address": "127.0.0.1",
                     "inbound": [
                         {
-                            "interface": "127.0.0.1:8080:80",
+                            "port": 8080,
+                            "servicePort": 80,
                             "tags": {
                                 "service": "mobile",
                                 "version": "v1"

--- a/dev/examples/universal/dataplanes/example.yaml
+++ b/dev/examples/universal/dataplanes/example.yaml
@@ -2,12 +2,14 @@ type: Dataplane
 mesh: default
 name: example
 networking:
+  address: 127.0.0.1
   inbound:
-  - interface: 127.0.0.1:11011:11012
+  - port: 11011
+    servicePort: 11012
     tags:
       service: backend
       version: "2.0"
       env: production
   outbound:
-  - interface: :33033
+  - port: 33033
     service: database

--- a/pkg/api-server/dataplane_overview_ws_test.go
+++ b/pkg/api-server/dataplane_overview_ws_test.go
@@ -54,9 +54,11 @@ var _ = Describe("Dataplane Overview WS", func() {
 		dpResource := mesh_core.DataplaneResource{
 			Spec: v1alpha1.Dataplane{
 				Networking: &v1alpha1.Dataplane_Networking{
+					Address: "127.0.0.1",
 					Inbound: []*v1alpha1.Dataplane_Networking_Inbound{
 						{
-							Interface: "127.0.0.1:9090:9091",
+							Port:        9090,
+							ServicePort: 9091,
 							Tags: map[string]string{
 								"service": "sample",
 								"version": "v1",
@@ -93,9 +95,11 @@ var _ = Describe("Dataplane Overview WS", func() {
 	"mesh": "mesh1",
 	"dataplane": {
 		"networking": {
+			"address": "127.0.0.1",
 			"inbound": [
 				{
-					"interface": "127.0.0.1:9090:9091",
+					"port": 9090,
+					"servicePort": 9091,
 					"tags": {
 						"service": "sample",
 						"version": "v1"

--- a/pkg/core/logs/matcher_test.go
+++ b/pkg/core/logs/matcher_test.go
@@ -51,15 +51,18 @@ var _ = Describe("Matcher", func() {
 		dpRes = core_mesh.DataplaneResource{
 			Spec: mesh_proto.Dataplane{
 				Networking: &mesh_proto.Dataplane_Networking{
+					Address: "127.0.0.1",
 					Inbound: []*mesh_proto.Dataplane_Networking_Inbound{
 						{
-							Interface: "127.0.0.1:8080:8081",
+							Port:        8080,
+							ServicePort: 8081,
 							Tags: map[string]string{
 								"service": "kong",
 							},
 						},
 						{
-							Interface: "127.0.0.1:8090:8091",
+							Port:        8090,
+							ServicePort: 8091,
 							Tags: map[string]string{
 								"service": "kong-admin",
 							},
@@ -67,12 +70,12 @@ var _ = Describe("Matcher", func() {
 					},
 					Outbound: []*mesh_proto.Dataplane_Networking_Outbound{
 						{
-							Interface: ":9091",
-							Service:   "backend",
+							Port:    9091,
+							Service: "backend",
 						},
 						{
-							Interface: ":9092",
-							Service:   "web",
+							Port:    9092,
+							Service: "web",
 						},
 					},
 				},

--- a/pkg/core/permissions/matcher_test.go
+++ b/pkg/core/permissions/matcher_test.go
@@ -12,15 +12,18 @@ var _ = Describe("Matcher", func() {
 	It("should match only proper permissions", func() {
 		dataplane := mesh_proto.Dataplane{
 			Networking: &mesh_proto.Dataplane_Networking{
+				Address: "192.168.0.1",
 				Inbound: []*mesh_proto.Dataplane_Networking_Inbound{
 					{
-						Interface: "192.168.0.1:8080:80",
+						Port:        8080,
+						ServicePort: 80,
 						Tags: map[string]string{
 							"service": "backend",
 						},
 					},
 					{
-						Interface: "192.168.0.1:8090:90",
+						Port:        8090,
+						ServicePort: 90,
 						Tags: map[string]string{
 							"service": "web",
 						},

--- a/pkg/core/resources/apis/mesh/dataplane_helpers_test.go
+++ b/pkg/core/resources/apis/mesh/dataplane_helpers_test.go
@@ -39,12 +39,14 @@ var _ = Describe("Dataplane", func() {
 			Entry("port of an inbound interface is overshadowed (wilcard ip match)", testCase{
 				dataplane: `
                 networking:
+                  address: 192.168.0.1
                   inbound:
-                  - interface: 192.168.0.1:80:8080
+                  - port: 80
+                    servicePort: 8080
                   outbound:
-                  - interface: :54321
+                  - port: 54321
                     service: db
-                  - interface: :59200
+                  - port: 59200
                     service: elastic
 `,
 				address:  "0.0.0.0",
@@ -54,12 +56,14 @@ var _ = Describe("Dataplane", func() {
 			Entry("port of the application is overshadowed (wilcard ip match)", testCase{
 				dataplane: `
                 networking:
+                  address: 192.168.0.1
                   inbound:
-                   - interface: 192.168.0.1:80:8080
+                  - port: 80
+                    servicePort: 8080
                   outbound:
-                  - interface: :54321
+                  - port: 54321
                     service: db
-                  - interface: :59200
+                  - port: 59200
                     service: elastic
 `,
 				address:  "0.0.0.0",
@@ -69,12 +73,14 @@ var _ = Describe("Dataplane", func() {
 			Entry("port of an outbound interface is overshadowed (wilcard ip match)", testCase{
 				dataplane: `
                 networking:
+                  address: 192.168.0.1
                   inbound:
-                   - interface: 192.168.0.1:80:8080
+                  - port: 80
+                    servicePort: 8080
                   outbound:
-                  - interface: :54321
+                  - port: 54321
                     service: db
-                  - interface: :59200
+                  - port: 59200
                     service: elastic
 `,
 				address:  "0.0.0.0",
@@ -84,12 +90,14 @@ var _ = Describe("Dataplane", func() {
 			Entry("port of an inbound interface is overshadowed (exact ip match)", testCase{
 				dataplane: `
                 networking:
+                  address: 192.168.0.1
                   inbound:
-                  - interface: 192.168.0.1:80:8080
+                  - port: 80
+                    servicePort: 8080
                   outbound:
-                  - interface: :54321
+                  - port: 54321
                     service: db
-                  - interface: :59200
+                  - port: 59200
                     service: elastic
 `,
 				address:  "192.168.0.1",
@@ -99,12 +107,14 @@ var _ = Describe("Dataplane", func() {
 			Entry("port of the application is overshadowed (exact ip match)", testCase{
 				dataplane: `
                 networking:
+                  address: 192.168.0.1
                   inbound:
-                   - interface: 192.168.0.1:80:8080
+                  - port: 80
+                    servicePort: 8080
                   outbound:
-                  - interface: :54321
+                  - port: 54321
                     service: db
-                  - interface: :59200
+                  - port: 59200
                     service: elastic
 `,
 				address:  "127.0.0.1",
@@ -114,12 +124,14 @@ var _ = Describe("Dataplane", func() {
 			Entry("port of an outbound interface is overshadowed (exact ip match)", testCase{
 				dataplane: `
                 networking:
+                  address: 192.168.0.1
                   inbound:
-                   - interface: 192.168.0.1:80:8080
+                  - port: 80
+                    servicePort: 8080
                   outbound:
-                  - interface: :54321
+                  - port: 54321
                     service: db
-                  - interface: :59200
+                  - port: 59200
                     service: elastic
 `,
 				address:  "127.0.0.1",
@@ -132,9 +144,9 @@ var _ = Describe("Dataplane", func() {
                   inbound:
                    - interface: ?:80:8080
                   outbound:
-                  - interface: :54321
+                  - port: 54321
                     service: db
-                  - interface: :59200
+                  - port: 59200
                     service: elastic
 `,
 				address:  "0.0.0.0",
@@ -144,12 +156,14 @@ var _ = Describe("Dataplane", func() {
 			Entry("port of invalid outbound interface is not overshadowed", testCase{
 				dataplane: `
                 networking:
+                  address: 192.168.0.1
                   inbound:
-                   - interface: 192.168.0.1:80:8080
+                  - port: 80
+                    servicePort: 8080
                   outbound:
                   - interface: ?:54321
                     service: db
-                  - interface: :59200
+                  - port: 59200
                     service: elastic
 `,
 				address:  "0.0.0.0",
@@ -159,12 +173,14 @@ var _ = Describe("Dataplane", func() {
 			Entry("non-overlapping ports are not overshadowed", testCase{
 				dataplane: `
                 networking:
+                  address: 192.168.0.1
                   inbound:
-                   - interface: 192.168.0.1:80:8080
+                  - port: 80
+                    servicePort: 8080
                   outbound:
-                  - interface: :54321
+                  - port: 54321
                     service: db
-                  - interface: :59200
+                  - port: 59200
                     service: elastic
 `,
 				address:  "0.0.0.0",
@@ -174,12 +190,14 @@ var _ = Describe("Dataplane", func() {
 			Entry("non-overlapping ip addresses are not overshadowed (inbound listener port)", testCase{
 				dataplane: `
                 networking:
+                  address: 192.168.0.1
                   inbound:
-                   - interface: 192.168.0.1:80:8080
+                  - port: 80
+                    servicePort: 8080
                   outbound:
-                  - interface: :54321
+                  - port: 54321
                     service: db
-                  - interface: :59200
+                  - port: 59200
                     service: elastic
 `,
 				address:  "192.168.0.2",
@@ -189,12 +207,14 @@ var _ = Describe("Dataplane", func() {
 			Entry("non-overlapping ip addresses are not overshadowed (application port)", testCase{
 				dataplane: `
                 networking:
+                  address: 192.168.0.1
                   inbound:
-                   - interface: 192.168.0.1:80:8080
+                  - port: 80
+                    servicePort: 8080
                   outbound:
-                  - interface: :54321
+                  - port: 54321
                     service: db
-                  - interface: :59200
+                  - port: 59200
                     service: elastic
 `,
 				address:  "192.168.0.2",
@@ -204,12 +224,14 @@ var _ = Describe("Dataplane", func() {
 			Entry("non-overlapping ip addresses are not overshadowed (outbound listener port)", testCase{
 				dataplane: `
                 networking:
+                  address: 192.168.0.1
                   inbound:
-                   - interface: 192.168.0.1:80:8080
+                  - port: 80
+                    servicePort: 8080
                   outbound:
-                  - interface: :54321
+                  - port: 54321
                     service: db
-                  - interface: :59200
+                  - port: 59200
                     service: elastic
 `,
 				address:  "192.168.0.2",

--- a/pkg/mads/generator/assignments_test.go
+++ b/pkg/mads/generator/assignments_test.go
@@ -52,8 +52,10 @@ var _ = Describe("MonitoringAssignmentsGenerator", func() {
 						},
 						Spec: mesh_proto.Dataplane{
 							Networking: &mesh_proto.Dataplane_Networking{
+								Address: "192.168.0.1",
 								Inbound: []*mesh_proto.Dataplane_Networking_Inbound{{
-									Interface: "192.168.0.1:80:8080",
+									Port:        80,
+									ServicePort: 8080,
 									Tags: map[string]string{
 										"service": "backend",
 									},
@@ -81,8 +83,10 @@ var _ = Describe("MonitoringAssignmentsGenerator", func() {
 						},
 						Spec: mesh_proto.Dataplane{
 							Networking: &mesh_proto.Dataplane_Networking{
+								Address: "192.168.0.1",
 								Inbound: []*mesh_proto.Dataplane_Networking_Inbound{{
-									Interface: "192.168.0.1:80:8080",
+									Port:        80,
+									ServicePort: 8080,
 									Tags: map[string]string{
 										"service": "backend",
 									},
@@ -186,9 +190,11 @@ var _ = Describe("MonitoringAssignmentsGenerator", func() {
 						},
 						Spec: mesh_proto.Dataplane{
 							Networking: &mesh_proto.Dataplane_Networking{
+								Address: "192.168.0.1",
 								Inbound: []*mesh_proto.Dataplane_Networking_Inbound{
 									{
-										Interface: "192.168.0.1:80:8080",
+										Port:        80,
+										ServicePort: 8080,
 										Tags: map[string]string{
 											"service": "backend",
 											"env":     "prod",
@@ -196,7 +202,9 @@ var _ = Describe("MonitoringAssignmentsGenerator", func() {
 										},
 									},
 									{
-										Interface: "192.168.0.2:443:8443",
+										Address:     "192.168.0.2",
+										Port:        443,
+										ServicePort: 8443,
 										Tags: map[string]string{
 											"service": "backend-https",
 											"env":     "prod",
@@ -262,8 +270,10 @@ var _ = Describe("MonitoringAssignmentsGenerator", func() {
 						},
 						Spec: mesh_proto.Dataplane{
 							Networking: &mesh_proto.Dataplane_Networking{
+								Address: "192.168.0.1",
 								Inbound: []*mesh_proto.Dataplane_Networking_Inbound{{
-									Interface: "192.168.0.1:80:8080",
+									Port:        80,
+									ServicePort: 8080,
 									Tags: map[string]string{
 										"service":  "backend",
 										"version":  "v1",
@@ -327,8 +337,10 @@ var _ = Describe("MonitoringAssignmentsGenerator", func() {
 						},
 						Spec: mesh_proto.Dataplane{
 							Networking: &mesh_proto.Dataplane_Networking{
+								Address: "192.168.0.1",
 								Inbound: []*mesh_proto.Dataplane_Networking_Inbound{{
-									Interface: "192.168.0.1:80:8080",
+									Port:        80,
+									ServicePort: 8080,
 									Tags: map[string]string{
 										"service":         "backend",
 										"app:description": "?!,.:;",
@@ -407,8 +419,10 @@ var _ = Describe("MonitoringAssignmentsGenerator", func() {
 						},
 						Spec: mesh_proto.Dataplane{
 							Networking: &mesh_proto.Dataplane_Networking{
+								Address: "192.168.0.1",
 								Inbound: []*mesh_proto.Dataplane_Networking_Inbound{{
-									Interface: "192.168.0.1:80:8080",
+									Port:        80,
+									ServicePort: 8080,
 									Tags: map[string]string{
 										"service": "backend",
 										"env":     "prod",
@@ -424,8 +438,10 @@ var _ = Describe("MonitoringAssignmentsGenerator", func() {
 						},
 						Spec: mesh_proto.Dataplane{
 							Networking: &mesh_proto.Dataplane_Networking{
+								Address: "192.168.0.2",
 								Inbound: []*mesh_proto.Dataplane_Networking_Inbound{{
-									Interface: "192.168.0.2:443:8443",
+									Port:        443,
+									ServicePort: 8443,
 									Tags: map[string]string{
 										"service": "web",
 										"env":     "intg",

--- a/pkg/mads/reconcile/snapshot_generator_test.go
+++ b/pkg/mads/reconcile/snapshot_generator_test.go
@@ -90,8 +90,10 @@ var _ = Describe("snapshotGenerator", func() {
 						},
 						Spec: mesh_proto.Dataplane{
 							Networking: &mesh_proto.Dataplane_Networking{
+								Address: "192.168.0.1",
 								Inbound: []*mesh_proto.Dataplane_Networking_Inbound{{
-									Interface: "192.168.0.1:80:8080",
+									Port:        80,
+									ServicePort: 8080,
 									Tags: map[string]string{
 										"service": "backend",
 									},
@@ -133,8 +135,10 @@ var _ = Describe("snapshotGenerator", func() {
 						},
 						Spec: mesh_proto.Dataplane{
 							Networking: &mesh_proto.Dataplane_Networking{
+								Address: "192.168.0.1",
 								Inbound: []*mesh_proto.Dataplane_Networking_Inbound{{
-									Interface: "192.168.0.1:80:8080",
+									Port:        80,
+									ServicePort: 8080,
 									Tags: map[string]string{
 										"service": "backend",
 									},
@@ -176,8 +180,10 @@ var _ = Describe("snapshotGenerator", func() {
 						},
 						Spec: mesh_proto.Dataplane{
 							Networking: &mesh_proto.Dataplane_Networking{
+								Address: "192.168.0.1",
 								Inbound: []*mesh_proto.Dataplane_Networking_Inbound{{
-									Interface: "192.168.0.1:80:8080",
+									Port:        80,
+									ServicePort: 8080,
 									Tags: map[string]string{
 										"service": "backend",
 										"env":     "prod",
@@ -193,8 +199,10 @@ var _ = Describe("snapshotGenerator", func() {
 						},
 						Spec: mesh_proto.Dataplane{
 							Networking: &mesh_proto.Dataplane_Networking{
+								Address: "192.168.0.2",
 								Inbound: []*mesh_proto.Dataplane_Networking_Inbound{{
-									Interface: "192.168.0.2:443:8443",
+									Port:        443,
+									ServicePort: 8443,
 									Tags: map[string]string{
 										"service": "backend",
 										"env":     "intg",

--- a/pkg/sds/auth/common/identity_test.go
+++ b/pkg/sds/auth/common/identity_test.go
@@ -21,9 +21,11 @@ var _ = Describe("GetDataplaneIdentity()", func() {
 			},
 			Spec: mesh_proto.Dataplane{
 				Networking: &mesh_proto.Dataplane_Networking{
+					Address: "127.0.0.1",
 					Inbound: []*mesh_proto.Dataplane_Networking_Inbound{
 						{
-							Interface: "127.0.0.1:8080:80",
+							Port:        8080,
+							ServicePort: 80,
 							Tags: map[string]string{
 								"service": "backend",
 							},

--- a/pkg/sds/auth/universal/auth_test.go
+++ b/pkg/sds/auth/universal/auth_test.go
@@ -41,9 +41,11 @@ var _ = Describe("Authentication flow", func() {
 		dpRes := core_mesh.DataplaneResource{
 			Spec: v1alpha1.Dataplane{
 				Networking: &v1alpha1.Dataplane_Networking{
+					Address: "127.0.0.1",
 					Inbound: []*v1alpha1.Dataplane_Networking_Inbound{
 						{
-							Interface: "127.0.0.1:8080:8081",
+							Port:        8080,
+							ServicePort: 8081,
 							Tags: map[string]string{
 								"service": "web",
 							},

--- a/pkg/sds/auth/universal/noop_authenticator_test.go
+++ b/pkg/sds/auth/universal/noop_authenticator_test.go
@@ -37,9 +37,11 @@ var _ = Describe("Noop Authenticator", func() {
 		dpRes := core_mesh.DataplaneResource{
 			Spec: mesh_proto.Dataplane{
 				Networking: &mesh_proto.Dataplane_Networking{
+					Address: "127.0.0.1",
 					Inbound: []*mesh_proto.Dataplane_Networking_Inbound{
 						{
-							Interface: "127.0.0.1:8080:8081",
+							Port:        8080,
+							ServicePort: 8081,
 							Tags: map[string]string{
 								"service": "web",
 							},

--- a/pkg/xds/bootstrap/generator_test.go
+++ b/pkg/xds/bootstrap/generator_test.go
@@ -35,9 +35,11 @@ var _ = Describe("bootstrapGenerator", func() {
 		dataplane := mesh.DataplaneResource{
 			Spec: mesh_proto.Dataplane{
 				Networking: &mesh_proto.Dataplane_Networking{
+					Address: "8.8.8.8",
 					Inbound: []*mesh_proto.Dataplane_Networking_Inbound{
 						{
-							Interface: "8.8.8.8:443:8443",
+							Port:        443,
+							ServicePort: 8443,
 							Tags: map[string]string{
 								"service": "backend",
 							},

--- a/pkg/xds/bootstrap/server_test.go
+++ b/pkg/xds/bootstrap/server_test.go
@@ -76,9 +76,11 @@ var _ = Describe("Bootstrap Server", func() {
 			res := mesh.DataplaneResource{
 				Spec: mesh_proto.Dataplane{
 					Networking: &mesh_proto.Dataplane_Networking{
+						Address: "8.8.8.8",
 						Inbound: []*mesh_proto.Dataplane_Networking_Inbound{
 							{
-								Interface: "8.8.8.8:443:8443",
+								Port:        443,
+								ServicePort: 8443,
 								Tags: map[string]string{
 									"service": "backend",
 								},

--- a/pkg/xds/envoy/listeners/network_access_log_configurer_test.go
+++ b/pkg/xds/envoy/listeners/network_access_log_configurer_test.go
@@ -39,15 +39,17 @@ var _ = Describe("NetworkAccessLogConfigurer", func() {
 				Dataplane: &mesh_core.DataplaneResource{
 					Spec: mesh_proto.Dataplane{
 						Networking: &mesh_proto.Dataplane_Networking{
+							Address: "192.168.0.1",
 							Inbound: []*mesh_proto.Dataplane_Networking_Inbound{{
-								Interface: "192.168.0.1:1234:8765",
+								Port:        1234,
+								ServicePort: 8765,
 								Tags: map[string]string{
 									"service": "backend",
 								},
 							}},
 							Outbound: []*mesh_proto.Dataplane_Networking_Outbound{{
-								Interface: ":15432",
-								Service:   "db",
+								Port:    15432,
+								Service: "db",
 							}},
 						},
 					},

--- a/pkg/xds/generator/outbound_proxy_generator_test.go
+++ b/pkg/xds/generator/outbound_proxy_generator_test.go
@@ -150,7 +150,7 @@ var _ = Describe("OutboundProxyGenerator", func() {
 			dataplane: `
             networking:
               outbound:
-              - interface: :18080
+              - port: 18080
                 service: backend
 `,
 			expected: "03.envoy.golden.yaml",
@@ -160,7 +160,7 @@ var _ = Describe("OutboundProxyGenerator", func() {
 			dataplane: `
             networking:
               outbound:
-              - interface: :18080
+              - port: 18080
                 service: backend
               transparentProxying:
                 redirectPort: 15001
@@ -172,7 +172,7 @@ var _ = Describe("OutboundProxyGenerator", func() {
 			dataplane: `
             networking:
               outbound:
-              - interface: :18080
+              - port: 18080
                 service: backend
 `,
 			expected: "05.envoy.golden.yaml",
@@ -182,7 +182,7 @@ var _ = Describe("OutboundProxyGenerator", func() {
 			dataplane: `
             networking:
               outbound:
-              - interface: :18080
+              - port: 18080
                 service: backend
               transparentProxying:
                 redirectPort: 15001
@@ -194,9 +194,9 @@ var _ = Describe("OutboundProxyGenerator", func() {
 			dataplane: `
             networking:
               outbound:
-              - interface: :18080
+              - port: 18080
                 service: backend
-              - interface: :54321
+              - port: 54321
                 service: db
 `,
 			expected: "07.envoy.golden.yaml",
@@ -206,9 +206,9 @@ var _ = Describe("OutboundProxyGenerator", func() {
 			dataplane: `
             networking:
               outbound:
-              - interface: :18080
+              - port: 18080
                 service: backend
-              - interface: :54321
+              - port: 54321
                 service: db
               transparentProxying:
                 redirectPort: 15001
@@ -223,9 +223,9 @@ var _ = Describe("OutboundProxyGenerator", func() {
 		dp := `
         networking:
           outbound:
-          - interface: :18080
+          - port: 18080
             service: backend.kuma-system
-          - interface: :54321
+          - port: 54321
             service: db.kuma-system`
 
 		dataplane := mesh_proto.Dataplane{}
@@ -398,7 +398,7 @@ var _ = Describe("OutboundProxyGenerator", func() {
 				dataplane: `
                 networking:
                   outbound:
-                  - interface: :18080
+                  - port: 18080
                     service: backend
 `,
 				chaos: func(proxy *model.Proxy) {
@@ -412,7 +412,7 @@ var _ = Describe("OutboundProxyGenerator", func() {
 				dataplane: `
                 networking:
                   outbound:
-                  - interface: :18080
+                  - port: 18080
                     service: backend
 `,
 				chaos: func(proxy *model.Proxy) {

--- a/pkg/xds/generator/prometheus_endpoint_generator_test.go
+++ b/pkg/xds/generator/prometheus_endpoint_generator_test.go
@@ -400,12 +400,14 @@ var _ = Describe("PrometheusEndpointGenerator", func() {
 			Entry("should not overshadow inbound listener port", testCase{
 				dataplane: `
                 networking:
+                  address: 192.168.0.1
                   inbound:
-                  - interface: 192.168.0.1:80:8080
+                  - port: 80
+                    servicePort: 8080
                   outbound:
-                  - interface: :54321
+                  - port: 54321
                     service: db
-                  - interface: :59200
+                  - port: 59200
                     service: elastic
                 metrics:
                   prometheus:
@@ -415,12 +417,14 @@ var _ = Describe("PrometheusEndpointGenerator", func() {
 			Entry("should not overshadow application port", testCase{
 				dataplane: `
                 networking:
+                  address: 192.168.0.1
                   inbound:
-                  - interface: 192.168.0.1:80:8080
+                  - port: 80
+                    servicePort: 8080
                   outbound:
-                  - interface: :54321
+                  - port: 54321
                     service: db
-                  - interface: :59200
+                  - port: 59200
                     service: elastic
                 metrics:
                   prometheus:
@@ -430,12 +434,14 @@ var _ = Describe("PrometheusEndpointGenerator", func() {
 			Entry("should not overshadow outbound listener port", testCase{
 				dataplane: `
                 networking:
+                  address: 192.168.0.1
                   inbound:
-                  - interface: 192.168.0.1:80:8080
+                  - port: 80
+                    servicePort: 8080
                   outbound:
-                  - interface: :54321
+                  - port: 54321
                     service: db
-                  - interface: :59200
+                  - port: 59200
                     service: elastic
                 metrics:
                   prometheus:

--- a/pkg/xds/generator/proxy_template_profile_source_test.go
+++ b/pkg/xds/generator/proxy_template_profile_source_test.go
@@ -143,14 +143,16 @@ var _ = Describe("ProxyTemplateProfileSource", func() {
 `,
 			dataplane: `
             networking:
+              address: 192.168.0.1
               inbound:
-                - interface: 192.168.0.1:80:8080
+                - port: 80
+                  servicePort: 8080
                   tags:
                     service: backend
               outbound:
-              - interface: :54321
+              - port: 54321
                 service: db
-              - interface: :59200
+              - port: 59200
                 service: elastic
 `,
 			profile:         mesh_core.ProfileDefaultProxy,
@@ -163,14 +165,16 @@ var _ = Describe("ProxyTemplateProfileSource", func() {
 `,
 			dataplane: `
             networking:
+              address: 192.168.0.1
               inbound:
-                - interface: 192.168.0.1:80:8080
+                - port: 80
+                  servicePort: 8080
                   tags:
                     service: backend
               outbound:
-              - interface: :54321
+              - port: 54321
                 service: db
-              - interface: :59200
+              - port: 59200
                 service: elastic
               transparentProxying:
                 redirectPort: 15001
@@ -189,15 +193,17 @@ var _ = Describe("ProxyTemplateProfileSource", func() {
 `,
 			dataplane: `
             networking:
+              address: 192.168.0.1
               inbound:
-                - interface: 192.168.0.1:80:8080
+                - port: 80
+                  servicePort: 8080
                   tags:
                     service: backend
                     protocol: http
               outbound:
-              - interface: :54321
+              - port: 54321
                 service: db
-              - interface: :59200
+              - port: 59200
                 service: elastic
 `,
 			profile:         mesh_core.ProfileDefaultProxy,
@@ -214,15 +220,17 @@ var _ = Describe("ProxyTemplateProfileSource", func() {
 `,
 			dataplane: `
             networking:
+              address: 192.168.0.1
               inbound:
-                - interface: 192.168.0.1:80:8080
+                - port: 80
+                  servicePort: 8080
                   tags:
                     service: backend
                     protocol: http
               outbound:
-              - interface: :54321
+              - port: 54321
                 service: db
-              - interface: :59200
+              - port: 59200
                 service: elastic
               transparentProxying:
                 redirectPort: 15001
@@ -241,12 +249,14 @@ var _ = Describe("ProxyTemplateProfileSource", func() {
 `,
 			dataplane: `
             networking:
+              address: 192.168.0.1
               inbound:
-                - interface: 192.168.0.1:80:8080
+                - port: 80
+                  servicePort: 8080
               outbound:
-              - interface: :54321
+              - port: 54321
                 service: db
-              - interface: :59200
+              - port: 59200
                 service: elastic
 `,
 			profile: mesh_core.ProfileDefaultProxy,
@@ -265,12 +275,14 @@ var _ = Describe("ProxyTemplateProfileSource", func() {
 `,
 			dataplane: `
             networking:
+              address: 192.168.0.1
               inbound:
-                - interface: 192.168.0.1:80:8080
+                - port: 80
+                  servicePort: 8080
               outbound:
-              - interface: :54321
+              - port: 54321
                 service: db
-              - interface: :59200
+              - port: 59200
                 service: elastic
               transparentProxying:
                 redirectPort: 15001
@@ -291,12 +303,14 @@ var _ = Describe("ProxyTemplateProfileSource", func() {
 `,
 			dataplane: `
             networking:
+              address: 192.168.0.1
               inbound:
-                - interface: 192.168.0.1:80:8080
+                - port: 80
+                  servicePort: 8080
               outbound:
-              - interface: :54321
+              - port: 54321
                 service: db
-              - interface: :59200
+              - port: 59200
                 service: elastic
 `,
 			profile: mesh_core.ProfileDefaultProxy,
@@ -315,12 +329,14 @@ var _ = Describe("ProxyTemplateProfileSource", func() {
 `,
 			dataplane: `
             networking:
+              address: 192.168.0.1
               inbound:
-                - interface: 192.168.0.1:80:8080
+                - port: 80
+                  servicePort: 8080
               outbound:
-              - interface: :54321
+              - port: 54321
                 service: db
-              - interface: :59200
+              - port: 59200
                 service: elastic
               transparentProxying:
                 redirectPort: 15001
@@ -341,12 +357,14 @@ var _ = Describe("ProxyTemplateProfileSource", func() {
 `,
 			dataplane: `
             networking:
+              address: 192.168.0.1
               inbound:
-                - interface: 192.168.0.1:80:8080
+                - port: 80
+                  servicePort: 8080
               outbound:
-              - interface: :54321
+              - port: 54321
                 service: db
-              - interface: :59200
+              - port: 59200
                 service: elastic
 `,
 			profile: mesh_core.ProfileDefaultProxy,
@@ -365,12 +383,14 @@ var _ = Describe("ProxyTemplateProfileSource", func() {
 `,
 			dataplane: `
             networking:
+              address: 192.168.0.1
               inbound:
-                - interface: 192.168.0.1:80:8080
+                - port: 80
+                  servicePort: 8080
               outbound:
-              - interface: :54321
+              - port: 54321
                 service: db
-              - interface: :59200
+              - port: 59200
                 service: elastic
               transparentProxying:
                 redirectPort: 15001

--- a/pkg/xds/generator/proxy_template_raw_source_test.go
+++ b/pkg/xds/generator/proxy_template_raw_source_test.go
@@ -50,8 +50,12 @@ var _ = Describe("ProxyTemplateRawSource", func() {
 						},
 						Spec: mesh_proto.Dataplane{
 							Networking: &mesh_proto.Dataplane_Networking{
+								Address: "192.168.0.1",
 								Inbound: []*mesh_proto.Dataplane_Networking_Inbound{
-									{Interface: "192.168.0.1:80:8080"},
+									{
+										Port:        80,
+										ServicePort: 8080,
+									},
 								},
 							},
 						},
@@ -74,8 +78,12 @@ var _ = Describe("ProxyTemplateRawSource", func() {
 						},
 						Spec: mesh_proto.Dataplane{
 							Networking: &mesh_proto.Dataplane_Networking{
+								Address: "192.168.0.1",
 								Inbound: []*mesh_proto.Dataplane_Networking_Inbound{
-									{Interface: "192.168.0.1:80:8080"},
+									{
+										Port:        80,
+										ServicePort: 8080,
+									},
 								},
 							},
 						},
@@ -97,8 +105,12 @@ var _ = Describe("ProxyTemplateRawSource", func() {
 						},
 						Spec: mesh_proto.Dataplane{
 							Networking: &mesh_proto.Dataplane_Networking{
+								Address: "192.168.0.1",
 								Inbound: []*mesh_proto.Dataplane_Networking_Inbound{
-									{Interface: "192.168.0.1:80:8080"},
+									{
+										Port:        80,
+										ServicePort: 8080,
+									},
 								},
 							},
 						},
@@ -122,8 +134,12 @@ var _ = Describe("ProxyTemplateRawSource", func() {
 						},
 						Spec: mesh_proto.Dataplane{
 							Networking: &mesh_proto.Dataplane_Networking{
+								Address: "192.168.0.1",
 								Inbound: []*mesh_proto.Dataplane_Networking_Inbound{
-									{Interface: "192.168.0.1:80:8080"},
+									{
+										Port:        80,
+										ServicePort: 8080,
+									},
 								},
 							},
 						},
@@ -158,8 +174,12 @@ var _ = Describe("ProxyTemplateRawSource", func() {
 						},
 						Spec: mesh_proto.Dataplane{
 							Networking: &mesh_proto.Dataplane_Networking{
+								Address: "192.168.0.1",
 								Inbound: []*mesh_proto.Dataplane_Networking_Inbound{
-									{Interface: "192.168.0.1:80:8080"},
+									{
+										Port:        80,
+										ServicePort: 8080,
+									},
 								},
 							},
 						},
@@ -229,8 +249,12 @@ var _ = Describe("ProxyTemplateRawSource", func() {
 						},
 						Spec: mesh_proto.Dataplane{
 							Networking: &mesh_proto.Dataplane_Networking{
+								Address: "192.168.0.1",
 								Inbound: []*mesh_proto.Dataplane_Networking_Inbound{
-									{Interface: "192.168.0.1:80:8080"},
+									{
+										Port:        80,
+										ServicePort: 8080,
+									},
 								},
 							},
 						},
@@ -248,8 +272,12 @@ var _ = Describe("ProxyTemplateRawSource", func() {
 						},
 						Spec: mesh_proto.Dataplane{
 							Networking: &mesh_proto.Dataplane_Networking{
+								Address: "192.168.0.1",
 								Inbound: []*mesh_proto.Dataplane_Networking_Inbound{
-									{Interface: "192.168.0.1:80:8080"},
+									{
+										Port:        80,
+										ServicePort: 8080,
+									},
 								},
 							},
 						},
@@ -305,8 +333,12 @@ var _ = Describe("ProxyTemplateRawSource", func() {
 						},
 						Spec: mesh_proto.Dataplane{
 							Networking: &mesh_proto.Dataplane_Networking{
+								Address: "192.168.0.1",
 								Inbound: []*mesh_proto.Dataplane_Networking_Inbound{
-									{Interface: "192.168.0.1:80:8080"},
+									{
+										Port:        80,
+										ServicePort: 8080,
+									},
 								},
 							},
 						},
@@ -360,8 +392,12 @@ var _ = Describe("ProxyTemplateRawSource", func() {
 						},
 						Spec: mesh_proto.Dataplane{
 							Networking: &mesh_proto.Dataplane_Networking{
+								Address: "192.168.0.1",
 								Inbound: []*mesh_proto.Dataplane_Networking_Inbound{
-									{Interface: "192.168.0.1:80:8080"},
+									{
+										Port:        80,
+										ServicePort: 8080,
+									},
 								},
 							},
 						},

--- a/pkg/xds/generator/proxy_template_test.go
+++ b/pkg/xds/generator/proxy_template_test.go
@@ -66,8 +66,12 @@ var _ = Describe("TemplateProxyGenerator", func() {
 						},
 						Spec: mesh_proto.Dataplane{
 							Networking: &mesh_proto.Dataplane_Networking{
+								Address: "192.168.0.1",
 								Inbound: []*mesh_proto.Dataplane_Networking_Inbound{
-									{Interface: "192.168.0.1:80:8080"},
+									{
+										Port:        80,
+										ServicePort: 8080,
+									},
 								},
 								TransparentProxying: &mesh_proto.Dataplane_Networking_TransparentProxying{
 									RedirectPort: 15001,
@@ -173,8 +177,10 @@ var _ = Describe("TemplateProxyGenerator", func() {
                 networking:
                   transparentProxying:
                     redirectPort: 15001
+                  address: 192.168.0.1
                   inbound:
-                    - interface: 192.168.0.1:80:8080
+                    - port: 80
+                      servicePort: 8080
 `,
 				proxyTemplateFile: "1-proxy-template.input.yaml",
 				envoyConfigFile:   "1-envoy-config.golden.yaml",

--- a/pkg/xds/generator/testdata/inbound-proxy/3-dataplane.input.yaml
+++ b/pkg/xds/generator/testdata/inbound-proxy/3-dataplane.input.yaml
@@ -1,6 +1,8 @@
 networking:
+  address: 192.168.0.1
   inbound:
-    - interface: 192.168.0.1:80:8080
+    - port: 80
+      servicePort: 8080
       tags:
         service: backend1
         protocol: http

--- a/pkg/xds/generator/testdata/inbound-proxy/4-dataplane.input.yaml
+++ b/pkg/xds/generator/testdata/inbound-proxy/4-dataplane.input.yaml
@@ -1,8 +1,10 @@
 networking:
   transparentProxying:
     redirectPort: 15001
+  address: 192.168.0.1
   inbound:
-    - interface: 192.168.0.1:80:8080
+    - port: 80
+      servicePort: 8080
       tags:
         service: backend1
         protocol: http

--- a/pkg/xds/generator/testdata/inbound-proxy/5-dataplane.input.yaml
+++ b/pkg/xds/generator/testdata/inbound-proxy/5-dataplane.input.yaml
@@ -1,9 +1,12 @@
 networking:
+  address: 192.168.0.1
   inbound:
-    - interface: 192.168.0.1:80:8080
+    - port: 80
+      servicePort: 8080
       tags:
         service: backend1
         protocol: http
-    - interface: 192.168.0.1:443:8443
+    - port: 443
+      servicePort: 8443
       tags:
         service: backend2

--- a/pkg/xds/generator/testdata/inbound-proxy/6-dataplane.input.yaml
+++ b/pkg/xds/generator/testdata/inbound-proxy/6-dataplane.input.yaml
@@ -1,11 +1,14 @@
 networking:
   transparentProxying:
     redirectPort: 15001
+  address: 192.168.0.1
   inbound:
-    - interface: 192.168.0.1:80:8080
+    - port: 80
+      servicePort: 8080
       tags:
         service: backend1
         protocol: http
-    - interface: 192.168.0.1:443:8443
+    - port: 443
+      servicePort: 8443
       tags:
         service: backend2

--- a/pkg/xds/generator/testdata/inbound-proxy/7-dataplane.input.yaml
+++ b/pkg/xds/generator/testdata/inbound-proxy/7-dataplane.input.yaml
@@ -1,16 +1,23 @@
 networking:
+  address: 192.168.0.1
   inbound:
-    - interface: 192.168.0.1:80:8080
+    - port: 80
+      servicePort: 8080
       tags:
         service: backend1
         protocol: http
-    - interface: 192.168.0.1:443:8443
+    - port: 443
+      servicePort: 8443
       tags:
         service: backend2
-    - interface: 192.168.0.2:80:8080
+    - address: 192.168.0.2
+      port: 80
+      servicePort: 8080
       tags:
         service: backend3
         protocol: http
-    - interface: 192.168.0.2:443:8443
+    - address: 192.168.0.2
+      port: 443
+      servicePort: 8443
       tags:
         service: backend4

--- a/pkg/xds/generator/testdata/inbound-proxy/8-dataplane.input.yaml
+++ b/pkg/xds/generator/testdata/inbound-proxy/8-dataplane.input.yaml
@@ -1,18 +1,25 @@
 networking:
   transparentProxying:
     redirectPort: 15001
+  address: 192.168.0.1
   inbound:
-    - interface: 192.168.0.1:80:8080
+    - port: 80
+      servicePort: 8080
       tags:
         service: backend1
         protocol: http
-    - interface: 192.168.0.1:443:8443
+    - port: 443
+      servicePort: 8443
       tags:
         service: backend2
-    - interface: 192.168.0.2:80:8080
+    - address: 192.168.0.2
+      port: 80
+      servicePort: 8080
       tags:
         service: backend3
         protocol: http
-    - interface: 192.168.0.2:443:8443
+    - address: 192.168.0.2
+      port: 443
+      servicePort: 8443
       tags:
         service: backend4

--- a/pkg/xds/server/components_test.go
+++ b/pkg/xds/server/components_test.go
@@ -100,9 +100,11 @@ var _ = Describe("Components", func() {
 			resource := &mesh_core.DataplaneResource{
 				Spec: mesh_proto.Dataplane{
 					Networking: &mesh_proto.Dataplane_Networking{
+						Address: "127.0.0.1",
 						Inbound: []*mesh_proto.Dataplane_Networking_Inbound{
 							{
-								Interface: "127.0.0.1:9090:8080",
+								Port:        9090,
+								ServicePort: 8080,
 								Tags: map[string]string{
 									"service": "backend",
 								},

--- a/pkg/xds/server/testdata/dataplane.input.yaml
+++ b/pkg/xds/server/testdata/dataplane.input.yaml
@@ -1,8 +1,15 @@
 networking:
   transparentProxying:
     redirectPort: 15001
+  address: 192.168.0.1
   inbound:
-    - interface: 192.168.0.1:80:8080
-    - interface: 192.168.0.1:443:8443
-    - interface: 192.168.0.2:80:8080
-    - interface: 192.168.0.2:443:8443
+    - port: 80
+      servicePort: 8080
+    - port: 443
+      servicePort: 8443
+    - address: 192.168.0.2
+      port: 80
+      servicePort: 8080
+    - address: 192.168.0.2
+      port: 443
+      servicePort: 8443

--- a/pkg/xds/topology/healthchecks_test.go
+++ b/pkg/xds/topology/healthchecks_test.go
@@ -55,13 +55,22 @@ var _ = Describe("HealthCheck", func() {
 				},
 				Spec: mesh_proto.Dataplane{
 					Networking: &mesh_proto.Dataplane_Networking{
+						Address: "192.168.0.1",
 						Inbound: []*mesh_proto.Dataplane_Networking_Inbound{
-							{Tags: map[string]string{"service": "backend", "region": "eu"}, Interface: "192.168.0.1:8080:18080"},
-							{Tags: map[string]string{"service": "frontend", "region": "eu"}, Interface: "192.168.0.1:7070:17070"},
+							{
+								Tags:        map[string]string{"service": "backend", "region": "eu"},
+								Port:        8080,
+								ServicePort: 18080,
+							},
+							{
+								Tags:        map[string]string{"service": "frontend", "region": "eu"},
+								Port:        7070,
+								ServicePort: 17070,
+							},
 						},
 						Outbound: []*mesh_proto.Dataplane_Networking_Outbound{
-							{Service: "redis", Interface: ":10001"},
-							{Service: "elastic", Interface: ":10002"},
+							{Service: "redis", Port: 10001},
+							{Service: "elastic", Port: 10002},
 						},
 					},
 				},

--- a/pkg/xds/topology/outbound_test.go
+++ b/pkg/xds/topology/outbound_test.go
@@ -52,13 +52,22 @@ var _ = Describe("TrafficRoute", func() {
 				},
 				Spec: mesh_proto.Dataplane{
 					Networking: &mesh_proto.Dataplane_Networking{
+						Address: "192.168.0.1",
 						Inbound: []*mesh_proto.Dataplane_Networking_Inbound{
-							{Tags: map[string]string{"service": "backend", "region": "eu"}, Interface: "192.168.0.1:8080:18080"},
-							{Tags: map[string]string{"service": "frontend", "region": "eu"}, Interface: "192.168.0.1:7070:17070"},
+							{
+								Tags:        map[string]string{"service": "backend", "region": "eu"},
+								Port:        8080,
+								ServicePort: 18080,
+							},
+							{
+								Tags:        map[string]string{"service": "frontend", "region": "eu"},
+								Port:        7070,
+								ServicePort: 17070,
+							},
 						},
 						Outbound: []*mesh_proto.Dataplane_Networking_Outbound{
-							{Service: "redis", Interface: ":10001"},
-							{Service: "elastic", Interface: ":10002"},
+							{Service: "redis", Port: 10001},
+							{Service: "elastic", Port: 10002},
 						},
 					},
 				},
@@ -70,8 +79,13 @@ var _ = Describe("TrafficRoute", func() {
 				},
 				Spec: mesh_proto.Dataplane{
 					Networking: &mesh_proto.Dataplane_Networking{
+						Address: "192.168.0.2",
 						Inbound: []*mesh_proto.Dataplane_Networking_Inbound{
-							{Tags: map[string]string{"service": "redis", "version": "v1"}, Interface: "192.168.0.2:6379:16379"},
+							{
+								Tags:        map[string]string{"service": "redis", "version": "v1"},
+								Port:        6379,
+								ServicePort: 16379,
+							},
 						},
 					},
 				},
@@ -83,8 +97,13 @@ var _ = Describe("TrafficRoute", func() {
 				},
 				Spec: mesh_proto.Dataplane{
 					Networking: &mesh_proto.Dataplane_Networking{
+						Address: "192.168.0.3",
 						Inbound: []*mesh_proto.Dataplane_Networking_Inbound{
-							{Tags: map[string]string{"service": "redis", "version": "v2"}, Interface: "192.168.0.3:6379:26379"},
+							{
+								Tags:        map[string]string{"service": "redis", "version": "v2"},
+								Port:        6379,
+								ServicePort: 26379,
+							},
 						},
 					},
 				},
@@ -96,8 +115,13 @@ var _ = Describe("TrafficRoute", func() {
 				},
 				Spec: mesh_proto.Dataplane{
 					Networking: &mesh_proto.Dataplane_Networking{
+						Address: "192.168.0.4",
 						Inbound: []*mesh_proto.Dataplane_Networking_Inbound{
-							{Tags: map[string]string{"service": "redis", "version": "v3"}, Interface: "192.168.0.4:6379:36379"},
+							{
+								Tags:        map[string]string{"service": "redis", "version": "v3"},
+								Port:        6379,
+								ServicePort: 36379,
+							},
 						},
 					},
 				},
@@ -109,8 +133,13 @@ var _ = Describe("TrafficRoute", func() {
 				},
 				Spec: mesh_proto.Dataplane{
 					Networking: &mesh_proto.Dataplane_Networking{
+						Address: "192.168.0.5",
 						Inbound: []*mesh_proto.Dataplane_Networking_Inbound{
-							{Tags: map[string]string{"service": "elastic", "region": "eu"}, Interface: "192.168.0.5:9200:49200"},
+							{
+								Tags:        map[string]string{"service": "elastic", "region": "eu"},
+								Port:        9200,
+								ServicePort: 49200,
+							},
 						},
 					},
 				},
@@ -122,8 +151,13 @@ var _ = Describe("TrafficRoute", func() {
 				},
 				Spec: mesh_proto.Dataplane{
 					Networking: &mesh_proto.Dataplane_Networking{
+						Address: "192.168.0.6",
 						Inbound: []*mesh_proto.Dataplane_Networking_Inbound{
-							{Tags: map[string]string{"service": "elastic", "region": "us"}, Interface: "192.168.0.6:9200:59200"},
+							{
+								Tags:        map[string]string{"service": "elastic", "region": "us"},
+								Port:        9200,
+								ServicePort: 59200,
+							},
 						},
 					},
 				},
@@ -195,8 +229,13 @@ var _ = Describe("TrafficRoute", func() {
 					{
 						Spec: mesh_proto.Dataplane{
 							Networking: &mesh_proto.Dataplane_Networking{
+								Address: "192.168.0.1",
 								Inbound: []*mesh_proto.Dataplane_Networking_Inbound{
-									{Interface: "192.168.0.1:9200:19200", Tags: map[string]string{"service": "elastic"}},
+									{
+										Tags:        map[string]string{"service": "elastic"},
+										Port:        9200,
+										ServicePort: 19200,
+									},
 								},
 							},
 						},
@@ -212,8 +251,13 @@ var _ = Describe("TrafficRoute", func() {
 					{
 						Spec: mesh_proto.Dataplane{
 							Networking: &mesh_proto.Dataplane_Networking{
+								Address: "192.168.0.1",
 								Inbound: []*mesh_proto.Dataplane_Networking_Inbound{
-									{Interface: "192.168.0.1:6379:16379", Tags: map[string]string{"service": "redis", "version": "v2"}},
+									{
+										Tags:        map[string]string{"service": "redis", "version": "v2"},
+										Port:        6379,
+										ServicePort: 16379,
+									},
 								},
 							},
 						},
@@ -229,8 +273,13 @@ var _ = Describe("TrafficRoute", func() {
 					{
 						Spec: mesh_proto.Dataplane{
 							Networking: &mesh_proto.Dataplane_Networking{
+								Address: "192.168.0.1",
 								Inbound: []*mesh_proto.Dataplane_Networking_Inbound{
-									{Interface: "192.168.0.1:6379:16379", Tags: map[string]string{"service": "redis", "version": "v1"}},
+									{
+										Tags:        map[string]string{"service": "redis", "version": "v1"},
+										Port:        6379,
+										ServicePort: 16379,
+									},
 								},
 							},
 						},
@@ -247,8 +296,13 @@ var _ = Describe("TrafficRoute", func() {
 					{
 						Spec: mesh_proto.Dataplane{
 							Networking: &mesh_proto.Dataplane_Networking{
+								Address: "192.168.0.3",
 								Inbound: []*mesh_proto.Dataplane_Networking_Inbound{
-									{Interface: "192.168.0.3:6379:36379", Tags: map[string]string{"service": "redis", "version": "v3"}},
+									{
+										Tags:        map[string]string{"service": "redis", "version": "v3"},
+										Port:        6379,
+										ServicePort: 36379,
+									},
 								},
 							},
 						},
@@ -272,8 +326,13 @@ var _ = Describe("TrafficRoute", func() {
 					{
 						Spec: mesh_proto.Dataplane{
 							Networking: &mesh_proto.Dataplane_Networking{
+								Address: "192.168.0.1",
 								Inbound: []*mesh_proto.Dataplane_Networking_Inbound{
-									{Interface: "192.168.0.1:6379:16379", Tags: map[string]string{"service": "redis", "region": "us"}},
+									{
+										Tags:        map[string]string{"service": "redis", "region": "us"},
+										Port:        6379,
+										ServicePort: 16379,
+									},
 								},
 							},
 						},
@@ -296,8 +355,13 @@ var _ = Describe("TrafficRoute", func() {
 					{
 						Spec: mesh_proto.Dataplane{
 							Networking: &mesh_proto.Dataplane_Networking{
+								Address: "192.168.0.1",
 								Inbound: []*mesh_proto.Dataplane_Networking_Inbound{
-									{Interface: "192.168.0.1:6379:16379", Tags: map[string]string{"service": "redis", "region": "us"}},
+									{
+										Tags:        map[string]string{"service": "redis", "region": "us"},
+										Port:        6379,
+										ServicePort: 16379,
+									},
 								},
 							},
 						},
@@ -324,8 +388,13 @@ var _ = Describe("TrafficRoute", func() {
 					{
 						Spec: mesh_proto.Dataplane{
 							Networking: &mesh_proto.Dataplane_Networking{
+								Address: "192.168.0.1",
 								Inbound: []*mesh_proto.Dataplane_Networking_Inbound{
-									{Interface: "192.168.0.1:6379:16379", Tags: map[string]string{"service": "redis", "version": "v1"}},
+									{
+										Tags:        map[string]string{"service": "redis", "version": "v1"},
+										Port:        6379,
+										ServicePort: 16379,
+									},
 								},
 							},
 						},
@@ -333,8 +402,13 @@ var _ = Describe("TrafficRoute", func() {
 					{
 						Spec: mesh_proto.Dataplane{
 							Networking: &mesh_proto.Dataplane_Networking{
+								Address: "192.168.0.2",
 								Inbound: []*mesh_proto.Dataplane_Networking_Inbound{
-									{Interface: "192.168.0.2:9200:19200", Tags: map[string]string{"service": "elastic", "region": "us"}},
+									{
+										Tags:        map[string]string{"service": "elastic", "region": "us"},
+										Port:        9200,
+										ServicePort: 19200,
+									},
 								},
 							},
 						},
@@ -364,9 +438,19 @@ var _ = Describe("TrafficRoute", func() {
 					{
 						Spec: mesh_proto.Dataplane{
 							Networking: &mesh_proto.Dataplane_Networking{
+								Address: "192.168.0.1",
 								Inbound: []*mesh_proto.Dataplane_Networking_Inbound{
-									{Interface: "192.168.0.1:6379:16379", Tags: map[string]string{"service": "redis", "version": "v1"}},
-									{Interface: "192.168.0.2:9200:19200", Tags: map[string]string{"service": "elastic", "region": "us"}},
+									{
+										Tags:        map[string]string{"service": "redis", "version": "v1"},
+										Port:        6379,
+										ServicePort: 16379,
+									},
+									{
+										Tags:        map[string]string{"service": "elastic", "region": "us"},
+										Address:     "192.168.0.2",
+										Port:        9200,
+										ServicePort: 19200,
+									},
 								},
 							},
 						},

--- a/pkg/xds/topology/router_test.go
+++ b/pkg/xds/topology/router_test.go
@@ -53,13 +53,22 @@ var _ = Describe("TrafficRoute", func() {
 				},
 				Spec: mesh_proto.Dataplane{
 					Networking: &mesh_proto.Dataplane_Networking{
+						Address: "192.168.0.1",
 						Inbound: []*mesh_proto.Dataplane_Networking_Inbound{
-							{Tags: map[string]string{"service": "backend", "region": "eu"}, Interface: "192.168.0.1:8080:18080"},
-							{Tags: map[string]string{"service": "frontend", "region": "eu"}, Interface: "192.168.0.1:7070:17070"},
+							{
+								Tags:        map[string]string{"service": "backend", "region": "eu"},
+								Port:        8080,
+								ServicePort: 18080,
+							},
+							{
+								Tags:        map[string]string{"service": "frontend", "region": "eu"},
+								Port:        7070,
+								ServicePort: 17070,
+							},
 						},
 						Outbound: []*mesh_proto.Dataplane_Networking_Outbound{
-							{Service: "redis", Interface: ":10001"},
-							{Service: "elastic", Interface: ":10002"},
+							{Service: "redis", Port: 10001},
+							{Service: "elastic", Port: 10002},
 						},
 					},
 				},
@@ -648,8 +657,8 @@ var _ = Describe("TrafficRoute", func() {
 					Spec: mesh_proto.Dataplane{
 						Networking: &mesh_proto.Dataplane_Networking{
 							Outbound: []*mesh_proto.Dataplane_Networking_Outbound{
-								{Service: "redis", Interface: ":10001"},
-								{Service: "elastic", Interface: ":10002"},
+								{Service: "redis", Port: 10001},
+								{Service: "elastic", Port: 10002},
 							},
 						},
 					},
@@ -669,8 +678,8 @@ var _ = Describe("TrafficRoute", func() {
 					Spec: mesh_proto.Dataplane{
 						Networking: &mesh_proto.Dataplane_Networking{
 							Outbound: []*mesh_proto.Dataplane_Networking_Outbound{
-								{Service: "redis", Interface: ":10001"},
-								{Service: "elastic", Interface: ":10002"},
+								{Service: "redis", Port: 10001},
+								{Service: "elastic", Port: 10002},
 							},
 						},
 					},

--- a/tools/e2e/examples/docker-compose/kuma-example-installer.sh
+++ b/tools/e2e/examples/docker-compose/kuma-example-installer.sh
@@ -89,8 +89,10 @@ type: Dataplane
 mesh: default
 name: kuma-example-app
 networking:
+  address: {{ IP }}
   inbound:
-  - interface: {{ IP }}:{{ PUBLIC_PORT }}:{{ LOCAL_PORT }}
+  - port: {{ PUBLIC_PORT }}
+    servicePort: {{ LOCAL_PORT }}
     tags:
       service: kuma-example-app
       protocol: http
@@ -105,12 +107,14 @@ type: Dataplane
 mesh: default
 name: kuma-example-client
 networking:
+  address: {{ IP }}
   inbound:
-  - interface: {{ IP }}:{{ PUBLIC_PORT }}:{{ LOCAL_PORT }}
+  - port: {{ PUBLIC_PORT }}
+    servicePort: {{ LOCAL_PORT }}
     tags:
       service: kuma-example-client
   outbound:
-  - interface: :4000
+  - port: 4000
     service: kuma-example-app"
 
 #
@@ -122,14 +126,16 @@ type: Dataplane
 mesh: default
 name: kuma-example-web
 networking:
+  address: {{ IP }}
   inbound:
-  - interface: {{ IP }}:{{ PUBLIC_PORT }}:{{ LOCAL_PORT }}
+  - port: {{ PUBLIC_PORT }}
+    servicePort: {{ LOCAL_PORT }}
     tags:
       service: kuma-example-web
       version: v8
       env: prod
   outbound:
-  - interface: :5000
+  - port: 5000
     service: kuma-example-backend"
 
 #
@@ -141,8 +147,10 @@ type: Dataplane
 mesh: default
 name: kuma-example-backend-v1
 networking:
+  address: {{ IP }}
   inbound:
-  - interface: {{ IP }}:{{ PUBLIC_PORT }}:{{ LOCAL_PORT }}
+  - port: {{ PUBLIC_PORT }}
+    servicePort: {{ LOCAL_PORT }}
     tags:
       service: kuma-example-backend
       protocol: http
@@ -158,8 +166,10 @@ type: Dataplane
 mesh: default
 name: kuma-example-backend-v2
 networking:
+  address: {{ IP }}
   inbound:
-  - interface: {{ IP }}:{{ PUBLIC_PORT }}:{{ LOCAL_PORT }}
+  - port: {{ PUBLIC_PORT }}
+    servicePort: {{ LOCAL_PORT }}
     tags:
       service: kuma-example-backend
       protocol: http


### PR DESCRIPTION
### Summary

Changed the DP format across the project for two reasons
1) Check if the new format is compatible everywhere
2) Removing old format will be easier in the future.