### PR TITLE
kuma-cp: generate HTTP-specific outbound listeners for services tagged with `protocol: http`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 Changes:
 
+* feature: generate HTTP-specific outbound listeners for services tagged with `protocol: http`
+  [#585](https://github.com/Kong/kuma/pull/585)
 * feature: TracingTrace in Kuma REST API
   [#583](https://github.com/Kong/kuma/pull/583)
 * feature: TracingTrace entity

--- a/pkg/xds/envoy/listeners/http_inbound_route_configurer.go
+++ b/pkg/xds/envoy/listeners/http_inbound_route_configurer.go
@@ -4,15 +4,13 @@ import (
 	"fmt"
 
 	"github.com/golang/protobuf/proto"
-	wrappers "github.com/golang/protobuf/ptypes/wrappers"
 
-	v2 "github.com/envoyproxy/go-control-plane/envoy/api/v2"
 	envoy_listener "github.com/envoyproxy/go-control-plane/envoy/api/v2/listener"
-	envoy_route "github.com/envoyproxy/go-control-plane/envoy/api/v2/route"
 	envoy_hcm "github.com/envoyproxy/go-control-plane/envoy/config/filter/network/http_connection_manager/v2"
 	envoy_wellknown "github.com/envoyproxy/go-control-plane/pkg/wellknown"
 
 	envoy_common "github.com/Kong/kuma/pkg/xds/envoy"
+	envoy_routes "github.com/Kong/kuma/pkg/xds/envoy/routes"
 )
 
 func HttpInboundRoute(service string, cluster envoy_common.ClusterInfo) FilterChainBuilderOpt {
@@ -31,7 +29,16 @@ type HttpInboundRouteConfigurer struct {
 }
 
 func (c *HttpInboundRouteConfigurer) Configure(filterChain *envoy_listener.FilterChain) error {
-	routeConfig := c.routeConfiguration()
+	routeName := fmt.Sprintf("inbound:%s", c.service)
+	routeConfig, err := envoy_routes.NewRouteConfigurationBuilder().
+		Configure(envoy_routes.CommonRouteConfiguration(routeName)).
+		Configure(envoy_routes.VirtualHost(envoy_routes.NewVirtualHostBuilder().
+			Configure(envoy_routes.CommonVirtualHost(c.service)).
+			Configure(envoy_routes.DefaultRoute(c.cluster)))).
+		Build()
+	if err != nil {
+		return err
+	}
 
 	return UpdateFilterConfig(filterChain, envoy_wellknown.HTTPConnectionManager, func(filterConfig proto.Message) error {
 		hcm, ok := filterConfig.(*envoy_hcm.HttpConnectionManager)
@@ -43,31 +50,4 @@ func (c *HttpInboundRouteConfigurer) Configure(filterChain *envoy_listener.Filte
 		}
 		return nil
 	})
-}
-
-func (c *HttpInboundRouteConfigurer) routeConfiguration() *v2.RouteConfiguration {
-	return &v2.RouteConfiguration{
-		Name: fmt.Sprintf("inbound:%s", c.service),
-		VirtualHosts: []*envoy_route.VirtualHost{{
-			Name:    c.service,
-			Domains: []string{"*"},
-			Routes: []*envoy_route.Route{{
-				Match: &envoy_route.RouteMatch{
-					PathSpecifier: &envoy_route.RouteMatch_Prefix{
-						Prefix: "/",
-					},
-				},
-				Action: &envoy_route.Route_Route{
-					Route: &envoy_route.RouteAction{
-						ClusterSpecifier: &envoy_route.RouteAction_Cluster{
-							Cluster: c.cluster.Name,
-						},
-					},
-				},
-			}},
-		}},
-		ValidateClusters: &wrappers.BoolValue{
-			Value: true,
-		},
-	}
 }

--- a/pkg/xds/envoy/listeners/http_inbound_route_configurer.go
+++ b/pkg/xds/envoy/listeners/http_inbound_route_configurer.go
@@ -1,8 +1,6 @@
 package listeners
 
 import (
-	"fmt"
-
 	"github.com/golang/protobuf/proto"
 
 	envoy_listener "github.com/envoyproxy/go-control-plane/envoy/api/v2/listener"
@@ -10,6 +8,7 @@ import (
 	envoy_wellknown "github.com/envoyproxy/go-control-plane/pkg/wellknown"
 
 	envoy_common "github.com/Kong/kuma/pkg/xds/envoy"
+	envoy_names "github.com/Kong/kuma/pkg/xds/envoy/names"
 	envoy_routes "github.com/Kong/kuma/pkg/xds/envoy/routes"
 )
 
@@ -29,7 +28,7 @@ type HttpInboundRouteConfigurer struct {
 }
 
 func (c *HttpInboundRouteConfigurer) Configure(filterChain *envoy_listener.FilterChain) error {
-	routeName := fmt.Sprintf("inbound:%s", c.service)
+	routeName := envoy_names.GetInboundRouteName(c.service)
 	routeConfig, err := envoy_routes.NewRouteConfigurationBuilder().
 		Configure(envoy_routes.CommonRouteConfiguration(routeName)).
 		Configure(envoy_routes.VirtualHost(envoy_routes.NewVirtualHostBuilder().

--- a/pkg/xds/envoy/listeners/http_outbound_route_configurer.go
+++ b/pkg/xds/envoy/listeners/http_outbound_route_configurer.go
@@ -1,0 +1,43 @@
+package listeners
+
+import (
+	"github.com/golang/protobuf/proto"
+
+	envoy_core "github.com/envoyproxy/go-control-plane/envoy/api/v2/core"
+	envoy_listener "github.com/envoyproxy/go-control-plane/envoy/api/v2/listener"
+	envoy_hcm "github.com/envoyproxy/go-control-plane/envoy/config/filter/network/http_connection_manager/v2"
+	envoy_wellknown "github.com/envoyproxy/go-control-plane/pkg/wellknown"
+)
+
+func HttpOutboundRoute(routeName string) FilterChainBuilderOpt {
+	return FilterChainBuilderOptFunc(func(config *FilterChainBuilderConfig) {
+		config.Add(&HttpOutboundRouteConfigurer{
+			routeName: routeName,
+		})
+	})
+}
+
+type HttpOutboundRouteConfigurer struct {
+	routeName string
+}
+
+func (c *HttpOutboundRouteConfigurer) Configure(filterChain *envoy_listener.FilterChain) error {
+	return UpdateFilterConfig(filterChain, envoy_wellknown.HTTPConnectionManager, func(filterConfig proto.Message) error {
+		hcm, ok := filterConfig.(*envoy_hcm.HttpConnectionManager)
+		if !ok {
+			return NewUnexpectedFilterConfigTypeError(filterConfig, &envoy_hcm.HttpConnectionManager{})
+		}
+
+		hcm.RouteSpecifier = &envoy_hcm.HttpConnectionManager_Rds{
+			Rds: &envoy_hcm.Rds{
+				ConfigSource: &envoy_core.ConfigSource{
+					ConfigSourceSpecifier: &envoy_core.ConfigSource_Ads{
+						Ads: &envoy_core.AggregatedConfigSource{},
+					},
+				},
+				RouteConfigName: c.routeName,
+			},
+		}
+		return nil
+	})
+}

--- a/pkg/xds/envoy/listeners/http_outbound_route_configurer_test.go
+++ b/pkg/xds/envoy/listeners/http_outbound_route_configurer_test.go
@@ -1,0 +1,69 @@
+package listeners_test
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/ginkgo/extensions/table"
+	. "github.com/onsi/gomega"
+
+	. "github.com/Kong/kuma/pkg/xds/envoy/listeners"
+
+	util_proto "github.com/Kong/kuma/pkg/util/proto"
+)
+
+var _ = Describe("HttpOutboundRouteConfigurer", func() {
+
+	type testCase struct {
+		listenerName    string
+		listenerAddress string
+		listenerPort    uint32
+		statsName       string
+		routeName       string
+		expected        string
+	}
+
+	DescribeTable("should generate proper Envoy config",
+		func(given testCase) {
+			// when
+			listener, err := NewListenerBuilder().
+				Configure(OutboundListener(given.listenerName, given.listenerAddress, given.listenerPort)).
+				Configure(FilterChain(NewFilterChainBuilder().
+					Configure(HttpConnectionManager(given.statsName)).
+					Configure(HttpOutboundRoute(given.routeName)))).
+				Build()
+			// then
+			Expect(err).ToNot(HaveOccurred())
+
+			// when
+			actual, err := util_proto.ToYAML(listener)
+			Expect(err).ToNot(HaveOccurred())
+			// and
+			Expect(actual).To(MatchYAML(given.expected))
+		},
+		Entry("basic http_connection_manager with an outbound route", testCase{
+			listenerName:    "outbound:127.0.0.1:18080",
+			listenerAddress: "127.0.0.1",
+			listenerPort:    18080,
+			statsName:       "127.0.0.1:18080",
+			routeName:       "outbound:backend",
+			expected: `
+            name: outbound:127.0.0.1:18080
+            address:
+              socketAddress:
+                address: 127.0.0.1
+                portValue: 18080
+            filterChains:
+            - filters:
+              - name: envoy.http_connection_manager
+                typedConfig:
+                  '@type': type.googleapis.com/envoy.config.filter.network.http_connection_manager.v2.HttpConnectionManager
+                  httpFilters:
+                  - name: envoy.router
+                  rds:
+                    configSource:
+                      ads: {}
+                    routeConfigName: outbound:backend
+                  statPrefix: "127_0_0_1_18080"
+`,
+		}),
+	)
+})

--- a/pkg/xds/envoy/listeners/network_rbac_configurer_test.go
+++ b/pkg/xds/envoy/listeners/network_rbac_configurer_test.go
@@ -11,7 +11,6 @@ import (
 	mesh_core "github.com/Kong/kuma/pkg/core/resources/apis/mesh"
 
 	test_model "github.com/Kong/kuma/pkg/test/resources/model"
-
 	util_proto "github.com/Kong/kuma/pkg/util/proto"
 	envoy_common "github.com/Kong/kuma/pkg/xds/envoy"
 )

--- a/pkg/xds/envoy/names/resource_names.go
+++ b/pkg/xds/envoy/names/resource_names.go
@@ -1,4 +1,4 @@
-package generator
+package names
 
 import (
 	"fmt"
@@ -8,31 +8,35 @@ import (
 	mesh_proto "github.com/Kong/kuma/api/mesh/v1alpha1"
 )
 
-func localClusterName(port uint32) string {
+func GetLocalClusterName(port uint32) string {
 	return fmt.Sprintf("localhost:%d", port)
 }
 
-func inboundListenerName(address string, port uint32) string {
+func GetInboundListenerName(address string, port uint32) string {
 	return fmt.Sprintf("inbound:%s:%d", address, port)
 }
 
-func outboundListenerName(address string, port uint32) string {
+func GetOutboundListenerName(address string, port uint32) string {
 	return fmt.Sprintf("outbound:%s:%d", address, port)
 }
 
-func outboundRouteName(service string) string {
+func GetInboundRouteName(service string) string {
+	return fmt.Sprintf("inbound:%s", service)
+}
+
+func GetOutboundRouteName(service string) string {
 	return fmt.Sprintf("outbound:%s", service)
 }
 
-func envoyAdminClusterName() string {
+func GetEnvoyAdminClusterName() string {
 	return "kuma:envoy:admin"
 }
 
-func prometheusListenerName() string {
+func GetPrometheusListenerName() string {
 	return "kuma:metrics:prometheus"
 }
 
-func destinationClusterName(service string, selector map[string]string) string {
+func GetDestinationClusterName(service string, selector map[string]string) string {
 	var pairs []string
 	for key, value := range selector {
 		if key == mesh_proto.ServiceTag {

--- a/pkg/xds/envoy/routes/common_route_configuration_configurer.go
+++ b/pkg/xds/envoy/routes/common_route_configuration_configurer.go
@@ -1,0 +1,27 @@
+package routes
+
+import (
+	"github.com/golang/protobuf/ptypes/wrappers"
+
+	v2 "github.com/envoyproxy/go-control-plane/envoy/api/v2"
+)
+
+func CommonRouteConfiguration(name string) RouteConfigurationBuilderOpt {
+	return RouteConfigurationBuilderOptFunc(func(config *RouteConfigurationBuilderConfig) {
+		config.Add(&CommonRouteConfigurationConfigurer{
+			name: name,
+		})
+	})
+}
+
+type CommonRouteConfigurationConfigurer struct {
+	name string
+}
+
+func (c CommonRouteConfigurationConfigurer) Configure(routeConfiguration *v2.RouteConfiguration) error {
+	routeConfiguration.Name = c.name
+	routeConfiguration.ValidateClusters = &wrappers.BoolValue{
+		Value: true,
+	}
+	return nil
+}

--- a/pkg/xds/envoy/routes/common_route_configuration_configurer_test.go
+++ b/pkg/xds/envoy/routes/common_route_configuration_configurer_test.go
@@ -1,0 +1,44 @@
+package routes_test
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/ginkgo/extensions/table"
+	. "github.com/onsi/gomega"
+
+	. "github.com/Kong/kuma/pkg/xds/envoy/routes"
+
+	util_proto "github.com/Kong/kuma/pkg/util/proto"
+)
+
+var _ = Describe("CommonRouteConfigurationConfigurer", func() {
+
+	type testCase struct {
+		routeName string
+		expected  string
+	}
+
+	DescribeTable("should generate proper Envoy config",
+		func(given testCase) {
+			// when
+			routeConfiguration, err := NewRouteConfigurationBuilder().
+				Configure(CommonRouteConfiguration(given.routeName)).
+				Build()
+			// then
+			Expect(err).ToNot(HaveOccurred())
+
+			// when
+			actual, err := util_proto.ToYAML(routeConfiguration)
+			// then
+			Expect(err).ToNot(HaveOccurred())
+			// and
+			Expect(actual).To(MatchYAML(given.expected))
+		},
+		Entry("basic RouteConfiguration", testCase{
+			routeName: "outbound:backend",
+			expected: `
+            name: outbound:backend
+            validateClusters: true
+`,
+		}),
+	)
+})

--- a/pkg/xds/envoy/routes/common_virtual_host_configurer.go
+++ b/pkg/xds/envoy/routes/common_virtual_host_configurer.go
@@ -1,0 +1,23 @@
+package routes
+
+import (
+	envoy_route "github.com/envoyproxy/go-control-plane/envoy/api/v2/route"
+)
+
+func CommonVirtualHost(name string) VirtualHostBuilderOpt {
+	return VirtualHostBuilderOptFunc(func(config *VirtualHostBuilderConfig) {
+		config.Add(&CommonVirtualHostConfigurer{
+			name: name,
+		})
+	})
+}
+
+type CommonVirtualHostConfigurer struct {
+	name string
+}
+
+func (c CommonVirtualHostConfigurer) Configure(virtualHost *envoy_route.VirtualHost) error {
+	virtualHost.Name = c.name
+	virtualHost.Domains = []string{"*"}
+	return nil
+}

--- a/pkg/xds/envoy/routes/common_virtual_host_configurer_test.go
+++ b/pkg/xds/envoy/routes/common_virtual_host_configurer_test.go
@@ -1,0 +1,45 @@
+package routes_test
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/ginkgo/extensions/table"
+	. "github.com/onsi/gomega"
+
+	. "github.com/Kong/kuma/pkg/xds/envoy/routes"
+
+	util_proto "github.com/Kong/kuma/pkg/util/proto"
+)
+
+var _ = Describe("CommonVirtualHostConfigurer", func() {
+
+	type testCase struct {
+		virtualHostName string
+		expected        string
+	}
+
+	DescribeTable("should generate proper Envoy config",
+		func(given testCase) {
+			// when
+			routeConfiguration, err := NewVirtualHostBuilder().
+				Configure(CommonVirtualHost(given.virtualHostName)).
+				Build()
+			// then
+			Expect(err).ToNot(HaveOccurred())
+
+			// when
+			actual, err := util_proto.ToYAML(routeConfiguration)
+			// then
+			Expect(err).ToNot(HaveOccurred())
+			// and
+			Expect(actual).To(MatchYAML(given.expected))
+		},
+		Entry("basic VirtualHost", testCase{
+			virtualHostName: "backend",
+			expected: `
+            name: backend
+            domains:
+            - '*'
+`,
+		}),
+	)
+})

--- a/pkg/xds/envoy/routes/default_route_configurer.go
+++ b/pkg/xds/envoy/routes/default_route_configurer.go
@@ -1,0 +1,66 @@
+package routes
+
+import (
+	"github.com/golang/protobuf/ptypes/wrappers"
+
+	envoy_route "github.com/envoyproxy/go-control-plane/envoy/api/v2/route"
+
+	envoy_common "github.com/Kong/kuma/pkg/xds/envoy"
+)
+
+func DefaultRoute(clusters ...envoy_common.ClusterInfo) VirtualHostBuilderOpt {
+	return VirtualHostBuilderOptFunc(func(config *VirtualHostBuilderConfig) {
+		config.Add(&DefaultRouteConfigurer{
+			RouteConfigurer: RouteConfigurer{
+				clusters: clusters,
+			},
+		})
+	})
+}
+
+type DefaultRouteConfigurer struct {
+	RouteConfigurer
+}
+
+func (c DefaultRouteConfigurer) Configure(virtualHost *envoy_route.VirtualHost) error {
+	route := &envoy_route.Route{
+		Match: &envoy_route.RouteMatch{
+			PathSpecifier: &envoy_route.RouteMatch_Prefix{
+				Prefix: "/",
+			},
+		},
+		Action: &envoy_route.Route_Route{
+			Route: c.routeAction(),
+		},
+	}
+	virtualHost.Routes = append(virtualHost.Routes, route)
+	return nil
+}
+
+type RouteConfigurer struct {
+	// Clusters to forward traffic to.
+	clusters []envoy_common.ClusterInfo
+}
+
+func (c RouteConfigurer) routeAction() *envoy_route.RouteAction {
+	routeAction := envoy_route.RouteAction{}
+	if len(c.clusters) == 1 {
+		routeAction.ClusterSpecifier = &envoy_route.RouteAction_Cluster{
+			Cluster: c.clusters[0].Name,
+		}
+	} else {
+		var weightedClusters []*envoy_route.WeightedCluster_ClusterWeight
+		for _, cluster := range c.clusters {
+			weightedClusters = append(weightedClusters, &envoy_route.WeightedCluster_ClusterWeight{
+				Name:   cluster.Name,
+				Weight: &wrappers.UInt32Value{Value: cluster.Weight},
+			})
+		}
+		routeAction.ClusterSpecifier = &envoy_route.RouteAction_WeightedClusters{
+			WeightedClusters: &envoy_route.WeightedCluster{
+				Clusters: weightedClusters,
+			},
+		}
+	}
+	return &routeAction
+}

--- a/pkg/xds/envoy/routes/default_route_configurer_test.go
+++ b/pkg/xds/envoy/routes/default_route_configurer_test.go
@@ -1,0 +1,68 @@
+package routes_test
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/ginkgo/extensions/table"
+	. "github.com/onsi/gomega"
+
+	. "github.com/Kong/kuma/pkg/xds/envoy/routes"
+
+	util_proto "github.com/Kong/kuma/pkg/util/proto"
+	envoy_common "github.com/Kong/kuma/pkg/xds/envoy"
+)
+
+var _ = Describe("DefaultRouteConfigurer", func() {
+
+	type testCase struct {
+		clusters []envoy_common.ClusterInfo
+		expected string
+	}
+
+	DescribeTable("should generate proper Envoy config",
+		func(given testCase) {
+			// when
+			routeConfiguration, err := NewVirtualHostBuilder().
+				Configure(DefaultRoute(given.clusters...)).
+				Build()
+			// then
+			Expect(err).ToNot(HaveOccurred())
+
+			// when
+			actual, err := util_proto.ToYAML(routeConfiguration)
+			// then
+			Expect(err).ToNot(HaveOccurred())
+			// and
+			Expect(actual).To(MatchYAML(given.expected))
+		},
+		Entry("basic VirtualHost with a single destination cluster", testCase{
+			clusters: []envoy_common.ClusterInfo{
+				{Name: "backend", Weight: 200},
+			},
+			expected: `
+            routes:
+            - match:
+                prefix: /
+              route:
+                cluster: backend
+`,
+		}),
+		Entry("basic VirtualHost with weighted destination clusters", testCase{
+			clusters: []envoy_common.ClusterInfo{
+				{Name: "backend{version=v1}", Weight: 30},
+				{Name: "backend{version=v2}", Weight: 70},
+			},
+			expected: `
+            routes:
+            - match:
+                prefix: /
+              route:
+                weightedClusters:
+                  clusters:
+                  - name: backend{version=v1}
+                    weight: 30
+                  - name: backend{version=v2}
+                    weight: 70
+`,
+		}),
+	)
+})

--- a/pkg/xds/envoy/routes/route_configuration_builder.go
+++ b/pkg/xds/envoy/routes/route_configuration_builder.go
@@ -1,0 +1,67 @@
+package routes
+
+import (
+	v2 "github.com/envoyproxy/go-control-plane/envoy/api/v2"
+)
+
+// RouteConfigurationConfigurer is responsible for configuring a single aspect of the entire Envoy RouteConfiguration,
+// such as VirtualHost, HTTP headers to add or remove, etc.
+type RouteConfigurationConfigurer interface {
+	// Configure configures a single aspect on a given Envoy RouteConfiguration.
+	Configure(routeConfiguration *v2.RouteConfiguration) error
+}
+
+// RouteConfigurationBuilderOpt is a configuration option for RouteConfigurationBuilder.
+//
+// The goal of RouteConfigurationBuilderOpt is to facilitate fluent RouteConfigurationBuilder API.
+type RouteConfigurationBuilderOpt interface {
+	// ApplyTo adds RouteConfigurationConfigurer(s) to the RouteConfigurationBuilder.
+	ApplyTo(config *RouteConfigurationBuilderConfig)
+}
+
+func NewRouteConfigurationBuilder() *RouteConfigurationBuilder {
+	return &RouteConfigurationBuilder{}
+}
+
+// RouteConfigurationBuilder is responsible for generating an Envoy RouteConfiguration
+// by applying a series of RouteConfigurationConfigurers.
+type RouteConfigurationBuilder struct {
+	config RouteConfigurationBuilderConfig
+}
+
+// Configure configures RouteConfigurationBuilder by adding individual RouteConfigurationConfigurers.
+func (b *RouteConfigurationBuilder) Configure(opts ...RouteConfigurationBuilderOpt) *RouteConfigurationBuilder {
+	for _, opt := range opts {
+		opt.ApplyTo(&b.config)
+	}
+	return b
+}
+
+// Build generates an Envoy RouteConfiguration by applying a series of RouteConfigurationConfigurers.
+func (b *RouteConfigurationBuilder) Build() (*v2.RouteConfiguration, error) {
+	routeConfiguration := v2.RouteConfiguration{}
+	for _, configurer := range b.config.Configurers {
+		if err := configurer.Configure(&routeConfiguration); err != nil {
+			return nil, err
+		}
+	}
+	return &routeConfiguration, nil
+}
+
+// RouteConfigurationBuilderConfig holds configuration of a RouteConfigurationBuilder.
+type RouteConfigurationBuilderConfig struct {
+	// A series of RouteConfigurationConfigurers to apply to Envoy RouteConfiguration.
+	Configurers []RouteConfigurationConfigurer
+}
+
+// Add appends a given RouteConfigurationConfigurer to the end of the chain.
+func (c *RouteConfigurationBuilderConfig) Add(configurer RouteConfigurationConfigurer) {
+	c.Configurers = append(c.Configurers, configurer)
+}
+
+// RouteConfigurationBuilderOptFunc is a convenience type adapter.
+type RouteConfigurationBuilderOptFunc func(config *RouteConfigurationBuilderConfig)
+
+func (f RouteConfigurationBuilderOptFunc) ApplyTo(config *RouteConfigurationBuilderConfig) {
+	f(config)
+}

--- a/pkg/xds/envoy/routes/routes_suite_test.go
+++ b/pkg/xds/envoy/routes/routes_suite_test.go
@@ -1,0 +1,13 @@
+package routes_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+func TestRoutes(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Routes Suite")
+}

--- a/pkg/xds/envoy/routes/virtual_host_builder.go
+++ b/pkg/xds/envoy/routes/virtual_host_builder.go
@@ -1,0 +1,67 @@
+package routes
+
+import (
+	envoy_route "github.com/envoyproxy/go-control-plane/envoy/api/v2/route"
+)
+
+// VirtualHostConfigurer is responsible for configuring a single aspect of the entire Envoy VirtualHost,
+// such as Route, CORS, etc.
+type VirtualHostConfigurer interface {
+	// Configure configures a single aspect on a given Envoy VirtualHost.
+	Configure(virtualHost *envoy_route.VirtualHost) error
+}
+
+// VirtualHostBuilderOpt is a configuration option for VirtualHostBuilder.
+//
+// The goal of VirtualHostBuilderOpt is to facilitate fluent VirtualHostBuilder API.
+type VirtualHostBuilderOpt interface {
+	// ApplyTo adds VirtualHostConfigurer(s) to the VirtualHostBuilder.
+	ApplyTo(config *VirtualHostBuilderConfig)
+}
+
+func NewVirtualHostBuilder() *VirtualHostBuilder {
+	return &VirtualHostBuilder{}
+}
+
+// VirtualHostBuilder is responsible for generating an Envoy VirtualHost
+// by applying a series of VirtualHostConfigurers.
+type VirtualHostBuilder struct {
+	config VirtualHostBuilderConfig
+}
+
+// Configure configures VirtualHostBuilder by adding individual VirtualHostConfigurers.
+func (b *VirtualHostBuilder) Configure(opts ...VirtualHostBuilderOpt) *VirtualHostBuilder {
+	for _, opt := range opts {
+		opt.ApplyTo(&b.config)
+	}
+	return b
+}
+
+// Build generates an Envoy VirtualHost by applying a series of VirtualHostConfigurers.
+func (b *VirtualHostBuilder) Build() (*envoy_route.VirtualHost, error) {
+	virtualHost := envoy_route.VirtualHost{}
+	for _, configurer := range b.config.Configurers {
+		if err := configurer.Configure(&virtualHost); err != nil {
+			return nil, err
+		}
+	}
+	return &virtualHost, nil
+}
+
+// VirtualHostBuilderConfig holds configuration of a VirtualHostBuilder.
+type VirtualHostBuilderConfig struct {
+	// A series of VirtualHostConfigurers to apply to Envoy VirtualHost.
+	Configurers []VirtualHostConfigurer
+}
+
+// Add appends a given VirtualHostConfigurer to the end of the chain.
+func (c *VirtualHostBuilderConfig) Add(configurer VirtualHostConfigurer) {
+	c.Configurers = append(c.Configurers, configurer)
+}
+
+// VirtualHostBuilderOptFunc is a convenience type adapter.
+type VirtualHostBuilderOptFunc func(config *VirtualHostBuilderConfig)
+
+func (f VirtualHostBuilderOptFunc) ApplyTo(config *VirtualHostBuilderConfig) {
+	f(config)
+}

--- a/pkg/xds/envoy/routes/virtual_host_configurer.go
+++ b/pkg/xds/envoy/routes/virtual_host_configurer.go
@@ -1,0 +1,26 @@
+package routes
+
+import (
+	v2 "github.com/envoyproxy/go-control-plane/envoy/api/v2"
+)
+
+func VirtualHost(builder *VirtualHostBuilder) RouteConfigurationBuilderOpt {
+	return RouteConfigurationBuilderOptFunc(func(config *RouteConfigurationBuilderConfig) {
+		config.Add(&RouteConfigurationVirtualHostConfigurer{
+			builder: builder,
+		})
+	})
+}
+
+type RouteConfigurationVirtualHostConfigurer struct {
+	builder *VirtualHostBuilder
+}
+
+func (c RouteConfigurationVirtualHostConfigurer) Configure(routeConfiguration *v2.RouteConfiguration) error {
+	virtualHost, err := c.builder.Build()
+	if err != nil {
+		return err
+	}
+	routeConfiguration.VirtualHosts = append(routeConfiguration.VirtualHosts, virtualHost)
+	return nil
+}

--- a/pkg/xds/envoy/routes/virtual_host_configurer_test.go
+++ b/pkg/xds/envoy/routes/virtual_host_configurer_test.go
@@ -1,0 +1,47 @@
+package routes_test
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/ginkgo/extensions/table"
+	. "github.com/onsi/gomega"
+
+	. "github.com/Kong/kuma/pkg/xds/envoy/routes"
+
+	util_proto "github.com/Kong/kuma/pkg/util/proto"
+)
+
+var _ = Describe("RouteConfigurationVirtualHostConfigurer", func() {
+
+	type testCase struct {
+		virtualHostName string
+		expected        string
+	}
+
+	DescribeTable("should generate proper Envoy config",
+		func(given testCase) {
+			// when
+			routeConfiguration, err := NewRouteConfigurationBuilder().
+				Configure(VirtualHost(NewVirtualHostBuilder().
+					Configure(CommonVirtualHost(given.virtualHostName)))).
+				Build()
+			// then
+			Expect(err).ToNot(HaveOccurred())
+
+			// when
+			actual, err := util_proto.ToYAML(routeConfiguration)
+			// then
+			Expect(err).ToNot(HaveOccurred())
+			// and
+			Expect(actual).To(MatchYAML(given.expected))
+		},
+		Entry("basic virtual host", testCase{
+			virtualHostName: "backend",
+			expected: `
+            virtualHosts:
+            - domains:
+              - '*'
+              name: backend
+`,
+		}),
+	)
+})

--- a/pkg/xds/generator/prometheus_endpoint_generator.go
+++ b/pkg/xds/generator/prometheus_endpoint_generator.go
@@ -8,6 +8,7 @@ import (
 
 	envoy_clusters "github.com/Kong/kuma/pkg/xds/envoy/clusters"
 	envoy_listeners "github.com/Kong/kuma/pkg/xds/envoy/listeners"
+	envoy_names "github.com/Kong/kuma/pkg/xds/envoy/names"
 )
 
 // PrometheusEndpointGenerator generates an inbound Envoy listener
@@ -57,8 +58,8 @@ func (g PrometheusEndpointGenerator) Generate(ctx xds_context.Context, proxy *co
 	// since it would allow a malicious user to manipulate that value and use Prometheus endpoint
 	// as a gateway to another host.
 	adminAddress := "127.0.0.1"
-	envoyAdminClusterName := envoyAdminClusterName()
-	prometheusListenerName := prometheusListenerName()
+	envoyAdminClusterName := envoy_names.GetEnvoyAdminClusterName()
+	prometheusListenerName := envoy_names.GetPrometheusListenerName()
 
 	listener, err := envoy_listeners.NewListenerBuilder().
 		Configure(envoy_listeners.InboundListener(prometheusListenerName, prometheusEndpointAddress, prometheusEndpoint.Port)).

--- a/pkg/xds/generator/protocol.go
+++ b/pkg/xds/generator/protocol.go
@@ -17,14 +17,14 @@ var (
 	}
 )
 
-// GetCommonProtocol returns a common protocol between given two.
+// getCommonProtocol returns a common protocol between given two.
 //
 // E.g.,
 // a common protocol between HTTP and HTTP  is HTTP,
 // a common protocol between HTTP and TCP   is TCP,
 // a common protocol between GRPC and HTTP2 is HTTP2,
 // a common protocol between HTTP and HTTP2 is TCP.
-func GetCommonProtocol(one, another mesh_core.Protocol) mesh_core.Protocol {
+func getCommonProtocol(one, another mesh_core.Protocol) mesh_core.Protocol {
 	if one == another {
 		return one
 	}
@@ -57,7 +57,7 @@ func InferServiceProtocol(endpoints []core_xds.Endpoint) mesh_core.Protocol {
 	serviceProtocol := mesh_core.ParseProtocol(endpoints[0].Tags[mesh_proto.ProtocolTag])
 	for _, endpoint := range endpoints[1:] {
 		endpointProtocol := mesh_core.ParseProtocol(endpoint.Tags[mesh_proto.ProtocolTag])
-		serviceProtocol = GetCommonProtocol(serviceProtocol, endpointProtocol)
+		serviceProtocol = getCommonProtocol(serviceProtocol, endpointProtocol)
 	}
 	return serviceProtocol
 }

--- a/pkg/xds/generator/protocol.go
+++ b/pkg/xds/generator/protocol.go
@@ -1,0 +1,63 @@
+package generator
+
+import (
+	mesh_proto "github.com/Kong/kuma/api/mesh/v1alpha1"
+	mesh_core "github.com/Kong/kuma/pkg/core/resources/apis/mesh"
+	core_xds "github.com/Kong/kuma/pkg/core/xds"
+)
+
+var (
+	// protocolStack is a mapping between a protocol and its full protocol stack, e.g.
+	// HTTP has a protocol stack [HTTP, TCP],
+	// GRPC has a protocol stack [GRPC, HTTP2, TCP],
+	// TCP  has a protocol stack [TCP].
+	protocolStacks = map[mesh_core.Protocol]mesh_core.ProtocolList{
+		mesh_core.ProtocolHTTP: mesh_core.ProtocolList{mesh_core.ProtocolHTTP, mesh_core.ProtocolTCP},
+		mesh_core.ProtocolTCP:  mesh_core.ProtocolList{mesh_core.ProtocolTCP},
+	}
+)
+
+// GetCommonProtocol returns a common protocol between given two.
+//
+// E.g.,
+// a common protocol between HTTP and HTTP  is HTTP,
+// a common protocol between HTTP and TCP   is TCP,
+// a common protocol between GRPC and HTTP2 is HTTP2,
+// a common protocol between HTTP and HTTP2 is TCP.
+func GetCommonProtocol(one, another mesh_core.Protocol) mesh_core.Protocol {
+	if one == another {
+		return one
+	}
+	if one == mesh_core.ProtocolUnknown || another == mesh_core.ProtocolUnknown {
+		return mesh_core.ProtocolUnknown
+	}
+	oneProtocolStack, exist := protocolStacks[one]
+	if !exist {
+		return mesh_core.ProtocolUnknown
+	}
+	anotherProtocolStack, exist := protocolStacks[another]
+	if !exist {
+		return mesh_core.ProtocolUnknown
+	}
+	for _, firstProtocol := range oneProtocolStack {
+		for _, secondProtocol := range anotherProtocolStack {
+			if firstProtocol == secondProtocol {
+				return firstProtocol
+			}
+		}
+	}
+	return mesh_core.ProtocolUnknown
+}
+
+// InferServiceProtocol returns a common protocol for a given group of endpoints.
+func InferServiceProtocol(endpoints []core_xds.Endpoint) mesh_core.Protocol {
+	if len(endpoints) == 0 {
+		return mesh_core.ProtocolUnknown
+	}
+	serviceProtocol := mesh_core.ParseProtocol(endpoints[0].Tags[mesh_proto.ProtocolTag])
+	for _, endpoint := range endpoints[1:] {
+		endpointProtocol := mesh_core.ParseProtocol(endpoint.Tags[mesh_proto.ProtocolTag])
+		serviceProtocol = GetCommonProtocol(serviceProtocol, endpointProtocol)
+	}
+	return serviceProtocol
+}

--- a/pkg/xds/generator/protocol_private_test.go
+++ b/pkg/xds/generator/protocol_private_test.go
@@ -1,0 +1,71 @@
+package generator
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/ginkgo/extensions/table"
+	. "github.com/onsi/gomega"
+
+	mesh_core "github.com/Kong/kuma/pkg/core/resources/apis/mesh"
+)
+
+var _ = Describe("getCommonProtocol()", func() {
+	type testCase struct {
+		one      mesh_core.Protocol
+		another  mesh_core.Protocol
+		expected mesh_core.Protocol
+	}
+
+	DescribeTable("should correctly determine common protocol",
+		func(given testCase) {
+			// when
+			actual := getCommonProtocol(given.one, given.another)
+			// then
+			Expect(actual).To(Equal(given.expected))
+		},
+		Entry("`unknown` and `unknown`", testCase{
+			one:      mesh_core.ProtocolUnknown,
+			another:  mesh_core.ProtocolUnknown,
+			expected: mesh_core.ProtocolUnknown,
+		}),
+		Entry("`unknown` and `http`", testCase{
+			one:      mesh_core.ProtocolUnknown,
+			another:  mesh_core.ProtocolHTTP,
+			expected: mesh_core.ProtocolUnknown,
+		}),
+		Entry("`http` and `unknown`", testCase{
+			one:      mesh_core.ProtocolHTTP,
+			another:  mesh_core.ProtocolUnknown,
+			expected: mesh_core.ProtocolUnknown,
+		}),
+		Entry("`unknown` and `tcp`", testCase{
+			one:      mesh_core.ProtocolUnknown,
+			another:  mesh_core.ProtocolTCP,
+			expected: mesh_core.ProtocolUnknown,
+		}),
+		Entry("`tcp` and `unknown`", testCase{
+			one:      mesh_core.ProtocolTCP,
+			another:  mesh_core.ProtocolUnknown,
+			expected: mesh_core.ProtocolUnknown,
+		}),
+		Entry("`http` and `tcp`", testCase{
+			one:      mesh_core.ProtocolHTTP,
+			another:  mesh_core.ProtocolTCP,
+			expected: mesh_core.ProtocolTCP,
+		}),
+		Entry("`tcp` and `http`", testCase{
+			one:      mesh_core.ProtocolTCP,
+			another:  mesh_core.ProtocolHTTP,
+			expected: mesh_core.ProtocolTCP,
+		}),
+		Entry("`http` and `http`", testCase{
+			one:      mesh_core.ProtocolHTTP,
+			another:  mesh_core.ProtocolHTTP,
+			expected: mesh_core.ProtocolHTTP,
+		}),
+		Entry("`tcp` and `tcp`", testCase{
+			one:      mesh_core.ProtocolTCP,
+			another:  mesh_core.ProtocolTCP,
+			expected: mesh_core.ProtocolTCP,
+		}),
+	)
+})

--- a/pkg/xds/generator/protocol_test.go
+++ b/pkg/xds/generator/protocol_test.go
@@ -1,0 +1,154 @@
+package generator_test
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/ginkgo/extensions/table"
+	. "github.com/onsi/gomega"
+
+	. "github.com/Kong/kuma/pkg/xds/generator"
+
+	mesh_core "github.com/Kong/kuma/pkg/core/resources/apis/mesh"
+	core_xds "github.com/Kong/kuma/pkg/core/xds"
+)
+
+var _ = Describe("GetCommonProtocol()", func() {
+	type testCase struct {
+		one      mesh_core.Protocol
+		another  mesh_core.Protocol
+		expected mesh_core.Protocol
+	}
+
+	DescribeTable("should correctly determine common protocol",
+		func(given testCase) {
+			// when
+			actual := GetCommonProtocol(given.one, given.another)
+			// then
+			Expect(actual).To(Equal(given.expected))
+		},
+		Entry("`unknown` and `unknown`", testCase{
+			one:      mesh_core.ProtocolUnknown,
+			another:  mesh_core.ProtocolUnknown,
+			expected: mesh_core.ProtocolUnknown,
+		}),
+		Entry("`unknown` and `http`", testCase{
+			one:      mesh_core.ProtocolUnknown,
+			another:  mesh_core.ProtocolHTTP,
+			expected: mesh_core.ProtocolUnknown,
+		}),
+		Entry("`http` and `unknown`", testCase{
+			one:      mesh_core.ProtocolHTTP,
+			another:  mesh_core.ProtocolUnknown,
+			expected: mesh_core.ProtocolUnknown,
+		}),
+		Entry("`unknown` and `tcp`", testCase{
+			one:      mesh_core.ProtocolUnknown,
+			another:  mesh_core.ProtocolTCP,
+			expected: mesh_core.ProtocolUnknown,
+		}),
+		Entry("`tcp` and `unknown`", testCase{
+			one:      mesh_core.ProtocolTCP,
+			another:  mesh_core.ProtocolUnknown,
+			expected: mesh_core.ProtocolUnknown,
+		}),
+		Entry("`http` and `tcp`", testCase{
+			one:      mesh_core.ProtocolHTTP,
+			another:  mesh_core.ProtocolTCP,
+			expected: mesh_core.ProtocolTCP,
+		}),
+		Entry("`tcp` and `http`", testCase{
+			one:      mesh_core.ProtocolTCP,
+			another:  mesh_core.ProtocolHTTP,
+			expected: mesh_core.ProtocolTCP,
+		}),
+		Entry("`http` and `http`", testCase{
+			one:      mesh_core.ProtocolHTTP,
+			another:  mesh_core.ProtocolHTTP,
+			expected: mesh_core.ProtocolHTTP,
+		}),
+		Entry("`tcp` and `tcp`", testCase{
+			one:      mesh_core.ProtocolTCP,
+			another:  mesh_core.ProtocolTCP,
+			expected: mesh_core.ProtocolTCP,
+		}),
+	)
+})
+
+var _ = Describe("InferServiceProtocol()", func() {
+
+	type testCase struct {
+		endpoints []core_xds.Endpoint
+		expected  mesh_core.Protocol
+	}
+
+	DescribeTable("should correctly infer common protocol for a group of endpoints",
+		func(given testCase) {
+			// when
+			actual := InferServiceProtocol(given.endpoints)
+			// then
+			Expect(actual).To(Equal(given.expected))
+		},
+		Entry("empty list", testCase{
+			endpoints: nil,
+			expected:  mesh_core.ProtocolUnknown,
+		}),
+		Entry("one-item list: no `protocol` tag", testCase{
+			endpoints: []core_xds.Endpoint{
+				{Tags: map[string]string{"service": "backend"}},
+			},
+			expected: mesh_core.ProtocolUnknown,
+		}),
+		Entry("one-item list: `protocol: http`", testCase{
+			endpoints: []core_xds.Endpoint{
+				{Tags: map[string]string{"service": "backend", "protocol": "http"}},
+			},
+			expected: mesh_core.ProtocolHTTP,
+		}),
+		Entry("one-item list: `protocol: tcp`", testCase{
+			endpoints: []core_xds.Endpoint{
+				{Tags: map[string]string{"service": "backend", "protocol": "tcp"}},
+			},
+			expected: mesh_core.ProtocolTCP,
+		}),
+		Entry("one-item list: `protocol: not-yet-supported-protocol`", testCase{
+			endpoints: []core_xds.Endpoint{
+				{Tags: map[string]string{"service": "backend", "protocol": "not-yet-supported-protocol"}},
+			},
+			expected: mesh_core.ProtocolUnknown,
+		}),
+		Entry("multi-item list: no `protocol` tag", testCase{
+			endpoints: []core_xds.Endpoint{
+				{Tags: map[string]string{"service": "backend", "region": "us"}},
+				{Tags: map[string]string{"service": "backend", "region": "eu"}},
+			},
+			expected: mesh_core.ProtocolUnknown,
+		}),
+		Entry("multi-item list: no `protocol` tag on some endpoints", testCase{
+			endpoints: []core_xds.Endpoint{
+				{Tags: map[string]string{"service": "backend", "region": "us", "protocol": "http"}},
+				{Tags: map[string]string{"service": "backend", "region": "eu"}},
+			},
+			expected: mesh_core.ProtocolUnknown,
+		}),
+		Entry("multi-item list: `protocol: http` on every endpoint", testCase{
+			endpoints: []core_xds.Endpoint{
+				{Tags: map[string]string{"service": "backend", "region": "us", "protocol": "http"}},
+				{Tags: map[string]string{"service": "backend", "region": "eu", "protocol": "http"}},
+			},
+			expected: mesh_core.ProtocolHTTP,
+		}),
+		Entry("multi-item list: `protocol: tcp` on every endpoint", testCase{
+			endpoints: []core_xds.Endpoint{
+				{Tags: map[string]string{"service": "backend", "region": "us", "protocol": "tcp"}},
+				{Tags: map[string]string{"service": "backend", "region": "eu", "protocol": "tcp"}},
+			},
+			expected: mesh_core.ProtocolTCP,
+		}),
+		Entry("multi-item list: `protocol: tcp` and `protocol: http`", testCase{
+			endpoints: []core_xds.Endpoint{
+				{Tags: map[string]string{"service": "backend", "region": "us", "protocol": "tcp"}},
+				{Tags: map[string]string{"service": "backend", "region": "eu", "protocol": "http"}},
+			},
+			expected: mesh_core.ProtocolTCP,
+		}),
+	)
+})

--- a/pkg/xds/generator/protocol_test.go
+++ b/pkg/xds/generator/protocol_test.go
@@ -11,68 +11,6 @@ import (
 	core_xds "github.com/Kong/kuma/pkg/core/xds"
 )
 
-var _ = Describe("GetCommonProtocol()", func() {
-	type testCase struct {
-		one      mesh_core.Protocol
-		another  mesh_core.Protocol
-		expected mesh_core.Protocol
-	}
-
-	DescribeTable("should correctly determine common protocol",
-		func(given testCase) {
-			// when
-			actual := GetCommonProtocol(given.one, given.another)
-			// then
-			Expect(actual).To(Equal(given.expected))
-		},
-		Entry("`unknown` and `unknown`", testCase{
-			one:      mesh_core.ProtocolUnknown,
-			another:  mesh_core.ProtocolUnknown,
-			expected: mesh_core.ProtocolUnknown,
-		}),
-		Entry("`unknown` and `http`", testCase{
-			one:      mesh_core.ProtocolUnknown,
-			another:  mesh_core.ProtocolHTTP,
-			expected: mesh_core.ProtocolUnknown,
-		}),
-		Entry("`http` and `unknown`", testCase{
-			one:      mesh_core.ProtocolHTTP,
-			another:  mesh_core.ProtocolUnknown,
-			expected: mesh_core.ProtocolUnknown,
-		}),
-		Entry("`unknown` and `tcp`", testCase{
-			one:      mesh_core.ProtocolUnknown,
-			another:  mesh_core.ProtocolTCP,
-			expected: mesh_core.ProtocolUnknown,
-		}),
-		Entry("`tcp` and `unknown`", testCase{
-			one:      mesh_core.ProtocolTCP,
-			another:  mesh_core.ProtocolUnknown,
-			expected: mesh_core.ProtocolUnknown,
-		}),
-		Entry("`http` and `tcp`", testCase{
-			one:      mesh_core.ProtocolHTTP,
-			another:  mesh_core.ProtocolTCP,
-			expected: mesh_core.ProtocolTCP,
-		}),
-		Entry("`tcp` and `http`", testCase{
-			one:      mesh_core.ProtocolTCP,
-			another:  mesh_core.ProtocolHTTP,
-			expected: mesh_core.ProtocolTCP,
-		}),
-		Entry("`http` and `http`", testCase{
-			one:      mesh_core.ProtocolHTTP,
-			another:  mesh_core.ProtocolHTTP,
-			expected: mesh_core.ProtocolHTTP,
-		}),
-		Entry("`tcp` and `tcp`", testCase{
-			one:      mesh_core.ProtocolTCP,
-			another:  mesh_core.ProtocolTCP,
-			expected: mesh_core.ProtocolTCP,
-		}),
-	)
-})
-
 var _ = Describe("InferServiceProtocol()", func() {
 
 	type testCase struct {

--- a/pkg/xds/generator/proxy_template.go
+++ b/pkg/xds/generator/proxy_template.go
@@ -2,8 +2,6 @@ package generator
 
 import (
 	"fmt"
-	"sort"
-	"strings"
 
 	"github.com/pkg/errors"
 
@@ -18,6 +16,7 @@ import (
 	envoy_clusters "github.com/Kong/kuma/pkg/xds/envoy/clusters"
 	envoy_endpoints "github.com/Kong/kuma/pkg/xds/envoy/endpoints"
 	envoy_listeners "github.com/Kong/kuma/pkg/xds/envoy/listeners"
+	envoy_routes "github.com/Kong/kuma/pkg/xds/envoy/routes"
 )
 
 type TemplateProxyGenerator struct {
@@ -111,13 +110,28 @@ func (g InboundProxyGenerator) Generate(ctx xds_context.Context, proxy *model.Pr
 		iface := proxy.Dataplane.Spec.Networking.Inbound[i]
 		service := iface.GetService()
 		protocol := mesh_core.ParseProtocol(iface.GetProtocol())
-		inboundListenerName := localListenerName(endpoint.DataplaneIP, endpoint.DataplanePort)
+		inboundListenerName := inboundListenerName(endpoint.DataplaneIP, endpoint.DataplanePort)
+		filterChainBuilder := func() *envoy_listeners.FilterChainBuilder {
+			filterChainBuilder := envoy_listeners.NewFilterChainBuilder()
+			switch protocol {
+			case mesh_core.ProtocolHTTP:
+				// configuration for HTTP case
+				filterChainBuilder.
+					Configure(envoy_listeners.HttpConnectionManager(localClusterName)).
+					Configure(envoy_listeners.HttpInboundRoute(service, envoy_common.ClusterInfo{Name: localClusterName}))
+			case mesh_core.ProtocolTCP:
+				fallthrough
+			default:
+				// configuration for non-HTTP cases
+				filterChainBuilder.Configure(envoy_listeners.TcpProxy(localClusterName, envoy_common.ClusterInfo{Name: localClusterName}))
+			}
+			return filterChainBuilder.
+				Configure(envoy_listeners.ServerSideMTLS(ctx, proxy.Metadata)).
+				Configure(envoy_listeners.NetworkRBAC(inboundListenerName, ctx.Mesh.Resource.Spec.GetMtls().GetEnabled(), proxy.TrafficPermissions.Get(endpoint)))
+		}()
 		inboundListener, err := envoy_listeners.NewListenerBuilder().
 			Configure(envoy_listeners.InboundListener(inboundListenerName, endpoint.DataplaneIP, endpoint.DataplanePort)).
-			Configure(envoy_listeners.FilterChain(envoy_listeners.NewFilterChainBuilder().
-				Configure(g.protocolSpecificOpts(service, protocol, envoy_common.ClusterInfo{Name: localClusterName})...).
-				Configure(envoy_listeners.ServerSideMTLS(ctx, proxy.Metadata)).
-				Configure(envoy_listeners.NetworkRBAC(inboundListenerName, ctx.Mesh.Resource.Spec.GetMtls().GetEnabled(), proxy.TrafficPermissions.Get(endpoint))))).
+			Configure(envoy_listeners.FilterChain(filterChainBuilder)).
 			Configure(envoy_listeners.TransparentProxying(proxy.Dataplane.Spec.Networking.GetTransparentProxying())).
 			Build()
 		if err != nil {
@@ -132,41 +146,25 @@ func (g InboundProxyGenerator) Generate(ctx xds_context.Context, proxy *model.Pr
 	return resources.List(), nil
 }
 
-func (_ InboundProxyGenerator) protocolSpecificOpts(service string, protocol mesh_core.Protocol, localCluster envoy_common.ClusterInfo) []envoy_listeners.FilterChainBuilderOpt {
-	switch protocol {
-	case mesh_core.ProtocolHTTP:
-		return []envoy_listeners.FilterChainBuilderOpt{
-			envoy_listeners.HttpConnectionManager(localCluster.Name),
-			envoy_listeners.HttpInboundRoute(service, localCluster),
-		}
-	case mesh_core.ProtocolTCP:
-		fallthrough
-	default:
-		return []envoy_listeners.FilterChainBuilderOpt{
-			envoy_listeners.TcpProxy(localCluster.Name, localCluster),
-		}
-	}
-}
-
 type OutboundProxyGenerator struct {
 }
 
 func (g OutboundProxyGenerator) Generate(ctx xds_context.Context, proxy *model.Proxy) ([]*model.Resource, error) {
-	ofaces := proxy.Dataplane.Spec.Networking.GetOutbound()
-	if len(ofaces) == 0 {
+	outbounds := proxy.Dataplane.Spec.Networking.GetOutbound()
+	if len(outbounds) == 0 {
 		return nil, nil
 	}
 	resources := &model.ResourceSet{}
 	sourceService := proxy.Dataplane.Spec.GetIdentifyingService()
-	endpoints, err := proxy.Dataplane.Spec.Networking.GetOutboundInterfaces()
+	ofaces, err := proxy.Dataplane.Spec.Networking.GetOutboundInterfaces()
 	if err != nil {
 		return nil, err
 	}
-	for i, oface := range ofaces {
+	for i, outbound := range outbounds {
 		// pick a route
-		route := proxy.TrafficRoutes[oface.Service]
+		route := proxy.TrafficRoutes[outbound.Service]
 		if route == nil {
-			return nil, errors.Errorf("%s{service=%q}: has no TrafficRoute", validators.RootedAt("dataplane").Field("networking").Field("outbound").Index(i), oface.Service)
+			return nil, errors.Errorf("%s{service=%q}: has no TrafficRoute", validators.RootedAt("dataplane").Field("networking").Field("outbound").Index(i), outbound.Service)
 		}
 
 		// determine the list of destination clusters
@@ -176,21 +174,39 @@ func (g OutboundProxyGenerator) Generate(ctx xds_context.Context, proxy *model.P
 		}
 
 		// generate CDS and EDS resources
-		edsResources, err := g.generateEds(ctx, proxy, clusters)
+		edsResources, endpoints, err := g.generateEds(ctx, proxy, clusters)
 		if err != nil {
 			return nil, err
 		}
 		resources.Add(edsResources...)
 
-		// generate LDS resource
-		outboundListenerName := fmt.Sprintf("outbound:%s:%d", endpoints[i].DataplaneIP, endpoints[i].DataplanePort)
-		destinationService := oface.Service
+		protocol := InferServiceProtocol(endpoints)
 
+		// generate LDS resource
+		outboundListenerName := outboundListenerName(ofaces[i].DataplaneIP, ofaces[i].DataplanePort)
+		outboundRouteName := outboundRouteName(outbound.Service)
+		destinationService := outbound.Service
+
+		filterChainBuilder := func() *envoy_listeners.FilterChainBuilder {
+			filterChainBuilder := envoy_listeners.NewFilterChainBuilder()
+			switch protocol {
+			case mesh_core.ProtocolHTTP:
+				// configuration for HTTP case
+				filterChainBuilder.
+					Configure(envoy_listeners.HttpConnectionManager(outbound.Service)).
+					Configure(envoy_listeners.HttpOutboundRoute(outboundRouteName))
+			case mesh_core.ProtocolTCP:
+				fallthrough
+			default:
+				// configuration for non-HTTP cases
+				filterChainBuilder.Configure(envoy_listeners.TcpProxy(outbound.Service, clusters...))
+			}
+			// TODO(yskopets): configure NetworkAccessLog only for non-HTTP cases
+			return filterChainBuilder.Configure(envoy_listeners.NetworkAccessLog(sourceService, destinationService, proxy.Logs[outbound.Service], proxy))
+		}()
 		listener, err := envoy_listeners.NewListenerBuilder().
-			Configure(envoy_listeners.OutboundListener(outboundListenerName, endpoints[i].DataplaneIP, endpoints[i].DataplanePort)).
-			Configure(envoy_listeners.FilterChain(envoy_listeners.NewFilterChainBuilder().
-				Configure(envoy_listeners.TcpProxy(oface.Service, clusters...)).
-				Configure(envoy_listeners.NetworkAccessLog(sourceService, destinationService, proxy.Logs[oface.Service], proxy)))).
+			Configure(envoy_listeners.OutboundListener(outboundListenerName, ofaces[i].DataplaneIP, ofaces[i].DataplanePort)).
+			Configure(envoy_listeners.FilterChain(filterChainBuilder)).
 			Configure(envoy_listeners.TransparentProxying(proxy.Dataplane.Spec.Networking.GetTransparentProxying())).
 			Build()
 		if err != nil {
@@ -200,6 +216,13 @@ func (g OutboundProxyGenerator) Generate(ctx xds_context.Context, proxy *model.P
 			Name:     outboundListenerName,
 			Resource: listener,
 		})
+
+		// generate RDS resources
+		rdsResources, err := g.generateRds(protocol, outbound.Service, outboundRouteName, clusters)
+		if err != nil {
+			return nil, err
+		}
+		resources.Add(rdsResources...)
 	}
 	return resources.List(), nil
 }
@@ -223,13 +246,13 @@ func (_ OutboundProxyGenerator) determineClusters(ctx xds_context.Context, proxy
 	return
 }
 
-func (_ OutboundProxyGenerator) generateEds(ctx xds_context.Context, proxy *model.Proxy, clusters []envoy_common.ClusterInfo) (resources []*model.Resource, _ error) {
+func (_ OutboundProxyGenerator) generateEds(ctx xds_context.Context, proxy *model.Proxy, clusters []envoy_common.ClusterInfo) (resources []*model.Resource, allEndpoints []model.Endpoint, _ error) {
 	for _, cluster := range clusters {
 		serviceName := cluster.Tags[kuma_mesh.ServiceTag]
 		healthCheck := proxy.HealthChecks[serviceName]
 		edsCluster, err := envoy_clusters.CreateEdsCluster(ctx, cluster.Name, proxy.Metadata)
 		if err != nil {
-			return nil, err
+			return nil, nil, err
 		}
 		resources = append(resources, &model.Resource{
 			Name:     cluster.Name,
@@ -240,8 +263,31 @@ func (_ OutboundProxyGenerator) generateEds(ctx xds_context.Context, proxy *mode
 			Name:     cluster.Name,
 			Resource: envoy_endpoints.CreateClusterLoadAssignment(cluster.Name, endpoints),
 		})
+		allEndpoints = append(allEndpoints, endpoints...)
 	}
 	return
+}
+
+func (_ OutboundProxyGenerator) generateRds(protocol mesh_core.Protocol, service string, outboundRouteName string, clusters []envoy_common.ClusterInfo) ([]*model.Resource, error) {
+	resources := &model.ResourceSet{}
+	switch protocol {
+	case mesh_core.ProtocolHTTP:
+		// generate RDS resource
+		routeConfiguration, err := envoy_routes.NewRouteConfigurationBuilder().
+			Configure(envoy_routes.CommonRouteConfiguration(outboundRouteName)).
+			Configure(envoy_routes.VirtualHost(envoy_routes.NewVirtualHostBuilder().
+				Configure(envoy_routes.CommonVirtualHost(service)).
+				Configure(envoy_routes.DefaultRoute(clusters...)))).
+			Build()
+		if err != nil {
+			return nil, err
+		}
+		resources.Add(&model.Resource{
+			Name:     outboundRouteName,
+			Resource: routeConfiguration,
+		})
+	}
+	return resources.List(), nil
 }
 
 type TransparentProxyGenerator struct {
@@ -273,19 +319,4 @@ func (_ TransparentProxyGenerator) Generate(ctx xds_context.Context, proxy *mode
 			Resource: envoy_clusters.CreatePassThroughCluster("pass_through"),
 		},
 	}, nil
-}
-
-func destinationClusterName(service string, selector map[string]string) string {
-	var pairs []string
-	for key, value := range selector {
-		if key == kuma_mesh.ServiceTag {
-			continue
-		}
-		pairs = append(pairs, fmt.Sprintf("%s=%s", key, value))
-	}
-	if len(pairs) == 0 {
-		return service
-	}
-	sort.Strings(pairs)
-	return fmt.Sprintf("%s{%s}", service, strings.Join(pairs, ","))
 }

--- a/pkg/xds/generator/resource_names.go
+++ b/pkg/xds/generator/resource_names.go
@@ -2,14 +2,26 @@ package generator
 
 import (
 	"fmt"
+	"sort"
+	"strings"
+
+	mesh_proto "github.com/Kong/kuma/api/mesh/v1alpha1"
 )
 
 func localClusterName(port uint32) string {
 	return fmt.Sprintf("localhost:%d", port)
 }
 
-func localListenerName(address string, port uint32) string {
+func inboundListenerName(address string, port uint32) string {
 	return fmt.Sprintf("inbound:%s:%d", address, port)
+}
+
+func outboundListenerName(address string, port uint32) string {
+	return fmt.Sprintf("outbound:%s:%d", address, port)
+}
+
+func outboundRouteName(service string) string {
+	return fmt.Sprintf("outbound:%s", service)
 }
 
 func envoyAdminClusterName() string {
@@ -18,4 +30,19 @@ func envoyAdminClusterName() string {
 
 func prometheusListenerName() string {
 	return "kuma:metrics:prometheus"
+}
+
+func destinationClusterName(service string, selector map[string]string) string {
+	var pairs []string
+	for key, value := range selector {
+		if key == mesh_proto.ServiceTag {
+			continue
+		}
+		pairs = append(pairs, fmt.Sprintf("%s=%s", key, value))
+	}
+	if len(pairs) == 0 {
+		return service
+	}
+	sort.Strings(pairs)
+	return fmt.Sprintf("%s{%s}", service, strings.Join(pairs, ","))
 }

--- a/pkg/xds/generator/testdata/outbound-proxy/09.envoy.golden.yaml
+++ b/pkg/xds/generator/testdata/outbound-proxy/09.envoy.golden.yaml
@@ -1,0 +1,225 @@
+resources:
+- name: backend
+  resource:
+    '@type': type.googleapis.com/envoy.api.v2.Cluster
+    connectTimeout: 5s
+    edsClusterConfig:
+      edsConfig:
+        ads: {}
+    name: backend
+    type: EDS
+- name: backend
+  resource:
+    '@type': type.googleapis.com/envoy.api.v2.ClusterLoadAssignment
+    clusterName: backend
+    endpoints:
+    - lbEndpoints:
+      - endpoint:
+          address:
+            socketAddress:
+              address: 192.168.0.1
+              portValue: 8081
+        metadata:
+          filterMetadata:
+            envoy.lb:
+              region: us
+              service: backend
+- name: outbound:127.0.0.1:18080
+  resource:
+    '@type': type.googleapis.com/envoy.api.v2.Listener
+    address:
+      socketAddress:
+        address: 127.0.0.1
+        portValue: 18080
+    filterChains:
+    - filters:
+      - name: envoy.tcp_proxy
+        typedConfig:
+          '@type': type.googleapis.com/envoy.config.filter.network.tcp_proxy.v2.TcpProxy
+          cluster: backend
+          statPrefix: backend
+    name: outbound:127.0.0.1:18080
+- name: db{role=master}
+  resource:
+    '@type': type.googleapis.com/envoy.api.v2.Cluster
+    altStatName: db_role_master_
+    connectTimeout: 5s
+    edsClusterConfig:
+      edsConfig:
+        ads: {}
+    name: db{role=master}
+    type: EDS
+- name: db{role=master}
+  resource:
+    '@type': type.googleapis.com/envoy.api.v2.ClusterLoadAssignment
+    clusterName: db{role=master}
+    endpoints:
+    - lbEndpoints:
+      - endpoint:
+          address:
+            socketAddress:
+              address: 192.168.0.3
+              portValue: 5432
+        metadata:
+          filterMetadata:
+            envoy.lb:
+              role: master
+              service: db
+- name: db{role=replica}
+  resource:
+    '@type': type.googleapis.com/envoy.api.v2.Cluster
+    altStatName: db_role_replica_
+    connectTimeout: 5s
+    edsClusterConfig:
+      edsConfig:
+        ads: {}
+    name: db{role=replica}
+    type: EDS
+- name: db{role=replica}
+  resource:
+    '@type': type.googleapis.com/envoy.api.v2.ClusterLoadAssignment
+    clusterName: db{role=replica}
+    endpoints:
+    - {}
+- name: outbound:127.0.0.1:54321
+  resource:
+    '@type': type.googleapis.com/envoy.api.v2.Listener
+    address:
+      socketAddress:
+        address: 127.0.0.1
+        portValue: 54321
+    filterChains:
+    - filters:
+      - name: envoy.tcp_proxy
+        typedConfig:
+          '@type': type.googleapis.com/envoy.config.filter.network.tcp_proxy.v2.TcpProxy
+          statPrefix: db
+          weightedClusters:
+            clusters:
+            - name: db{role=master}
+              weight: 10
+            - name: db{role=replica}
+              weight: 90
+    name: outbound:127.0.0.1:54321
+- name: api-http
+  resource:
+    '@type': type.googleapis.com/envoy.api.v2.Cluster
+    connectTimeout: 5s
+    edsClusterConfig:
+      edsConfig:
+        ads: {}
+    name: api-http
+    type: EDS
+- name: api-http
+  resource:
+    '@type': type.googleapis.com/envoy.api.v2.ClusterLoadAssignment
+    clusterName: api-http
+    endpoints:
+    - lbEndpoints:
+      - endpoint:
+          address:
+            socketAddress:
+              address: 192.168.0.4
+              portValue: 8084
+        metadata:
+          filterMetadata:
+            envoy.lb:
+              protocol: http
+              region: us
+              service: api-http
+      - endpoint:
+          address:
+            socketAddress:
+              address: 192.168.0.5
+              portValue: 8085
+        metadata:
+          filterMetadata:
+            envoy.lb:
+              protocol: http
+              region: eu
+              service: api-http
+- name: outbound:127.0.0.1:40001
+  resource:
+    '@type': type.googleapis.com/envoy.api.v2.Listener
+    address:
+      socketAddress:
+        address: 127.0.0.1
+        portValue: 40001
+    filterChains:
+    - filters:
+      - name: envoy.http_connection_manager
+        typedConfig:
+          '@type': type.googleapis.com/envoy.config.filter.network.http_connection_manager.v2.HttpConnectionManager
+          httpFilters:
+          - name: envoy.router
+          rds:
+            configSource:
+              ads: {}
+            routeConfigName: outbound:api-http
+          statPrefix: api-http
+    name: outbound:127.0.0.1:40001
+- name: outbound:api-http
+  resource:
+    '@type': type.googleapis.com/envoy.api.v2.RouteConfiguration
+    name: outbound:api-http
+    validateClusters: true
+    virtualHosts:
+    - domains:
+      - '*'
+      name: api-http
+      routes:
+      - match:
+          prefix: /
+        route:
+          cluster: api-http
+- name: api-tcp
+  resource:
+    '@type': type.googleapis.com/envoy.api.v2.Cluster
+    connectTimeout: 5s
+    edsClusterConfig:
+      edsConfig:
+        ads: {}
+    name: api-tcp
+    type: EDS
+- name: api-tcp
+  resource:
+    '@type': type.googleapis.com/envoy.api.v2.ClusterLoadAssignment
+    clusterName: api-tcp
+    endpoints:
+    - lbEndpoints:
+      - endpoint:
+          address:
+            socketAddress:
+              address: 192.168.0.6
+              portValue: 8086
+        metadata:
+          filterMetadata:
+            envoy.lb:
+              protocol: http
+              region: us
+              service: api-tcp
+      - endpoint:
+          address:
+            socketAddress:
+              address: 192.168.0.7
+              portValue: 8087
+        metadata:
+          filterMetadata:
+            envoy.lb:
+              region: eu
+              service: api-tcp
+- name: outbound:127.0.0.1:40002
+  resource:
+    '@type': type.googleapis.com/envoy.api.v2.Listener
+    address:
+      socketAddress:
+        address: 127.0.0.1
+        portValue: 40002
+    filterChains:
+    - filters:
+      - name: envoy.tcp_proxy
+        typedConfig:
+          '@type': type.googleapis.com/envoy.config.filter.network.tcp_proxy.v2.TcpProxy
+          cluster: api-tcp
+          statPrefix: api-tcp
+    name: outbound:127.0.0.1:40002

--- a/pkg/xds/generator/testdata/outbound-proxy/10.envoy.golden.yaml
+++ b/pkg/xds/generator/testdata/outbound-proxy/10.envoy.golden.yaml
@@ -1,0 +1,373 @@
+resources:
+- name: backend
+  resource:
+    '@type': type.googleapis.com/envoy.api.v2.Cluster
+    connectTimeout: 5s
+    edsClusterConfig:
+      edsConfig:
+        ads: {}
+    name: backend
+    tlsContext:
+      commonTlsContext:
+        tlsCertificateSdsSecretConfigs:
+        - name: identity_cert
+          sdsConfig:
+            apiConfigSource:
+              apiType: GRPC
+              grpcServices:
+              - googleGrpc:
+                  channelCredentials:
+                    sslCredentials:
+                      rootCerts:
+                        inlineBytes: MTIzNDU=
+                  statPrefix: sds_identity_cert
+                  targetUri: kuma-system:5677
+        validationContextSdsSecretConfig:
+          name: mesh_ca
+          sdsConfig:
+            apiConfigSource:
+              apiType: GRPC
+              grpcServices:
+              - googleGrpc:
+                  channelCredentials:
+                    sslCredentials:
+                      rootCerts:
+                        inlineBytes: MTIzNDU=
+                  statPrefix: sds_mesh_ca
+                  targetUri: kuma-system:5677
+    type: EDS
+- name: backend
+  resource:
+    '@type': type.googleapis.com/envoy.api.v2.ClusterLoadAssignment
+    clusterName: backend
+    endpoints:
+    - lbEndpoints:
+      - endpoint:
+          address:
+            socketAddress:
+              address: 192.168.0.1
+              portValue: 8081
+        metadata:
+          filterMetadata:
+            envoy.lb:
+              region: us
+              service: backend
+- name: outbound:127.0.0.1:18080
+  resource:
+    '@type': type.googleapis.com/envoy.api.v2.Listener
+    address:
+      socketAddress:
+        address: 127.0.0.1
+        portValue: 18080
+    deprecatedV1:
+      bindToPort: false
+    filterChains:
+    - filters:
+      - name: envoy.tcp_proxy
+        typedConfig:
+          '@type': type.googleapis.com/envoy.config.filter.network.tcp_proxy.v2.TcpProxy
+          cluster: backend
+          statPrefix: backend
+    name: outbound:127.0.0.1:18080
+- name: db{role=master}
+  resource:
+    '@type': type.googleapis.com/envoy.api.v2.Cluster
+    altStatName: db_role_master_
+    connectTimeout: 5s
+    edsClusterConfig:
+      edsConfig:
+        ads: {}
+    name: db{role=master}
+    tlsContext:
+      commonTlsContext:
+        tlsCertificateSdsSecretConfigs:
+        - name: identity_cert
+          sdsConfig:
+            apiConfigSource:
+              apiType: GRPC
+              grpcServices:
+              - googleGrpc:
+                  channelCredentials:
+                    sslCredentials:
+                      rootCerts:
+                        inlineBytes: MTIzNDU=
+                  statPrefix: sds_identity_cert
+                  targetUri: kuma-system:5677
+        validationContextSdsSecretConfig:
+          name: mesh_ca
+          sdsConfig:
+            apiConfigSource:
+              apiType: GRPC
+              grpcServices:
+              - googleGrpc:
+                  channelCredentials:
+                    sslCredentials:
+                      rootCerts:
+                        inlineBytes: MTIzNDU=
+                  statPrefix: sds_mesh_ca
+                  targetUri: kuma-system:5677
+    type: EDS
+- name: db{role=master}
+  resource:
+    '@type': type.googleapis.com/envoy.api.v2.ClusterLoadAssignment
+    clusterName: db{role=master}
+    endpoints:
+    - lbEndpoints:
+      - endpoint:
+          address:
+            socketAddress:
+              address: 192.168.0.3
+              portValue: 5432
+        metadata:
+          filterMetadata:
+            envoy.lb:
+              role: master
+              service: db
+- name: db{role=replica}
+  resource:
+    '@type': type.googleapis.com/envoy.api.v2.Cluster
+    altStatName: db_role_replica_
+    connectTimeout: 5s
+    edsClusterConfig:
+      edsConfig:
+        ads: {}
+    name: db{role=replica}
+    tlsContext:
+      commonTlsContext:
+        tlsCertificateSdsSecretConfigs:
+        - name: identity_cert
+          sdsConfig:
+            apiConfigSource:
+              apiType: GRPC
+              grpcServices:
+              - googleGrpc:
+                  channelCredentials:
+                    sslCredentials:
+                      rootCerts:
+                        inlineBytes: MTIzNDU=
+                  statPrefix: sds_identity_cert
+                  targetUri: kuma-system:5677
+        validationContextSdsSecretConfig:
+          name: mesh_ca
+          sdsConfig:
+            apiConfigSource:
+              apiType: GRPC
+              grpcServices:
+              - googleGrpc:
+                  channelCredentials:
+                    sslCredentials:
+                      rootCerts:
+                        inlineBytes: MTIzNDU=
+                  statPrefix: sds_mesh_ca
+                  targetUri: kuma-system:5677
+    type: EDS
+- name: db{role=replica}
+  resource:
+    '@type': type.googleapis.com/envoy.api.v2.ClusterLoadAssignment
+    clusterName: db{role=replica}
+    endpoints:
+    - {}
+- name: outbound:127.0.0.1:54321
+  resource:
+    '@type': type.googleapis.com/envoy.api.v2.Listener
+    address:
+      socketAddress:
+        address: 127.0.0.1
+        portValue: 54321
+    deprecatedV1:
+      bindToPort: false
+    filterChains:
+    - filters:
+      - name: envoy.tcp_proxy
+        typedConfig:
+          '@type': type.googleapis.com/envoy.config.filter.network.tcp_proxy.v2.TcpProxy
+          statPrefix: db
+          weightedClusters:
+            clusters:
+            - name: db{role=master}
+              weight: 10
+            - name: db{role=replica}
+              weight: 90
+    name: outbound:127.0.0.1:54321
+- name: api-http
+  resource:
+    '@type': type.googleapis.com/envoy.api.v2.Cluster
+    connectTimeout: 5s
+    edsClusterConfig:
+      edsConfig:
+        ads: {}
+    name: api-http
+    tlsContext:
+      commonTlsContext:
+        tlsCertificateSdsSecretConfigs:
+        - name: identity_cert
+          sdsConfig:
+            apiConfigSource:
+              apiType: GRPC
+              grpcServices:
+              - googleGrpc:
+                  channelCredentials:
+                    sslCredentials:
+                      rootCerts:
+                        inlineBytes: MTIzNDU=
+                  statPrefix: sds_identity_cert
+                  targetUri: kuma-system:5677
+        validationContextSdsSecretConfig:
+          name: mesh_ca
+          sdsConfig:
+            apiConfigSource:
+              apiType: GRPC
+              grpcServices:
+              - googleGrpc:
+                  channelCredentials:
+                    sslCredentials:
+                      rootCerts:
+                        inlineBytes: MTIzNDU=
+                  statPrefix: sds_mesh_ca
+                  targetUri: kuma-system:5677
+    type: EDS
+- name: api-http
+  resource:
+    '@type': type.googleapis.com/envoy.api.v2.ClusterLoadAssignment
+    clusterName: api-http
+    endpoints:
+    - lbEndpoints:
+      - endpoint:
+          address:
+            socketAddress:
+              address: 192.168.0.4
+              portValue: 8084
+        metadata:
+          filterMetadata:
+            envoy.lb:
+              protocol: http
+              region: us
+              service: api-http
+      - endpoint:
+          address:
+            socketAddress:
+              address: 192.168.0.5
+              portValue: 8085
+        metadata:
+          filterMetadata:
+            envoy.lb:
+              protocol: http
+              region: eu
+              service: api-http
+- name: outbound:127.0.0.1:40001
+  resource:
+    '@type': type.googleapis.com/envoy.api.v2.Listener
+    address:
+      socketAddress:
+        address: 127.0.0.1
+        portValue: 40001
+    deprecatedV1:
+      bindToPort: false
+    filterChains:
+    - filters:
+      - name: envoy.http_connection_manager
+        typedConfig:
+          '@type': type.googleapis.com/envoy.config.filter.network.http_connection_manager.v2.HttpConnectionManager
+          httpFilters:
+          - name: envoy.router
+          rds:
+            configSource:
+              ads: {}
+            routeConfigName: outbound:api-http
+          statPrefix: api-http
+    name: outbound:127.0.0.1:40001
+- name: outbound:api-http
+  resource:
+    '@type': type.googleapis.com/envoy.api.v2.RouteConfiguration
+    name: outbound:api-http
+    validateClusters: true
+    virtualHosts:
+    - domains:
+      - '*'
+      name: api-http
+      routes:
+      - match:
+          prefix: /
+        route:
+          cluster: api-http
+- name: api-tcp
+  resource:
+    '@type': type.googleapis.com/envoy.api.v2.Cluster
+    connectTimeout: 5s
+    edsClusterConfig:
+      edsConfig:
+        ads: {}
+    name: api-tcp
+    tlsContext:
+      commonTlsContext:
+        tlsCertificateSdsSecretConfigs:
+        - name: identity_cert
+          sdsConfig:
+            apiConfigSource:
+              apiType: GRPC
+              grpcServices:
+              - googleGrpc:
+                  channelCredentials:
+                    sslCredentials:
+                      rootCerts:
+                        inlineBytes: MTIzNDU=
+                  statPrefix: sds_identity_cert
+                  targetUri: kuma-system:5677
+        validationContextSdsSecretConfig:
+          name: mesh_ca
+          sdsConfig:
+            apiConfigSource:
+              apiType: GRPC
+              grpcServices:
+              - googleGrpc:
+                  channelCredentials:
+                    sslCredentials:
+                      rootCerts:
+                        inlineBytes: MTIzNDU=
+                  statPrefix: sds_mesh_ca
+                  targetUri: kuma-system:5677
+    type: EDS
+- name: api-tcp
+  resource:
+    '@type': type.googleapis.com/envoy.api.v2.ClusterLoadAssignment
+    clusterName: api-tcp
+    endpoints:
+    - lbEndpoints:
+      - endpoint:
+          address:
+            socketAddress:
+              address: 192.168.0.6
+              portValue: 8086
+        metadata:
+          filterMetadata:
+            envoy.lb:
+              protocol: http
+              region: us
+              service: api-tcp
+      - endpoint:
+          address:
+            socketAddress:
+              address: 192.168.0.7
+              portValue: 8087
+        metadata:
+          filterMetadata:
+            envoy.lb:
+              region: eu
+              service: api-tcp
+- name: outbound:127.0.0.1:40002
+  resource:
+    '@type': type.googleapis.com/envoy.api.v2.Listener
+    address:
+      socketAddress:
+        address: 127.0.0.1
+        portValue: 40002
+    deprecatedV1:
+      bindToPort: false
+    filterChains:
+    - filters:
+      - name: envoy.tcp_proxy
+        typedConfig:
+          '@type': type.googleapis.com/envoy.config.filter.network.tcp_proxy.v2.TcpProxy
+          cluster: api-tcp
+          statPrefix: api-tcp
+    name: outbound:127.0.0.1:40002

--- a/tools/e2e/examples/docker-compose/kuma-example-installer.sh
+++ b/tools/e2e/examples/docker-compose/kuma-example-installer.sh
@@ -153,7 +153,6 @@ networking:
     servicePort: {{ LOCAL_PORT }}
     tags:
       service: kuma-example-backend
-      protocol: http
       version: v1
       env: prod"
 

--- a/tools/e2e/examples/docker-compose/kuma-example-installer.sh
+++ b/tools/e2e/examples/docker-compose/kuma-example-installer.sh
@@ -172,6 +172,5 @@ networking:
     servicePort: {{ LOCAL_PORT }}
     tags:
       service: kuma-example-backend
-      protocol: http
       version: v2
       env: intg"

--- a/tools/e2e/examples/minikube/kuma-routing/kuma-routing.yaml
+++ b/tools/e2e/examples/minikube/kuma-routing/kuma-routing.yaml
@@ -89,11 +89,14 @@ metadata:
   name: kuma-example-backend
   namespace: kuma-example
   annotations:
-    7070.service.kuma.io/protocol: http
+    8080.service.kuma.io/protocol: http
 spec:
   ports:
   - port: 7070
+    name: tcp
+  - port: 8080
     name: http
+    targetPort: 7070
   selector:
     app: kuma-example-backend
 ---


### PR DESCRIPTION
### Summary

* generate HTTP-specific outbound listeners for services tagged with `protocol: http`
