### PR TITLE
feat(kuma-cp) Generate tracing config in Bootstrap config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 Changes:
 
+* feature: generate tracing configuration in boostrap configuration
+  [#592](https://github.com/Kong/kuma/pull/592)
 * feature: generate tracing configuration on listeners
   [#591](https://github.com/Kong/kuma/pull/591)
 * chore: generify proxy template matching (it now supports Gateway dataplane and '*' selector)

--- a/api/mesh/v1alpha1/mesh.pb.go
+++ b/api/mesh/v1alpha1/mesh.pb.go
@@ -436,7 +436,9 @@ type TracingBackend_Zipkin struct {
 	Url string `protobuf:"bytes,1,opt,name=url,proto3" json:"url,omitempty"`
 	// Generate 128bit traces. Default: false
 	TraceId128Bit bool `protobuf:"varint,2,opt,name=traceId128bit,proto3" json:"traceId128bit,omitempty"`
-	// Version of the API. values: httpJson, httpProto. Default: httpJson
+	// Version of the API. values: httpJson, httpJsonV1, httpProto. Default:
+	// httpJson see
+	// https://www.envoyproxy.io/docs/envoy/latest/api-v3/config/trace/v3/trace.proto#envoy-v3-api-enum-config-trace-v3-zipkinconfig-collectorendpointversion
 	ApiVersion           string   `protobuf:"bytes,3,opt,name=apiVersion,proto3" json:"apiVersion,omitempty"`
 	XXX_NoUnkeyedLiteral struct{} `json:"-"`
 	XXX_unrecognized     []byte   `json:"-"`

--- a/api/mesh/v1alpha1/mesh.proto
+++ b/api/mesh/v1alpha1/mesh.proto
@@ -95,7 +95,8 @@ message TracingBackend {
     // Generate 128bit traces. Default: false
     bool traceId128bit = 2;
 
-    // Version of the API. values: httpJson, httpProto. Default: httpJson
+    // Version of the API. values: httpJson, httpJsonV1, httpProto. Default: httpJson
+    // see https://www.envoyproxy.io/docs/envoy/latest/api-v3/config/trace/v3/trace.proto#envoy-v3-api-enum-config-trace-v3-zipkinconfig-collectorendpointversion
     string apiVersion = 3;
   }
 

--- a/api/mesh/v1alpha1/mesh.proto
+++ b/api/mesh/v1alpha1/mesh.proto
@@ -95,8 +95,9 @@ message TracingBackend {
     // Generate 128bit traces. Default: false
     bool traceId128bit = 2;
 
-    // Version of the API. values: httpJson, httpJsonV1, httpProto. Default: httpJson
-    // see https://www.envoyproxy.io/docs/envoy/latest/api-v3/config/trace/v3/trace.proto#envoy-v3-api-enum-config-trace-v3-zipkinconfig-collectorendpointversion
+    // Version of the API. values: httpJson, httpJsonV1, httpProto. Default:
+    // httpJson see
+    // https://www.envoyproxy.io/docs/envoy/latest/api-v3/config/trace/v3/trace.proto#envoy-v3-api-enum-config-trace-v3-zipkinconfig-collectorendpointversion
     string apiVersion = 3;
   }
 

--- a/pkg/api-server/mesh_ws_test.go
+++ b/pkg/api-server/mesh_ws_test.go
@@ -135,7 +135,7 @@ var _ = Describe("Resource WS", func() {
 								Name: "zipkin-us",
 								Type: &v1alpha1.TracingBackend_Zipkin_{
 									Zipkin: &v1alpha1.TracingBackend_Zipkin{
-										Url: "http://zipkin-us/v2/spans",
+										Url: "http://zipkin-us:9090/v2/spans",
 									},
 								},
 							},

--- a/pkg/core/resources/apis/mesh/mesh_validator.go
+++ b/pkg/core/resources/apis/mesh/mesh_validator.go
@@ -120,8 +120,8 @@ func validateZipkin(zipkin *mesh_proto.TracingBackend_Zipkin) validators.Validat
 	} else if _, err := url.ParseRequestURI(zipkin.Url); err != nil {
 		verr.AddViolation("url", "invalid URL")
 	}
-	if zipkin.ApiVersion != "" && zipkin.ApiVersion != "httpJson" && zipkin.ApiVersion != "httpProto" {
-		verr.AddViolation("apiVersion", `has to be either "httpJson" or "httpProto"`)
+	if zipkin.ApiVersion != "" && zipkin.ApiVersion != "httpJsonV1" && zipkin.ApiVersion != "httpJson" && zipkin.ApiVersion != "httpProto" {
+		verr.AddViolation("apiVersion", `has to be one of the following values: "httpJsonV1", "httpJson" or "httpProto"`)
 	}
 	return verr
 }

--- a/pkg/core/resources/apis/mesh/mesh_validator.go
+++ b/pkg/core/resources/apis/mesh/mesh_validator.go
@@ -117,11 +117,16 @@ func validateZipkin(zipkin *mesh_proto.TracingBackend_Zipkin) validators.Validat
 	var verr validators.ValidationError
 	if zipkin.Url == "" {
 		verr.AddViolation("url", "cannot be empty")
-	} else if _, err := url.ParseRequestURI(zipkin.Url); err != nil {
-		verr.AddViolation("url", "invalid URL")
+	} else {
+		uri, err := url.ParseRequestURI(zipkin.Url)
+		if err != nil {
+			verr.AddViolation("url", "invalid URL")
+		} else if uri.Port() == "" {
+			verr.AddViolation("url", "port has to be explicitly specified")
+		}
 	}
 	if zipkin.ApiVersion != "" && zipkin.ApiVersion != "httpJsonV1" && zipkin.ApiVersion != "httpJson" && zipkin.ApiVersion != "httpProto" {
-		verr.AddViolation("apiVersion", `has to be one of the following values: "httpJsonV1", "httpJson" or "httpProto"`)
+		verr.AddViolation("apiVersion", fmt.Sprintf(`has invalid value. %s`, AllowedValuesHint("httpJsonV1", "httpJson", "httpProto")))
 	}
 	return verr
 }

--- a/pkg/core/resources/apis/mesh/mesh_validator_test.go
+++ b/pkg/core/resources/apis/mesh/mesh_validator_test.go
@@ -240,7 +240,7 @@ var _ = Describe("Mesh", func() {
 				expected: `
                 violations:
                 - field: tracing.backends[0].zipkin.apiVersion
-                  message: has to be either "httpJson" or "httpProto"`,
+                  message: 'has to be one of the following values: "httpJsonV1", "httpJson" or "httpProto"'`,
 			}),
 			Entry("default backend has to be set to one of the backends", testCase{
 				mesh: `

--- a/pkg/core/resources/apis/mesh/mesh_validator_test.go
+++ b/pkg/core/resources/apis/mesh/mesh_validator_test.go
@@ -34,12 +34,12 @@ var _ = Describe("Mesh", func() {
               - name: zipkin-us
                 sampling: 80.0
                 zipkin:
-                  url: http://zipkin.local/v2/spans
+                  url: http://zipkin.local:9411/v2/spans
                   traceId128bit: true
                   apiVersion: httpProto
               - name: zipkin-eu
                 zipkin:
-                  url: http://zipkin.local/v2/spans
+                  url: http://zipkin.local:9411/v2/spans
               defaultBackend: zipkin-us
 `
 			mesh := MeshResource{}
@@ -171,7 +171,7 @@ var _ = Describe("Mesh", func() {
                   backends:
                   - name:
                     zipkin:
-                      url: http://zipkin.local/v2/spans`,
+                      url: http://zipkin.local:9411/v2/spans`,
 				expected: `
                 violations:
                 - field: tracing.backends[0].name
@@ -183,10 +183,10 @@ var _ = Describe("Mesh", func() {
                   backends:
                   - name: zipkin-us
                     zipkin:
-                      url: http://zipkin.local/v2/spans
+                      url: http://zipkin.local:9411/v2/spans
                   - name: zipkin-us
                     zipkin:
-                      url: http://zipkin.local/v2/spans`,
+                      url: http://zipkin.local:9411/v2/spans`,
 				expected: `
                 violations:
                 - field: tracing.backends[1].name
@@ -199,7 +199,7 @@ var _ = Describe("Mesh", func() {
                   - name: zipkin-us
                     sampling: 100.1
                     zipkin:
-                      url: http://zipkin-us.local/v2/spans`,
+                      url: http://zipkin-us.local:9411/v2/spans`,
 				expected: `
                 violations:
                 - field: tracing.backends[0].sampling
@@ -229,18 +229,30 @@ var _ = Describe("Mesh", func() {
                 - field: tracing.backends[0].zipkin.url
                   message: invalid URL`,
 			}),
+			Entry("tracing with zipkin with valid url but without port", testCase{
+				mesh: `
+                tracing:
+                  backends:
+                  - name: zipkin-us
+                    zipkin:
+                      url: http://zipkin-us.local/v2/spans`,
+				expected: `
+                violations:
+                - field: tracing.backends[0].zipkin.url
+                  message: port has to be explicitly specified`,
+			}),
 			Entry("tracing with zipkin with invalid apiVersion", testCase{
 				mesh: `
                 tracing:
                   backends:
                   - name: zipkin-us
                     zipkin:
-                      url: http://zipkin-us.local/v2/spans
+                      url: http://zipkin-us.local:9411/v2/spans
                       apiVersion: invalid`,
 				expected: `
                 violations:
                 - field: tracing.backends[0].zipkin.apiVersion
-                  message: 'has to be one of the following values: "httpJsonV1", "httpJson" or "httpProto"'`,
+                  message: 'has invalid value. Allowed values: httpJsonV1, httpJson, httpProto'`,
 			}),
 			Entry("default backend has to be set to one of the backends", testCase{
 				mesh: `
@@ -249,7 +261,7 @@ var _ = Describe("Mesh", func() {
                   backends:
                   - name: zipkin-us
                     zipkin:
-                      url: http://zipkin.local/v2/spans`,
+                      url: http://zipkin.local:9411/v2/spans`,
 				expected: `
                 violations:
                 - field: tracing.defaultBackend

--- a/pkg/xds/bootstrap/generator_test.go
+++ b/pkg/xds/bootstrap/generator_test.go
@@ -50,7 +50,23 @@ var _ = Describe("bootstrapGenerator", func() {
 		}
 
 		// when
-		err := resManager.Create(context.Background(), &mesh.MeshResource{}, store.CreateByKey("mesh", "mesh"))
+		meshRes := mesh.MeshResource{
+			Spec: mesh_proto.Mesh{
+				Tracing: &mesh_proto.Tracing{
+					Backends: []*mesh_proto.TracingBackend{
+						{
+							Name: "zipkin-us",
+							Type: &mesh_proto.TracingBackend_Zipkin_{
+								Zipkin: &mesh_proto.TracingBackend_Zipkin{
+									Url: "http://zipkin.us:9090/v2/spans",
+								},
+							},
+						},
+					},
+				},
+			},
+		}
+		err := resManager.Create(context.Background(), &meshRes, store.CreateByKey("mesh", "mesh"))
 		// then
 		Expect(err).ToNot(HaveOccurred())
 
@@ -153,4 +169,54 @@ var _ = Describe("bootstrapGenerator", func() {
 			expectedConfigFile: "generator.custom-config.golden.yaml",
 		}),
 	)
+
+	It("should generate bootstrap configuration with zipkin tracing", func() {
+		// setup
+		trafficTrace := mesh.TrafficTraceResource{
+			Spec: mesh_proto.TrafficTrace{
+				Selectors: []*mesh_proto.Selector{
+					{
+						Match: map[string]string{
+							"service": "backend",
+						},
+					},
+				},
+				Conf: &mesh_proto.TrafficTrace_Conf{
+					Backend: "zipkin-us",
+				},
+			},
+		}
+		err := resManager.Create(context.Background(), &trafficTrace, store.CreateByKey("tt", "mesh"))
+		// then
+		Expect(err).ToNot(HaveOccurred())
+
+		// given
+		params := bootstrap_config.DefaultBootstrapParamsConfig()
+		params.XdsHost = "127.0.0.1"
+		params.XdsPort = 5678
+
+		generator := NewDefaultBootstrapGenerator(resManager, params)
+		request := types.BootstrapRequest{
+			Mesh: "mesh",
+			Name: "name.namespace",
+		}
+
+		// when
+		bootstrapConfig, err := generator.Generate(context.Background(), request)
+		// then
+		Expect(err).ToNot(HaveOccurred())
+
+		// when
+		actual, err := util_proto.ToYAML(bootstrapConfig)
+		// then
+		Expect(err).ToNot(HaveOccurred())
+
+		// when
+		expected, err := ioutil.ReadFile(filepath.Join("testdata", "bootstrap.tracing.yaml"))
+		// then
+		Expect(err).ToNot(HaveOccurred())
+
+		// expect
+		Expect(actual).To(MatchYAML(expected))
+	})
 })

--- a/pkg/xds/bootstrap/testdata/bootstrap.tracing.yaml
+++ b/pkg/xds/bootstrap/testdata/bootstrap.tracing.yaml
@@ -1,0 +1,74 @@
+dynamicResources:
+  adsConfig:
+    apiType: GRPC
+    grpcServices:
+      - envoyGrpc:
+          clusterName: ads_cluster
+  cdsConfig:
+    ads: {}
+  ldsConfig:
+    ads: {}
+node:
+  cluster: backend
+  id: mesh.name.namespace
+staticResources:
+  clusters:
+    - connectTimeout: 1s
+      http2ProtocolOptions: {}
+      loadAssignment:
+        clusterName: ads_cluster
+        endpoints:
+          - lbEndpoints:
+              - endpoint:
+                  address:
+                    socketAddress:
+                      address: 127.0.0.1
+                      portValue: 5678
+      name: ads_cluster
+      type: STRICT_DNS
+      upstreamConnectionOptions:
+        tcpKeepalive: {}
+    - connectTimeout: 1s
+      http2ProtocolOptions: {}
+      loadAssignment:
+        clusterName: access_log_sink
+        endpoints:
+          - lbEndpoints:
+              - endpoint:
+                  address:
+                    pipe:
+                      path: /tmp/kuma-access-logs-name.namespace-mesh.sock
+      name: access_log_sink
+      type: STATIC
+      upstreamConnectionOptions:
+        tcpKeepalive: {}
+    - connectTimeout: 10s
+      loadAssignment:
+        clusterName: zipkin-us
+        endpoints:
+          - lbEndpoints:
+              - endpoint:
+                  address:
+                    socketAddress:
+                      address: zipkin.us
+                      portValue: 9090
+      name: zipkin-us
+      type: STRICT_DNS
+statsConfig:
+  statsTags:
+    - regex: ^grpc\.((.+)\.)
+      tagName: name
+    - regex: ^grpc.*streams_closed(_([0-9]+))
+      tagName: status
+    - regex: (worker_([0-9]+)\.)
+      tagName: worker
+    - regex: ((.+?)\.)rbac\.
+      tagName: listener
+tracing:
+  http:
+    name: envoy.zipkin
+    typedConfig:
+      '@type': type.googleapis.com/envoy.config.trace.v2.ZipkinConfig
+      collectorCluster: zipkin-us
+      collectorEndpoint: /v2/spans
+      collectorEndpointVersion: HTTP_JSON

--- a/pkg/xds/bootstrap/tracing.go
+++ b/pkg/xds/bootstrap/tracing.go
@@ -1,0 +1,127 @@
+package bootstrap
+
+import (
+	net_url "net/url"
+	"strconv"
+	"time"
+
+	"github.com/golang/protobuf/ptypes"
+	"github.com/golang/protobuf/ptypes/duration"
+	"github.com/pkg/errors"
+
+	mesh_proto "github.com/Kong/kuma/api/mesh/v1alpha1"
+	envoy_api "github.com/envoyproxy/go-control-plane/envoy/api/v2"
+	envoy_api_v2_core "github.com/envoyproxy/go-control-plane/envoy/api/v2/core"
+	envoy_api_v2_endpoint "github.com/envoyproxy/go-control-plane/envoy/api/v2/endpoint"
+	envoy_bootstrap "github.com/envoyproxy/go-control-plane/envoy/config/bootstrap/v2"
+	envoy_config_trace_v2 "github.com/envoyproxy/go-control-plane/envoy/config/trace/v2"
+)
+
+func AddTracingConfig(bootstrap *envoy_bootstrap.Bootstrap, backend *mesh_proto.TracingBackend) error {
+	if zipkin, ok := backend.GetType().(*mesh_proto.TracingBackend_Zipkin_); ok {
+		cluster, tracingCfg, err := zipkinConfig(bootstrap, zipkin.Zipkin, backend.Name)
+		if err != nil {
+			return err
+		}
+		if bootstrap.StaticResources == nil {
+			bootstrap.StaticResources = &envoy_bootstrap.Bootstrap_StaticResources{}
+		}
+		bootstrap.StaticResources.Clusters = append(bootstrap.StaticResources.Clusters, cluster)
+		bootstrap.Tracing = tracingCfg
+	}
+	return nil
+}
+
+func zipkinConfig(bootstrap *envoy_bootstrap.Bootstrap, zipkin *mesh_proto.TracingBackend_Zipkin, backendName string) (*envoy_api.Cluster, *envoy_config_trace_v2.Tracing, error) {
+	url, err := net_url.ParseRequestURI(zipkin.Url)
+	if err != nil {
+		return nil, nil, errors.Wrap(err, "invalid URL of Zipkin")
+	}
+
+	cluster, err := zipkinCluster(backendName, url)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	zipkinConfig := envoy_config_trace_v2.ZipkinConfig{
+		CollectorCluster:         cluster.Name,
+		CollectorEndpoint:        url.Path,
+		TraceId_128Bit:           zipkin.TraceId128Bit,
+		CollectorEndpointVersion: apiVersion(zipkin, url),
+	}
+	zipkinConfigAny, err := ptypes.MarshalAny(&zipkinConfig)
+	if err != nil {
+		return nil, nil, err
+	}
+	tracingConfig := &envoy_config_trace_v2.Tracing{
+		Http: &envoy_config_trace_v2.Tracing_Http{
+			Name: "envoy.zipkin",
+			ConfigType: &envoy_config_trace_v2.Tracing_Http_TypedConfig{
+				TypedConfig: zipkinConfigAny,
+			},
+		},
+	}
+	return cluster, tracingConfig, nil
+}
+
+func apiVersion(zipkin *mesh_proto.TracingBackend_Zipkin, url *net_url.URL) envoy_config_trace_v2.ZipkinConfig_CollectorEndpointVersion {
+	if zipkin.ApiVersion == "" { // try to infer it from the URL
+		if url.Path == "/api/v1/spans" {
+			return envoy_config_trace_v2.ZipkinConfig_HTTP_JSON_V1
+		} else if url.Path == "/api/v2/spans" {
+			return envoy_config_trace_v2.ZipkinConfig_HTTP_JSON
+		}
+	} else {
+		switch zipkin.ApiVersion {
+		case "httpJsonV1":
+			return envoy_config_trace_v2.ZipkinConfig_HTTP_JSON_V1
+		case "httpJson":
+			return envoy_config_trace_v2.ZipkinConfig_HTTP_JSON
+		case "httpProto":
+			return envoy_config_trace_v2.ZipkinConfig_HTTP_PROTO
+		}
+	}
+	return envoy_config_trace_v2.ZipkinConfig_HTTP_JSON
+}
+
+const zipkinClusterTimeout = 10 * time.Second
+
+func zipkinCluster(backendName string, url *net_url.URL) (*envoy_api.Cluster, error) {
+	port, err := strconv.Atoi(url.Port())
+	if err != nil {
+		return nil, err
+	}
+
+	cluster := &envoy_api.Cluster{
+		Name:                 backendName,
+		ConnectTimeout:       &duration.Duration{Seconds: int64(zipkinClusterTimeout.Seconds())},
+		ClusterDiscoveryType: &envoy_api.Cluster_Type{Type: envoy_api.Cluster_STRICT_DNS},
+		LbPolicy:             envoy_api.Cluster_ROUND_ROBIN,
+		LoadAssignment: &envoy_api.ClusterLoadAssignment{
+			ClusterName: backendName,
+			Endpoints: []*envoy_api_v2_endpoint.LocalityLbEndpoints{
+				{
+					LbEndpoints: []*envoy_api_v2_endpoint.LbEndpoint{
+						{
+							HostIdentifier: &envoy_api_v2_endpoint.LbEndpoint_Endpoint{
+								Endpoint: &envoy_api_v2_endpoint.Endpoint{
+									Address: &envoy_api_v2_core.Address{
+										Address: &envoy_api_v2_core.Address_SocketAddress{
+											SocketAddress: &envoy_api_v2_core.SocketAddress{
+												Address: url.Hostname(),
+												PortSpecifier: &envoy_api_v2_core.SocketAddress_PortValue{
+													PortValue: uint32(port),
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+	return cluster, nil
+}

--- a/pkg/xds/bootstrap/tracing_test.go
+++ b/pkg/xds/bootstrap/tracing_test.go
@@ -1,0 +1,282 @@
+package bootstrap
+
+import (
+	mesh_proto "github.com/Kong/kuma/api/mesh/v1alpha1"
+	util_proto "github.com/Kong/kuma/pkg/util/proto"
+	envoy_config_bootstrap_v2 "github.com/envoyproxy/go-control-plane/envoy/config/bootstrap/v2"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/ginkgo/extensions/table"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("Bootstrap Tracing", func() {
+
+	type testCase struct {
+		backend      *mesh_proto.TracingBackend
+		expectedYAML string
+	}
+
+	DescribeTable("should enrich bootstrap config with tracing",
+		func(given testCase) {
+			// given
+			bootstrap := &envoy_config_bootstrap_v2.Bootstrap{}
+
+			// when
+			err := AddTracingConfig(bootstrap, given.backend)
+
+			// then
+			Expect(err).ToNot(HaveOccurred())
+
+			// and
+			actual, err := util_proto.ToYAML(bootstrap)
+
+			// then
+			Expect(err).ToNot(HaveOccurred())
+
+			// and
+			Expect(actual).To(MatchYAML(given.expectedYAML))
+		},
+		Entry("infer version from /api/v1/spans path", testCase{
+			backend: &mesh_proto.TracingBackend{
+				Name: "zipkin-us",
+				Type: &mesh_proto.TracingBackend_Zipkin_{
+					Zipkin: &mesh_proto.TracingBackend_Zipkin{
+						Url: "http://zipkin:9090/api/v1/spans",
+					},
+				},
+			},
+			expectedYAML: `
+                staticResources:
+                  clusters:
+                  - connectTimeout: 10s
+                    loadAssignment:
+                      clusterName: zipkin-us
+                      endpoints:
+                      - lbEndpoints:
+                        - endpoint:
+                            address:
+                              socketAddress:
+                                address: zipkin
+                                portValue: 9090
+                    name: zipkin-us
+                    type: STRICT_DNS
+                tracing:
+                  http:
+                    name: envoy.zipkin
+                    typedConfig:
+                      '@type': type.googleapis.com/envoy.config.trace.v2.ZipkinConfig
+                      collectorCluster: zipkin-us
+                      collectorEndpoint: /api/v1/spans
+`,
+		}),
+		Entry("infer version from /api/v2/spans path", testCase{
+			backend: &mesh_proto.TracingBackend{
+				Name: "zipkin-eu",
+				Type: &mesh_proto.TracingBackend_Zipkin_{
+					Zipkin: &mesh_proto.TracingBackend_Zipkin{
+						Url: "http://zipkin:9090/api/v2/spans",
+					},
+				},
+			},
+			expectedYAML: `
+                staticResources:
+                  clusters:
+                  - connectTimeout: 10s
+                    loadAssignment:
+                      clusterName: zipkin-eu
+                      endpoints:
+                      - lbEndpoints:
+                        - endpoint:
+                            address:
+                              socketAddress:
+                                address: zipkin
+                                portValue: 9090
+                    name: zipkin-eu
+                    type: STRICT_DNS
+                tracing:
+                  http:
+                    name: envoy.zipkin
+                    typedConfig:
+                      '@type': type.googleapis.com/envoy.config.trace.v2.ZipkinConfig
+                      collectorCluster: zipkin-eu
+                      collectorEndpoint: /api/v2/spans
+                      collectorEndpointVersion: HTTP_JSON
+`,
+		}),
+		Entry("explicit httpJsonV1 version config in backend", testCase{
+			backend: &mesh_proto.TracingBackend{
+				Name: "zipkin-eu",
+				Type: &mesh_proto.TracingBackend_Zipkin_{
+					Zipkin: &mesh_proto.TracingBackend_Zipkin{
+						Url:        "http://zipkin:9090/api/v2/spans",
+						ApiVersion: "httpJsonV1",
+					},
+				},
+			},
+			expectedYAML: `
+                staticResources:
+                  clusters:
+                  - connectTimeout: 10s
+                    loadAssignment:
+                      clusterName: zipkin-eu
+                      endpoints:
+                      - lbEndpoints:
+                        - endpoint:
+                            address:
+                              socketAddress:
+                                address: zipkin
+                                portValue: 9090
+                    name: zipkin-eu
+                    type: STRICT_DNS
+                tracing:
+                  http:
+                    name: envoy.zipkin
+                    typedConfig:
+                      '@type': type.googleapis.com/envoy.config.trace.v2.ZipkinConfig
+                      collectorCluster: zipkin-eu
+                      collectorEndpoint: /api/v2/spans
+`,
+		}),
+		Entry("explicit httpJson version config in backend", testCase{
+			backend: &mesh_proto.TracingBackend{
+				Name: "zipkin-eu",
+				Type: &mesh_proto.TracingBackend_Zipkin_{
+					Zipkin: &mesh_proto.TracingBackend_Zipkin{
+						Url:        "http://zipkin:9090/some/path",
+						ApiVersion: "httpJson",
+					},
+				},
+			},
+			expectedYAML: `
+                staticResources:
+                  clusters:
+                  - connectTimeout: 10s
+                    loadAssignment:
+                      clusterName: zipkin-eu
+                      endpoints:
+                      - lbEndpoints:
+                        - endpoint:
+                            address:
+                              socketAddress:
+                                address: zipkin
+                                portValue: 9090
+                    name: zipkin-eu
+                    type: STRICT_DNS
+                tracing:
+                  http:
+                    name: envoy.zipkin
+                    typedConfig:
+                      '@type': type.googleapis.com/envoy.config.trace.v2.ZipkinConfig
+                      collectorCluster: zipkin-eu
+                      collectorEndpoint: /some/path
+                      collectorEndpointVersion: HTTP_JSON
+`,
+		}),
+		Entry("explicit httpProto version config in backend", testCase{
+			backend: &mesh_proto.TracingBackend{
+				Name: "zipkin-eu",
+				Type: &mesh_proto.TracingBackend_Zipkin_{
+					Zipkin: &mesh_proto.TracingBackend_Zipkin{
+						Url:        "http://zipkin:9090/some/path",
+						ApiVersion: "httpProto",
+					},
+				},
+			},
+			expectedYAML: `
+                staticResources:
+                  clusters:
+                  - connectTimeout: 10s
+                    loadAssignment:
+                      clusterName: zipkin-eu
+                      endpoints:
+                      - lbEndpoints:
+                        - endpoint:
+                            address:
+                              socketAddress:
+                                address: zipkin
+                                portValue: 9090
+                    name: zipkin-eu
+                    type: STRICT_DNS
+                tracing:
+                  http:
+                    name: envoy.zipkin
+                    typedConfig:
+                      '@type': type.googleapis.com/envoy.config.trace.v2.ZipkinConfig
+                      collectorCluster: zipkin-eu
+                      collectorEndpoint: /some/path
+                      collectorEndpointVersion: HTTP_PROTO
+`,
+		}),
+		Entry("version defaults to httpJson", testCase{
+			backend: &mesh_proto.TracingBackend{
+				Name: "zipkin-eu",
+				Type: &mesh_proto.TracingBackend_Zipkin_{
+					Zipkin: &mesh_proto.TracingBackend_Zipkin{
+						Url: "http://zipkin:9090/some/path",
+					},
+				},
+			},
+			expectedYAML: `
+                staticResources:
+                  clusters:
+                  - connectTimeout: 10s
+                    loadAssignment:
+                      clusterName: zipkin-eu
+                      endpoints:
+                      - lbEndpoints:
+                        - endpoint:
+                            address:
+                              socketAddress:
+                                address: zipkin
+                                portValue: 9090
+                    name: zipkin-eu
+                    type: STRICT_DNS
+                tracing:
+                  http:
+                    name: envoy.zipkin
+                    typedConfig:
+                      '@type': type.googleapis.com/envoy.config.trace.v2.ZipkinConfig
+                      collectorCluster: zipkin-eu
+                      collectorEndpoint: /some/path
+                      collectorEndpointVersion: HTTP_JSON
+`,
+		}),
+		Entry("traceId128bit on", testCase{
+			backend: &mesh_proto.TracingBackend{
+				Name: "zipkin-eu",
+				Type: &mesh_proto.TracingBackend_Zipkin_{
+					Zipkin: &mesh_proto.TracingBackend_Zipkin{
+						Url:           "http://zipkin:9090/api/v2/spans",
+						TraceId128Bit: true,
+					},
+				},
+			},
+			expectedYAML: `
+                staticResources:
+                  clusters:
+                  - connectTimeout: 10s
+                    loadAssignment:
+                      clusterName: zipkin-eu
+                      endpoints:
+                      - lbEndpoints:
+                        - endpoint:
+                            address:
+                              socketAddress:
+                                address: zipkin
+                                portValue: 9090
+                    name: zipkin-eu
+                    type: STRICT_DNS
+                tracing:
+                  http:
+                    name: envoy.zipkin
+                    typedConfig:
+                      '@type': type.googleapis.com/envoy.config.trace.v2.ZipkinConfig
+                      collectorCluster: zipkin-eu
+                      collectorEndpoint: /api/v2/spans
+                      collectorEndpointVersion: HTTP_JSON
+                      traceId128bit: true
+`,
+		}),
+	)
+})


### PR DESCRIPTION
### Summary

Generate tracing config in Bootstrap config.

When we generate snapshot, we do traffic trace matching and get proper backend from the mesh. Then we convert this to bootstrap config.

Note: There is some bug in Envoy - Zipkin V2 version of the API is not compatible with Jaeger, because timestamp field in JSON is string and Jeager expects int64 there. We can look for it as a separate task and just use V1 for now which works fine.