### PR TITLE
kuma-cp: add support for %KUMA_*% placeholders inside Envoy access log format

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 Changes:
 
+* feature: add support for Kuma-specific placeholders, such as `%KUMA_SOURCE_SERVICE%`, inside Envoy access log format
+  [#594](https://github.com/Kong/kuma/pull/594)
 * feature: add support for the entire Envoy access log command operator syntax
   [#589](https://github.com/Kong/kuma/pull/589)
 * feature: generate tracing configuration in boostrap configuration

--- a/pkg/core/resources/apis/mesh/mesh_validator.go
+++ b/pkg/core/resources/apis/mesh/mesh_validator.go
@@ -2,10 +2,12 @@ package mesh
 
 import (
 	"fmt"
-	mesh_proto "github.com/Kong/kuma/api/mesh/v1alpha1"
-	"github.com/Kong/kuma/pkg/core/validators"
 	"net"
 	"net/url"
+
+	mesh_proto "github.com/Kong/kuma/api/mesh/v1alpha1"
+	"github.com/Kong/kuma/pkg/core/validators"
+	"github.com/Kong/kuma/pkg/envoy/accesslog"
 )
 
 func (m *MeshResource) Validate() error {
@@ -50,6 +52,9 @@ func validateLoggingBackend(backend *mesh_proto.LoggingBackend) validators.Valid
 	var verr validators.ValidationError
 	if backend.Name == "" {
 		verr.AddViolation("name", "cannot be empty")
+	}
+	if err := accesslog.ValidateFormat(backend.Format); err != nil {
+		verr.AddViolation("format", err.Error())
 	}
 	if file, ok := backend.GetType().(*mesh_proto.LoggingBackend_File_); ok {
 		verr.AddError("file", validateLoggingFile(file))

--- a/pkg/core/resources/apis/mesh/mesh_validator_test.go
+++ b/pkg/core/resources/apis/mesh/mesh_validator_test.go
@@ -25,7 +25,15 @@ var _ = Describe("Mesh", func() {
               - name: file-1
                 file:
                   path: /path/to/file
+              - name: file-2
+                format: '%START_TIME% %KUMA_SOURCE_SERVICE%'
+                file:
+                  path: /path/to/file2
               - name: tcp-1
+                tcp:
+                  address: kibana:1234
+              - name: tcp-2
+                format: '%START_TIME% %KUMA_DESTINATION_SERVICE%'
                 tcp:
                   address: kibana:1234
               defaultBackend: tcp-1
@@ -151,6 +159,20 @@ var _ = Describe("Mesh", func() {
                 violations:
                 - field: logging.backends[0].file.path
                   message: cannot be empty`,
+			}),
+			Entry("invalid access log format", testCase{
+				mesh: `
+                logging:
+                  backends:
+                  - name: backend-1
+                    format: "%START_TIME% %sent_bytes%"
+                    file:
+                      path: /var/logs
+                  defaultBackend: backend-1`,
+				expected: `
+                violations:
+                - field: logging.backends[0].format
+                  message: 'format string is not valid: expected a command operator to start at position 14, instead got: "%sent_bytes%"'`,
 			}),
 			Entry("default backend has to be set to one of the backends", testCase{
 				mesh: `

--- a/pkg/envoy/accesslog/commands.go
+++ b/pkg/envoy/accesslog/commands.go
@@ -2,6 +2,7 @@ package accesslog
 
 import (
 	"fmt"
+	"strings"
 )
 
 // List of supported command operators.
@@ -61,6 +62,13 @@ const (
 	CMD_DOWNSTREAM_PEER_CERT_V_START    = "DOWNSTREAM_PEER_CERT_V_START"
 	CMD_DOWNSTREAM_PEER_CERT_V_END      = "DOWNSTREAM_PEER_CERT_V_END"
 	CMD_HOSTNAME                        = "HOSTNAME"
+
+	// Commands unique to Kuma.
+
+	CMD_KUMA_SOURCE_ADDRESS              = "KUMA_SOURCE_ADDRESS"
+	CMD_KUMA_SOURCE_ADDRESS_WITHOUT_PORT = "KUMA_SOURCE_ADDRESS_WITHOUT_PORT"
+	CMD_KUMA_SOURCE_SERVICE              = "KUMA_SOURCE_SERVICE"
+	CMD_KUMA_DESTINATION_SERVICE         = "KUMA_DESTINATION_SERVICE"
 )
 
 // CommandOperatorDescriptor represents a descriptor of an Envoy access log command operator.
@@ -156,7 +164,24 @@ func (o CommandOperatorDescriptor) String() string {
 		return "%DOWNSTREAM_PEER_CERT_V_END%"
 	case CMD_HOSTNAME:
 		return "%HOSTNAME%"
+	case CMD_KUMA_SOURCE_ADDRESS:
+		return "%KUMA_SOURCE_ADDRESS%"
+	case CMD_KUMA_SOURCE_ADDRESS_WITHOUT_PORT:
+		return "%KUMA_SOURCE_ADDRESS_WITHOUT_PORT%"
+	case CMD_KUMA_SOURCE_SERVICE:
+		return "%KUMA_SOURCE_SERVICE%"
+	case CMD_KUMA_DESTINATION_SERVICE:
+		return "%KUMA_DESTINATION_SERVICE%"
 	default:
 		return fmt.Sprintf("%%%s%%", string(o))
 	}
+}
+
+// IsPlaceholder returns true if this command is a placeholder
+// that must be resolved before configuring Envoy with that format string.
+// E.g., %KUMA_SOURCE_ADDRESS%, %KUMA_SOURCE_ADDRESS_WITHOUT_PORT%,
+// %KUMA_SOURCE_SERVICE% and %KUMA_DESTINATION_SERVICE%
+// are examples of such placeholders.
+func (o CommandOperatorDescriptor) IsPlaceholder() bool {
+	return strings.HasPrefix(string(o), "KUMA_")
 }

--- a/pkg/envoy/accesslog/format.go
+++ b/pkg/envoy/accesslog/format.go
@@ -64,12 +64,12 @@ func (f *AccessLogFormat) ConfigureTcpLog(config *accesslog_config.TcpGrpcAccess
 	return nil
 }
 
-func (f *AccessLogFormat) Interpolate(context InterpolationContext) (*AccessLogFormat, error) {
+func (f *AccessLogFormat) Interpolate(variables InterpolationVariables) (*AccessLogFormat, error) {
 	newFragments := make([]AccessLogFragment, len(f.Fragments))
 	interpolated := false
 	for i, fragment := range f.Fragments {
 		if interpolator, ok := fragment.(AccessLogFragmentInterpolator); ok {
-			newFragment, err := interpolator.Interpolate(context)
+			newFragment, err := interpolator.Interpolate(variables)
 			if err != nil {
 				return nil, err
 			}

--- a/pkg/envoy/accesslog/interfaces.go
+++ b/pkg/envoy/accesslog/interfaces.go
@@ -41,3 +41,27 @@ type HttpLogConfigurer interface {
 type TcpLogConfigurer interface {
 	ConfigureTcpLog(config *accesslog_config.TcpGrpcAccessLogConfig) error
 }
+
+// InterpolationContext represents a context of Interpolate() operation.
+type InterpolationContext interface {
+	// Get returns a variable value in this context.
+	Get(variable string) string
+}
+
+// AccessLogFragmentInterpolator interpolates placeholders
+// added to an access log format string.
+// E.g. %KUMA_SOURCE_SERVICE%, %KUMA_DESTINATION_SERVICE%,
+// %KUMA_SOURCE_ADDRESS% and %KUMA_SOURCE_ADDRESS_WITHOUT_PORT%
+// are examples of such placeholders.
+type AccessLogFragmentInterpolator interface {
+	// Interpolate returns an access log fragment with all placeholders resolved.
+	Interpolate(context InterpolationContext) (AccessLogFragment, error)
+}
+
+// InterpolationVariables represents a context of Interpolate() operation
+// as a map of variables.
+type InterpolationVariables map[string]string
+
+func (m InterpolationVariables) Get(variable string) string {
+	return m[variable]
+}

--- a/pkg/envoy/accesslog/interfaces.go
+++ b/pkg/envoy/accesslog/interfaces.go
@@ -42,12 +42,6 @@ type TcpLogConfigurer interface {
 	ConfigureTcpLog(config *accesslog_config.TcpGrpcAccessLogConfig) error
 }
 
-// InterpolationContext represents a context of Interpolate() operation.
-type InterpolationContext interface {
-	// Get returns a variable value in this context.
-	Get(variable string) string
-}
-
 // AccessLogFragmentInterpolator interpolates placeholders
 // added to an access log format string.
 // E.g. %KUMA_SOURCE_SERVICE%, %KUMA_DESTINATION_SERVICE%,
@@ -55,7 +49,7 @@ type InterpolationContext interface {
 // are examples of such placeholders.
 type AccessLogFragmentInterpolator interface {
 	// Interpolate returns an access log fragment with all placeholders resolved.
-	Interpolate(context InterpolationContext) (AccessLogFragment, error)
+	Interpolate(variables InterpolationVariables) (AccessLogFragment, error)
 }
 
 // InterpolationVariables represents a context of Interpolate() operation

--- a/pkg/envoy/accesslog/placeholder_fragment.go
+++ b/pkg/envoy/accesslog/placeholder_fragment.go
@@ -1,0 +1,43 @@
+package accesslog
+
+import (
+	accesslog_config "github.com/envoyproxy/go-control-plane/envoy/config/accesslog/v2"
+	accesslog_data "github.com/envoyproxy/go-control-plane/envoy/data/accesslog/v2"
+)
+
+// Placeholder represents a placeholder added to an access log format string
+// that must be resolved before configuring Envoy with that format string.
+//
+// E.g. %KUMA_SOURCE_SERVICE%, %KUMA_DESTINATION_SERVICE%,
+// %KUMA_SOURCE_ADDRESS% and %KUMA_SOURCE_ADDRESS_WITHOUT_PORT%
+// are examples of such placeholders.
+type Placeholder string
+
+func (f Placeholder) FormatHttpLogEntry(entry *accesslog_data.HTTPAccessLogEntry) (string, error) {
+	return f.String(), nil
+}
+
+func (f Placeholder) FormatTcpLogEntry(entry *accesslog_data.TCPAccessLogEntry) (string, error) {
+	return f.String(), nil
+}
+
+func (f Placeholder) ConfigureHttpLog(config *accesslog_config.HttpGrpcAccessLogConfig) error {
+	// has no effect on HttpGrpcAccessLogConfig
+	return nil
+}
+
+func (f Placeholder) ConfigureTcpLog(config *accesslog_config.TcpGrpcAccessLogConfig) error {
+	// has no effect on TcpGrpcAccessLogConfig
+	return nil
+}
+
+// String returns the canonical representation of this command operator.
+func (f Placeholder) String() string {
+	return CommandOperatorDescriptor(f).String()
+}
+
+// Interpolate returns an access log fragment with all placeholders resolved.
+func (f Placeholder) Interpolate(context InterpolationContext) (AccessLogFragment, error) {
+	value := context.Get(string(f))
+	return TextSpan(value), nil // turn placeholder into a text literal
+}

--- a/pkg/envoy/accesslog/placeholder_fragment.go
+++ b/pkg/envoy/accesslog/placeholder_fragment.go
@@ -37,7 +37,7 @@ func (f Placeholder) String() string {
 }
 
 // Interpolate returns an access log fragment with all placeholders resolved.
-func (f Placeholder) Interpolate(context InterpolationContext) (AccessLogFragment, error) {
-	value := context.Get(string(f))
+func (f Placeholder) Interpolate(variables InterpolationVariables) (AccessLogFragment, error) {
+	value := variables.Get(string(f))
 	return TextSpan(value), nil // turn placeholder into a text literal
 }

--- a/pkg/envoy/accesslog/placeholder_fragment_test.go
+++ b/pkg/envoy/accesslog/placeholder_fragment_test.go
@@ -1,0 +1,135 @@
+package accesslog_test
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/ginkgo/extensions/table"
+	. "github.com/onsi/gomega"
+
+	. "github.com/Kong/kuma/pkg/envoy/accesslog"
+
+	accesslog_data "github.com/envoyproxy/go-control-plane/envoy/data/accesslog/v2"
+)
+
+var _ = Describe("Placeholder", func() {
+
+	Describe("FormatHttpLogEntry() and FormatTcpLogEntry()", func() {
+		type testCase struct {
+			variable string
+			expected string
+		}
+
+		DescribeTable("should format properly",
+			func(given testCase) {
+				// setup
+				fragment := Placeholder(given.variable)
+
+				// when
+				actual, err := fragment.FormatHttpLogEntry(&accesslog_data.HTTPAccessLogEntry{})
+				// then
+				Expect(err).ToNot(HaveOccurred())
+				// and
+				Expect(actual).To(Equal(given.expected))
+
+				// when
+				actual, err = fragment.FormatTcpLogEntry(&accesslog_data.TCPAccessLogEntry{})
+				// then
+				Expect(err).ToNot(HaveOccurred())
+				// and
+				Expect(actual).To(Equal(given.expected))
+			},
+			Entry("KUMA_SOURCE_ADDRESS", testCase{
+				variable: "KUMA_SOURCE_ADDRESS",
+				expected: `%KUMA_SOURCE_ADDRESS%`, // placeholder must be rendered "as is"
+			}),
+			Entry("KUMA_SOURCE_ADDRESS_WITHOUT_PORT", testCase{
+				variable: "KUMA_SOURCE_ADDRESS_WITHOUT_PORT",
+				expected: `%KUMA_SOURCE_ADDRESS_WITHOUT_PORT%`, // placeholder must be rendered "as is"
+			}),
+			Entry("KUMA_SOURCE_SERVICE", testCase{
+				variable: "KUMA_SOURCE_SERVICE",
+				expected: `%KUMA_SOURCE_SERVICE%`, // placeholder must be rendered "as is"
+			}),
+			Entry("KUMA_DESTINATION_SERVICE", testCase{
+				variable: "KUMA_DESTINATION_SERVICE",
+				expected: `%KUMA_DESTINATION_SERVICE%`, // placeholder must be rendered "as is"
+			}),
+		)
+	})
+
+	Describe("Interpolate()", func() {
+		type testCase struct {
+			variable string
+			context  map[string]string
+			expected string
+		}
+
+		DescribeTable("should replace placeholder with a text literal",
+			func(given testCase) {
+				// setup
+				fragment := Placeholder(given.variable)
+
+				// when
+				actual, err := fragment.Interpolate(InterpolationVariables(given.context))
+				// then
+				Expect(err).ToNot(HaveOccurred())
+				// and
+				Expect(actual).To(Equal(TextSpan(given.expected)))
+			},
+			Entry("`nil` context", testCase{
+				variable: "KUMA_SOURCE_SERVICE",
+				context:  nil,
+				expected: ``,
+			}),
+			Entry("variable w/o a value in the context", testCase{
+				variable: "KUMA_SOURCE_SERVICE",
+				context: map[string]string{
+					"KUMA_DESTINATION_SERVICE": "backend",
+				},
+				expected: ``,
+			}),
+			Entry("variable w/ a value in the context", testCase{
+				variable: "KUMA_SOURCE_SERVICE",
+				context: map[string]string{
+					"KUMA_SOURCE_SERVICE": "web",
+				},
+				expected: `web`,
+			}),
+		)
+	})
+
+	Describe("String()", func() {
+		type testCase struct {
+			variable string
+			expected string
+		}
+
+		DescribeTable("should return correct canonical representation",
+			func(given testCase) {
+				// setup
+				fragment := Placeholder(given.variable)
+
+				// when
+				actual := fragment.String()
+				// then
+				Expect(actual).To(Equal(given.expected))
+
+			},
+			Entry("KUMA_SOURCE_ADDRESS", testCase{
+				variable: "KUMA_SOURCE_ADDRESS",
+				expected: `%KUMA_SOURCE_ADDRESS%`,
+			}),
+			Entry("KUMA_SOURCE_ADDRESS_WITHOUT_PORT", testCase{
+				variable: "KUMA_SOURCE_ADDRESS_WITHOUT_PORT",
+				expected: `%KUMA_SOURCE_ADDRESS_WITHOUT_PORT%`,
+			}),
+			Entry("KUMA_SOURCE_SERVICE", testCase{
+				variable: "KUMA_SOURCE_SERVICE",
+				expected: `%KUMA_SOURCE_SERVICE%`,
+			}),
+			Entry("KUMA_DESTINATION_SERVICE", testCase{
+				variable: "KUMA_DESTINATION_SERVICE",
+				expected: `%KUMA_DESTINATION_SERVICE%`,
+			}),
+		)
+	})
+})


### PR DESCRIPTION
### Summary

* add support for `%KUMA_*%` placeholders inside Envoy access log format

