### PR TITLE
kuma-dp: extend embedded gRPC Access Log Server to support the entire Envoy access log format

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 Changes:
 
+* feature: extend embedded gRPC Access Log Server to support the entire Envoy access log format
+  [#595](https://github.com/Kong/kuma/pull/595)
 * feature: generate HTTP-specific configuration of access log
   [#590](https://github.com/Kong/kuma/pull/590)
 * feature: add support for Kuma-specific placeholders, such as `%KUMA_SOURCE_SERVICE%`, inside Envoy access log format

--- a/app/kuma-dp/pkg/dataplane/accesslogs/accesslogs_suite_test.go
+++ b/app/kuma-dp/pkg/dataplane/accesslogs/accesslogs_suite_test.go
@@ -1,0 +1,13 @@
+package accesslogs_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+func TestAccesslogs(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Accesslogs Suite")
+}

--- a/app/kuma-dp/pkg/dataplane/accesslogs/factories.go
+++ b/app/kuma-dp/pkg/dataplane/accesslogs/factories.go
@@ -1,0 +1,46 @@
+package accesslogs
+
+import (
+	"strings"
+
+	"github.com/pkg/errors"
+
+	"github.com/go-logr/logr"
+
+	envoy_accesslog "github.com/envoyproxy/go-control-plane/envoy/service/accesslog/v2"
+
+	"github.com/Kong/kuma/pkg/envoy/accesslog"
+)
+
+func defaultHandler(log logr.Logger, msg *envoy_accesslog.StreamAccessLogsMessage, newSender logSenderFactoryFunc) (logHandler, error) {
+	parts := strings.SplitN(msg.GetIdentifier().GetLogName(), ";", 2)
+	if len(parts) != 2 {
+		return nil, errors.Errorf("log name %q has invalid format: expected %d components separated by ';', got %d", msg.GetIdentifier().GetLogName(), 2, len(parts))
+	}
+	address, formatString := parts[0], parts[1]
+
+	format, err := accesslog.ParseFormat(formatString)
+	if err != nil {
+		return nil, err
+	}
+
+	sender, err := newSender(log, address)
+	if err != nil {
+		return nil, err
+	}
+	if err := sender.Connect(); err != nil {
+		return nil, err
+	}
+
+	return &handler{
+		format: format,
+		sender: sender,
+	}, nil
+}
+
+func defaultSender(log logr.Logger, address string) (logSender, error) {
+	return &sender{
+		log:     log,
+		address: address,
+	}, nil
+}

--- a/app/kuma-dp/pkg/dataplane/accesslogs/factories.go
+++ b/app/kuma-dp/pkg/dataplane/accesslogs/factories.go
@@ -12,7 +12,7 @@ import (
 	"github.com/Kong/kuma/pkg/envoy/accesslog"
 )
 
-func defaultHandler(log logr.Logger, msg *envoy_accesslog.StreamAccessLogsMessage, newSender logSenderFactoryFunc) (logHandler, error) {
+func defaultHandler(log logr.Logger, msg *envoy_accesslog.StreamAccessLogsMessage) (logHandler, error) {
 	parts := strings.SplitN(msg.GetIdentifier().GetLogName(), ";", 2)
 	if len(parts) != 2 {
 		return nil, errors.Errorf("log name %q has invalid format: expected %d components separated by ';', got %d", msg.GetIdentifier().GetLogName(), 2, len(parts))
@@ -24,7 +24,7 @@ func defaultHandler(log logr.Logger, msg *envoy_accesslog.StreamAccessLogsMessag
 		return nil, err
 	}
 
-	sender, err := newSender(log, address)
+	sender, err := defaultSender(log, address)
 	if err != nil {
 		return nil, err
 	}

--- a/app/kuma-dp/pkg/dataplane/accesslogs/factories_private_test.go
+++ b/app/kuma-dp/pkg/dataplane/accesslogs/factories_private_test.go
@@ -5,8 +5,6 @@ import (
 	. "github.com/onsi/ginkgo/extensions/table"
 	. "github.com/onsi/gomega"
 
-	"github.com/go-logr/logr"
-
 	envoy_accesslog "github.com/envoyproxy/go-control-plane/envoy/service/accesslog/v2"
 )
 
@@ -19,13 +17,8 @@ var _ = Describe("defaultHandler", func() {
 
 		DescribeTable("should fail if configuration is not valid",
 			func(given testCase) {
-				// setup
-				sender := &fakeSender{}
-
 				// when
-				_, err := defaultHandler(nil, given.msg, func(log logr.Logger, address string) (logSender, error) {
-					return sender, nil
-				})
+				_, err := defaultHandler(nil, given.msg)
 				// then
 				Expect(err).To(HaveOccurred())
 				// and

--- a/app/kuma-dp/pkg/dataplane/accesslogs/factories_private_test.go
+++ b/app/kuma-dp/pkg/dataplane/accesslogs/factories_private_test.go
@@ -1,0 +1,47 @@
+package accesslogs
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/ginkgo/extensions/table"
+	. "github.com/onsi/gomega"
+
+	"github.com/go-logr/logr"
+
+	envoy_accesslog "github.com/envoyproxy/go-control-plane/envoy/service/accesslog/v2"
+)
+
+var _ = Describe("defaultHandler", func() {
+	Describe("error path", func() {
+		type testCase struct {
+			msg         *envoy_accesslog.StreamAccessLogsMessage
+			expectedErr string
+		}
+
+		DescribeTable("should fail if configuration is not valid",
+			func(given testCase) {
+				// setup
+				sender := &fakeSender{}
+
+				// when
+				_, err := defaultHandler(nil, given.msg, func(log logr.Logger, address string) (logSender, error) {
+					return sender, nil
+				})
+				// then
+				Expect(err).To(HaveOccurred())
+				// and
+				Expect(err.Error()).To(Equal(given.expectedErr))
+			},
+			Entry("empty `identifier.log_name` field", testCase{
+				expectedErr: `log name "" has invalid format: expected 2 components separated by ';', got 1`,
+			}),
+			Entry("invalid access log format string", testCase{
+				msg: &envoy_accesslog.StreamAccessLogsMessage{
+					Identifier: &envoy_accesslog.StreamAccessLogsMessage_Identifier{
+						LogName: ";%bytes_sent%",
+					},
+				},
+				expectedErr: `format string is not valid: expected a command operator to start at position 1, instead got: "%bytes_sent%"`,
+			}),
+		)
+	})
+})

--- a/app/kuma-dp/pkg/dataplane/accesslogs/handler.go
+++ b/app/kuma-dp/pkg/dataplane/accesslogs/handler.go
@@ -1,0 +1,46 @@
+package accesslogs
+
+import (
+	"github.com/pkg/errors"
+
+	envoy_accesslog "github.com/envoyproxy/go-control-plane/envoy/service/accesslog/v2"
+
+	"github.com/Kong/kuma/pkg/envoy/accesslog"
+)
+
+type handler struct {
+	format *accesslog.AccessLogFormat
+	sender logSender
+}
+
+func (h *handler) Handle(msg *envoy_accesslog.StreamAccessLogsMessage) error {
+	switch logEntries := msg.GetLogEntries().(type) {
+	case *envoy_accesslog.StreamAccessLogsMessage_HttpLogs:
+		for _, httpLogEntry := range logEntries.HttpLogs.GetLogEntry() {
+			record, err := h.format.FormatHttpLogEntry(httpLogEntry)
+			if err != nil {
+				return errors.Wrapf(err, "failed to format an HTTP log entry %v as %q", httpLogEntry, h.format)
+			}
+			if err := h.sender.Send(record); err != nil {
+				return err
+			}
+		}
+	case *envoy_accesslog.StreamAccessLogsMessage_TcpLogs:
+		for _, tcpLogEntry := range logEntries.TcpLogs.GetLogEntry() {
+			record, err := h.format.FormatTcpLogEntry(tcpLogEntry)
+			if err != nil {
+				return errors.Wrapf(err, "failed to format a TCP log entry %v as %q", tcpLogEntry, h.format)
+			}
+			if err := h.sender.Send(record); err != nil {
+				return err
+			}
+		}
+	default:
+		return errors.Errorf("unknown type of log entries: %T", msg.GetLogEntries())
+	}
+	return nil
+}
+
+func (h *handler) Close() error {
+	return h.sender.Close()
+}

--- a/app/kuma-dp/pkg/dataplane/accesslogs/handler_private_test.go
+++ b/app/kuma-dp/pkg/dataplane/accesslogs/handler_private_test.go
@@ -1,0 +1,207 @@
+package accesslogs
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/ginkgo/extensions/table"
+	. "github.com/onsi/gomega"
+
+	envoy_accesslog "github.com/envoyproxy/go-control-plane/envoy/service/accesslog/v2"
+
+	"github.com/Kong/kuma/pkg/envoy/accesslog"
+
+	util_proto "github.com/Kong/kuma/pkg/util/proto"
+)
+
+var _ = Describe("handler", func() {
+
+	Describe("Handle()", func() {
+		Describe("happy path", func() {
+
+			sampleFormat := `[%START_TIME%] "%REQ(:METHOD)% %REQ(X-ENVOY-ORIGINAL-PATH?:PATH)% %PROTOCOL%" %RESPONSE_CODE% %RESPONSE_FLAGS% %BYTES_RECEIVED% %BYTES_SENT% %DURATION% %RESP(CONTENT-TYPE)%
+` // intentional newline at the end
+
+			type testCase struct {
+				format   string
+				msg      string
+				expected []string
+			}
+
+			DescribeTable("should handle valid messages",
+				func(given testCase) {
+					By("doing setup")
+					fakeSender := fakeSender{}
+					// when
+					format, err := accesslog.ParseFormat(given.format)
+					// then
+					Expect(err).ToNot(HaveOccurred())
+					// and
+					handler := &handler{format: format, sender: &fakeSender}
+
+					// when
+					msg := &envoy_accesslog.StreamAccessLogsMessage{}
+					// and
+					err = util_proto.FromYAML([]byte(given.msg), msg)
+					// then
+					Expect(err).ToNot(HaveOccurred())
+
+					By("doing test")
+					// when
+					err = handler.Handle(msg)
+					// then
+					Expect(err).ToNot(HaveOccurred())
+					// and
+					Expect([]string(fakeSender)).To(Equal(given.expected))
+				},
+				Entry("empty HTTP log entry", testCase{
+					format: sampleFormat,
+					msg: `
+                    http_logs:
+                      log_entry:
+                      - {}
+`,
+					expected: []string{"[-] \"- - -\" 0 - 0 0 - -\n"},
+				}),
+				Entry("1 HTTP log entry", testCase{
+					format: sampleFormat,
+					msg: `
+                    http_logs:
+                      log_entry:
+                      - common_properties:
+                          start_time: 2020-02-11T12:34:56.123Z
+                        protocol_version: HTTP11
+                        request:
+                          request_method: POST
+                          authority: backend.internal:8080
+                          path: /api
+                          request_body_bytes: 234
+                        response:
+                          response_code: 200
+                          response_headers:
+                            content-type: application/json
+                          response_body_bytes: 567
+`,
+					expected: []string{"[2020-02-11T12:34:56.123Z] \"POST /api HTTP/1.1\" 200 - 234 567 - application/json\n"},
+				}),
+				Entry("2 HTTP log entries", testCase{
+					format: sampleFormat,
+					msg: `
+                    http_logs:
+                      log_entry:
+                      - common_properties:
+                          start_time: 2020-02-11T12:34:56.123Z
+                        protocol_version: HTTP11
+                        request:
+                          request_method: POST
+                          authority: backend.internal:8080
+                          path: /api
+                          request_body_bytes: 234
+                        response:
+                          response_code: 200
+                          response_headers:
+                            content-type: application/json
+                          response_body_bytes: 567
+                      - common_properties:
+                          start_time: 2020-02-18T23:45:07.456Z
+                        protocol_version: HTTP2
+                        request:
+                          request_method: GET
+                          authority: web.internal:8080
+                          path: /index.html
+                          request_body_bytes: 0
+                        response:
+                          response_code: 301
+                          response_headers:
+                            content-type: text/html
+                          response_body_bytes: 89012
+`,
+					expected: []string{
+						"[2020-02-11T12:34:56.123Z] \"POST /api HTTP/1.1\" 200 - 234 567 - application/json\n",
+						"[2020-02-18T23:45:07.456Z] \"GET /index.html HTTP/2\" 301 - 0 89012 - text/html\n",
+					},
+				}),
+				Entry("empty TCP log entry", testCase{
+					format: sampleFormat,
+					msg: `
+                    tcp_logs:
+                      log_entry:
+                      - {}
+`,
+					expected: []string{"[-] \"- - -\" 0 - 0 0 - -\n"},
+				}),
+				Entry("1 HTTP log entry", testCase{
+					format: sampleFormat,
+					msg: `
+                    tcp_logs:
+                      log_entry:
+                      - common_properties:
+                          start_time: 2020-02-11T12:34:56.123Z
+                        connection_properties:
+                          received_bytes: 234
+                          sent_bytes: 567
+`,
+					expected: []string{"[2020-02-11T12:34:56.123Z] \"- - -\" 0 - 234 567 - -\n"},
+				}),
+				Entry("2 TCP log entries", testCase{
+					format: sampleFormat,
+					msg: `
+                    tcp_logs:
+                      log_entry:
+                      - common_properties:
+                          start_time: 2020-02-11T12:34:56.123Z
+                        connection_properties:
+                          received_bytes: 234
+                          sent_bytes: 567
+                      - common_properties:
+                          start_time: 2020-02-18T23:45:07.456Z
+                        connection_properties:
+                          received_bytes: 0
+                          sent_bytes: 89012
+`,
+					expected: []string{
+						"[2020-02-11T12:34:56.123Z] \"- - -\" 0 - 234 567 - -\n",
+						"[2020-02-18T23:45:07.456Z] \"- - -\" 0 - 0 89012 - -\n",
+					},
+				}),
+			)
+		})
+
+		Describe("error path", func() {
+			type testCase struct {
+				format      string
+				msg         string
+				expectedErr string
+			}
+
+			DescribeTable("should reject invalid mesasages",
+				func(given testCase) {
+					By("doing setup")
+					fakeSender := fakeSender{}
+					// when
+					format, err := accesslog.ParseFormat(given.format)
+					// then
+					Expect(err).ToNot(HaveOccurred())
+					// and
+					handler := &handler{format: format, sender: &fakeSender}
+
+					// when
+					msg := &envoy_accesslog.StreamAccessLogsMessage{}
+					// and
+					err = util_proto.FromYAML([]byte(given.msg), msg)
+					// then
+					Expect(err).ToNot(HaveOccurred())
+
+					By("doing test")
+					// when
+					err = handler.Handle(msg)
+					// then
+					Expect(err).To(HaveOccurred())
+					// and
+					Expect(err.Error()).To(Equal(given.expectedErr))
+				},
+				Entry("no log entries", testCase{
+					expectedErr: `unknown type of log entries: <nil>`,
+				}),
+			)
+		})
+	})
+})

--- a/app/kuma-dp/pkg/dataplane/accesslogs/helper_test.go
+++ b/app/kuma-dp/pkg/dataplane/accesslogs/helper_test.go
@@ -1,0 +1,14 @@
+package accesslogs
+
+type fakeSender []string
+
+func (s *fakeSender) Connect() error {
+	return nil
+}
+func (s *fakeSender) Send(record string) error {
+	*s = append(*s, record)
+	return nil
+}
+func (s *fakeSender) Close() error {
+	return nil
+}

--- a/app/kuma-dp/pkg/dataplane/accesslogs/interfaces.go
+++ b/app/kuma-dp/pkg/dataplane/accesslogs/interfaces.go
@@ -1,0 +1,28 @@
+package accesslogs
+
+import (
+	"io"
+
+	"github.com/go-logr/logr"
+
+	envoy_accesslog "github.com/envoyproxy/go-control-plane/envoy/service/accesslog/v2"
+)
+
+// logHandler represents a contract between a log stream receiver and a log handler.
+type logHandler interface {
+	Handle(msg *envoy_accesslog.StreamAccessLogsMessage) error
+	io.Closer
+}
+
+// logSender represents a contract between a log handler and a log sender.
+type logSender interface {
+	Connect() error
+	Send(entry string) error
+	io.Closer
+}
+
+// logHandlerFactoryFunc represents a factory of log handler implementations.
+type logHandlerFactoryFunc = func(log logr.Logger, msg *envoy_accesslog.StreamAccessLogsMessage, newSender logSenderFactoryFunc) (logHandler, error)
+
+// logSenderFactoryFunc represents a factory of log sender implementations.
+type logSenderFactoryFunc = func(log logr.Logger, address string) (logSender, error)

--- a/app/kuma-dp/pkg/dataplane/accesslogs/interfaces.go
+++ b/app/kuma-dp/pkg/dataplane/accesslogs/interfaces.go
@@ -22,7 +22,4 @@ type logSender interface {
 }
 
 // logHandlerFactoryFunc represents a factory of log handler implementations.
-type logHandlerFactoryFunc = func(log logr.Logger, msg *envoy_accesslog.StreamAccessLogsMessage, newSender logSenderFactoryFunc) (logHandler, error)
-
-// logSenderFactoryFunc represents a factory of log sender implementations.
-type logSenderFactoryFunc = func(log logr.Logger, address string) (logSender, error)
+type logHandlerFactoryFunc = func(log logr.Logger, msg *envoy_accesslog.StreamAccessLogsMessage) (logHandler, error)

--- a/app/kuma-dp/pkg/dataplane/accesslogs/sender.go
+++ b/app/kuma-dp/pkg/dataplane/accesslogs/sender.go
@@ -1,0 +1,42 @@
+package accesslogs
+
+import (
+	"net"
+	"time"
+
+	"github.com/pkg/errors"
+
+	"github.com/go-logr/logr"
+)
+
+const (
+	defaultConnectTimeout = 5 * time.Second
+)
+
+type sender struct {
+	log     logr.Logger
+	address string
+	conn    net.Conn
+}
+
+func (s *sender) Connect() error {
+	conn, err := net.DialTimeout("tcp", s.address, defaultConnectTimeout)
+	if err != nil {
+		return errors.Wrapf(err, "failed to connect to a TCP logging backend: %s", s.address)
+	}
+	s.log.Info("connected to TCP logging backend", "address", s.address)
+	s.conn = conn
+	return nil
+}
+
+func (s *sender) Send(record string) error {
+	_, err := s.conn.Write(append([]byte(record), byte('\n')))
+	return errors.Wrapf(err, "failed to send a log entry to a TCP logging backend: %s", s.address)
+}
+
+func (s *sender) Close() error {
+	if s.conn != nil {
+		return s.conn.Close()
+	}
+	return nil
+}

--- a/app/kuma-dp/pkg/dataplane/accesslogs/server.go
+++ b/app/kuma-dp/pkg/dataplane/accesslogs/server.go
@@ -20,7 +20,6 @@ var logger = core.Log.WithName("accesslogs-server")
 type accessLogServer struct {
 	server     *grpc.Server
 	newHandler logHandlerFactoryFunc
-	newSender  logSenderFactoryFunc
 
 	// streamCount for counting streams
 	streamCount int64
@@ -30,7 +29,6 @@ func NewAccessLogServer() *accessLogServer {
 	return &accessLogServer{
 		server:     grpc.NewServer(),
 		newHandler: defaultHandler,
-		newSender:  defaultSender,
 	}
 }
 
@@ -65,7 +63,7 @@ func (s *accessLogServer) StreamAccessLogs(stream envoy_accesslog.AccessLogServi
 		if !initialized {
 			initialized = true
 
-			handler, err = s.newHandler(log, msg, s.newSender)
+			handler, err = s.newHandler(log, msg)
 			if err != nil {
 				return errors.Wrap(err, "failed to initialize Access Logs stream")
 			}

--- a/app/kuma-dp/pkg/dataplane/accesslogs/server.go
+++ b/app/kuma-dp/pkg/dataplane/accesslogs/server.go
@@ -4,33 +4,23 @@ import (
 	"fmt"
 	"io"
 	"net"
-	"strconv"
-	"strings"
 	"sync/atomic"
-	"time"
 
-	"github.com/go-logr/logr"
-	"github.com/golang/protobuf/ptypes"
-	"github.com/pkg/errors"
 	"google.golang.org/grpc"
 
 	kumadp "github.com/Kong/kuma/pkg/config/app/kuma-dp"
 	"github.com/Kong/kuma/pkg/core"
-	util_proto "github.com/Kong/kuma/pkg/util/proto"
+	"github.com/pkg/errors"
 
-	envoy_core "github.com/envoyproxy/go-control-plane/envoy/api/v2/core"
-	envoy_data_accesslog_v2 "github.com/envoyproxy/go-control-plane/envoy/data/accesslog/v2"
-	v2 "github.com/envoyproxy/go-control-plane/envoy/service/accesslog/v2"
+	envoy_accesslog "github.com/envoyproxy/go-control-plane/envoy/service/accesslog/v2"
 )
 
 var logger = core.Log.WithName("accesslogs-server")
 
-const (
-	defaultConnectTimeout = 5 * time.Second
-)
-
 type accessLogServer struct {
-	server *grpc.Server
+	server     *grpc.Server
+	newHandler logHandlerFactoryFunc
+	newSender  logSenderFactoryFunc
 
 	// streamCount for counting streams
 	streamCount int64
@@ -38,11 +28,13 @@ type accessLogServer struct {
 
 func NewAccessLogServer() *accessLogServer {
 	return &accessLogServer{
-		server: grpc.NewServer(),
+		server:     grpc.NewServer(),
+		newHandler: defaultHandler,
+		newSender:  defaultSender,
 	}
 }
 
-func (s *accessLogServer) StreamAccessLogs(stream v2.AccessLogService_StreamAccessLogsServer) (err error) {
+func (s *accessLogServer) StreamAccessLogs(stream envoy_accesslog.AccessLogService_StreamAccessLogsServer) (err error) {
 	// increment stream count
 	streamID := atomic.AddInt64(&s.streamCount, 1)
 
@@ -58,8 +50,7 @@ func (s *accessLogServer) StreamAccessLogs(stream v2.AccessLogService_StreamAcce
 	}()
 
 	initialized := false
-	var address, format string
-	var conn net.Conn
+	var handler logHandler
 	for {
 		msg, err := stream.Recv()
 		if err != nil {
@@ -74,86 +65,21 @@ func (s *accessLogServer) StreamAccessLogs(stream v2.AccessLogService_StreamAcce
 		if !initialized {
 			initialized = true
 
-			parts := strings.SplitN(msg.Identifier.GetLogName(), ";", 2)
-			if len(parts) != 2 {
-				return errors.Errorf("failed to initialize Access Logs stream: invalid log name %q: expected %d components, got %d", msg.Identifier.GetLogName(), 2, len(parts))
-			}
-			address = parts[0]
-			format = parts[1]
-			conn, err = s.connect(address, log)
+			handler, err = s.newHandler(log, msg, s.newSender)
 			if err != nil {
-				return err
+				return errors.Wrap(err, "failed to initialize Access Logs stream")
 			}
-			defer conn.Close()
+			defer handler.Close()
 		}
 
-		var httpLogs []*envoy_data_accesslog_v2.HTTPAccessLogEntry
-		switch logEntries := msg.LogEntries.(type) {
-		case *v2.StreamAccessLogsMessage_HttpLogs:
-			httpLogs = logEntries.HttpLogs.GetLogEntry()
-		case *v2.StreamAccessLogsMessage_TcpLogs:
-			return errors.New("TcpLogs entries are not supported yet")
-		default:
-			return errors.Errorf("unknown type of log entries: %T", msg.LogEntries)
-		}
-
-		for _, httpLogEntry := range httpLogs {
-			entry := formatEntry(httpLogEntry, format)
-			if err := s.sendLog(conn, entry); err != nil {
-				return errors.Wrap(err, "could not send log entry to a TCP logging backend")
-			}
+		if err := handler.Handle(msg); err != nil {
+			return err
 		}
 	}
-}
-
-func formatEntry(entry *envoy_data_accesslog_v2.HTTPAccessLogEntry, format string) string {
-	addrToString := func(addr *envoy_core.Address) string {
-		return fmt.Sprintf("%s:%d", addr.GetSocketAddress().GetAddress(), addr.GetSocketAddress().GetPortValue())
-	}
-	connectionTime := int64(0)
-	if entry.GetCommonProperties().GetTimeToLastDownstreamTxByte() != nil {
-		t, err := ptypes.Duration(entry.GetCommonProperties().GetTimeToLastDownstreamTxByte())
-		if err == nil {
-			connectionTime = int64(t / time.Millisecond)
-		}
-	}
-	placeholders := map[string]string{
-		"%START_TIME%":                util_proto.TimestampString(entry.GetCommonProperties().GetStartTime(), time.RFC3339),
-		"%DOWNSTREAM_REMOTE_ADDRESS%": addrToString(entry.GetCommonProperties().GetDownstreamRemoteAddress()),
-		"%DOWNSTREAM_LOCAL_ADDRESS%":  addrToString(entry.GetCommonProperties().GetDownstreamLocalAddress()),
-		"%UPSTREAM_HOST%":             addrToString(entry.GetCommonProperties().GetUpstreamRemoteAddress()),
-		"%UPSTREAM_REMOTE_ADDRESS%":   addrToString(entry.GetCommonProperties().GetUpstreamRemoteAddress()),
-		"%UPSTREAM_LOCAL_ADDRESS%":    addrToString(entry.GetCommonProperties().GetUpstreamLocalAddress()),
-		"%UPSTREAM_CLUSTER%":          entry.GetCommonProperties().GetUpstreamCluster(),
-		"%BYTES_RECEIVED%":            strconv.FormatUint(entry.GetResponse().GetResponseBodyBytes(), 10),
-		"%BYTES_SENT%":                strconv.FormatUint(entry.GetRequest().GetRequestBodyBytes(), 10),
-		"%DURATION%":                  strconv.FormatInt(connectionTime, 10),
-		"%RESPONSE_TX_DURATION%":      strconv.FormatInt(connectionTime, 10),
-	}
-	log := format
-	for placeholder, value := range placeholders {
-		log = strings.ReplaceAll(log, placeholder, value)
-	}
-	return log
-}
-
-func (s *accessLogServer) sendLog(conn net.Conn, log string) error {
-	_, err := conn.Write(append([]byte(log), byte('\n')))
-	return err
-}
-
-func (s *accessLogServer) connect(address string, log logr.Logger) (net.Conn, error) {
-	conn, err := net.DialTimeout("tcp", address, defaultConnectTimeout)
-	if err != nil {
-		log.Error(err, "failed to connect to TCP logging backend", "address", address)
-		return nil, err
-	}
-	log.Info("connected to TCP logging backend", "address", address)
-	return conn, nil
 }
 
 func (s *accessLogServer) Start(dataplane kumadp.Dataplane) error {
-	v2.RegisterAccessLogServiceServer(s.server, s)
+	envoy_accesslog.RegisterAccessLogServiceServer(s.server, s)
 	address := fmt.Sprintf("/tmp/kuma-access-logs-%s-%s.sock", dataplane.Name, dataplane.Mesh)
 	lis, err := net.Listen("unix", address)
 	if err != nil {
@@ -171,4 +97,4 @@ func (s *accessLogServer) Close() {
 	s.server.GracefulStop()
 }
 
-var _ v2.AccessLogServiceServer = &accessLogServer{}
+var _ envoy_accesslog.AccessLogServiceServer = &accessLogServer{}


### PR DESCRIPTION
### Summary

* extend embedded gRPC Access Log Server to support the entire Envoy access log format

