### PR TITLE
kuma-cp: include k8s namespace into a set of labels that describe a given Dataplane to Prometheus

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 Changes:
 
+* feature: include `k8s` namespace into a set of labels that describe a `Dataplane` to `Prometheus`
+  [#601](https://github.com/Kong/kuma/pull/601)
 * feature: provision Grafana with Kuma Dashboards
   [#608](https://github.com/Kong/kuma/pull/608)
 * feature: add support for `kuma.io/sidecar-injection: disabled` annotation on `Pods` to let users selectively opt out of side-car injection on `k8s`

--- a/app/kumactl/cmd/apply/apply.go
+++ b/app/kumactl/cmd/apply/apply.go
@@ -164,8 +164,8 @@ func (m meta) GetName() string {
 	return m.Name
 }
 
-func (m meta) GetDimensionalName() model.DimensionalResourceName {
-	return model.DimensionalResourceNameUnsupported
+func (m meta) GetNameExtensions() model.ResourceNameExtensions {
+	return model.ResourceNameExtensionsUnsupported
 }
 
 func (m meta) GetVersion() string {

--- a/app/kumactl/cmd/apply/apply.go
+++ b/app/kumactl/cmd/apply/apply.go
@@ -164,6 +164,10 @@ func (m meta) GetName() string {
 	return m.Name
 }
 
+func (m meta) GetDimensionalName() model.DimensionalResourceName {
+	return model.DimensionalResourceNameUnsupported
+}
+
 func (m meta) GetVersion() string {
 	return ""
 }

--- a/pkg/core/resources/model/resource.go
+++ b/pkg/core/resources/model/resource.go
@@ -2,13 +2,20 @@ package model
 
 import (
 	"fmt"
-	"github.com/golang/protobuf/proto"
 	"reflect"
 	"time"
+
+	"github.com/golang/protobuf/proto"
 )
 
 const (
 	DefaultMesh = "default"
+)
+
+var (
+	// DimensionalResourceNameUnsupported is a convenience constant
+	// that is meant to make source code more readable.
+	DimensionalResourceNameUnsupported = DimensionalResourceName(nil)
 )
 
 type ResourceKey struct {
@@ -27,8 +34,29 @@ type Resource interface {
 
 type ResourceType string
 
+// DimensionalResourceName represents a composite resource name.
+//
+// E.g., name of a Kubernetes resource consists of a namespace component
+// and a name component that is local to that namespace.
+//
+// Technically, DimensionalResourceName is a mapping between
+// a component identifier and a component value, e.g.
+//
+//   "k8s.kuma.io/namespace" => "my-namespace"
+//   "k8s.kuma.io/name"      => "my-policy"
+//
+// Component identifier must be considered a part of user-facing Kuma API.
+// In other words, it is supposed to be visible to users and should not be changed lightly.
+//
+// Component identifier might have any value, however, it's preferable
+// to choose one that is intuitive to users of that particular environment.
+// E.g., on Kubernetes component identifiers should use a label name format,
+// like in "k8s.kuma.io/namespace" and "k8s.kuma.io/name".
+type DimensionalResourceName map[string]string
+
 type ResourceMeta interface {
 	GetName() string
+	GetDimensionalName() DimensionalResourceName
 	GetVersion() string
 	GetMesh() string
 	GetCreationTime() time.Time

--- a/pkg/core/resources/model/resource.go
+++ b/pkg/core/resources/model/resource.go
@@ -13,9 +13,9 @@ const (
 )
 
 var (
-	// DimensionalResourceNameUnsupported is a convenience constant
+	// ResourceNameExtensionsUnsupported is a convenience constant
 	// that is meant to make source code more readable.
-	DimensionalResourceNameUnsupported = DimensionalResourceName(nil)
+	ResourceNameExtensionsUnsupported = ResourceNameExtensions(nil)
 )
 
 type ResourceKey struct {
@@ -34,12 +34,13 @@ type Resource interface {
 
 type ResourceType string
 
-// DimensionalResourceName represents a composite resource name.
+// ResourceNameExtensions represents an composite resource name in environments
+// other than Universal.
 //
 // E.g., name of a Kubernetes resource consists of a namespace component
 // and a name component that is local to that namespace.
 //
-// Technically, DimensionalResourceName is a mapping between
+// Technically, ResourceNameExtensions is a mapping between
 // a component identifier and a component value, e.g.
 //
 //   "k8s.kuma.io/namespace" => "my-namespace"
@@ -52,11 +53,11 @@ type ResourceType string
 // to choose one that is intuitive to users of that particular environment.
 // E.g., on Kubernetes component identifiers should use a label name format,
 // like in "k8s.kuma.io/namespace" and "k8s.kuma.io/name".
-type DimensionalResourceName map[string]string
+type ResourceNameExtensions map[string]string
 
 type ResourceMeta interface {
 	GetName() string
-	GetDimensionalName() DimensionalResourceName
+	GetNameExtensions() ResourceNameExtensions
 	GetVersion() string
 	GetMesh() string
 	GetCreationTime() time.Time

--- a/pkg/mads/generator/assignments.go
+++ b/pkg/mads/generator/assignments.go
@@ -164,8 +164,8 @@ func (g MonitoringAssignmentsGenerator) dataplaneLabels(dataplane *mesh_core.Dat
 		plural := fmt.Sprintf("%ss", key)
 		labels[prom_util.SanitizeLabelName(plural)] = g.multiValue(values)
 	}
-	// then, we turn components of a dimensional name into labels
-	for key, value := range dataplane.GetMeta().GetDimensionalName() {
+	// then, we turn name extensions into labels
+	for key, value := range dataplane.GetMeta().GetNameExtensions() {
 		labels[prom_util.SanitizeLabelName(key)] = value
 	}
 	// then, we apply mandatory labels on top

--- a/pkg/mads/generator/assignments.go
+++ b/pkg/mads/generator/assignments.go
@@ -164,6 +164,10 @@ func (g MonitoringAssignmentsGenerator) dataplaneLabels(dataplane *mesh_core.Dat
 		plural := fmt.Sprintf("%ss", key)
 		labels[prom_util.SanitizeLabelName(plural)] = g.multiValue(values)
 	}
+	// then, we turn components of a dimensional name into labels
+	for key, value := range dataplane.GetMeta().GetDimensionalName() {
+		labels[prom_util.SanitizeLabelName(key)] = value
+	}
 	// then, we apply mandatory labels on top
 	labels[prom.SchemeLabel] = "http"
 	labels[prom.MetricsPathLabel] = endpoint.GetPath()

--- a/pkg/mads/generator/assignments_test.go
+++ b/pkg/mads/generator/assignments_test.go
@@ -530,7 +530,7 @@ var _ = Describe("MonitoringAssignmentsGenerator", func() {
 					{
 						Meta: &test_model.ResourceMeta{
 							Name: "backend-5c89f4d995-85znn.my-namespace",
-							DimensionalName: core_model.DimensionalResourceName{
+							NameExtensions: core_model.ResourceNameExtensions{
 								"k8s.kuma.io/namespace": "my-namespace",
 								"k8s.kuma.io/name":      "backend-5c89f4d995-85znn",
 							},

--- a/pkg/plugins/common/k8s/k8s_suite_test.go
+++ b/pkg/plugins/common/k8s/k8s_suite_test.go
@@ -1,0 +1,13 @@
+package k8s_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+func TestK8s(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "K8s Suite")
+}

--- a/pkg/plugins/common/k8s/names.go
+++ b/pkg/plugins/common/k8s/names.go
@@ -5,20 +5,20 @@ import (
 )
 
 const (
-	// k8sNamespaceDimension identifies the namespace component of a resource name on Kubernetes.
+	// k8sNamespaceComponent identifies the namespace component of a resource name on Kubernetes.
 	// The value is considered a part of user-facing Kuma API and should not be changed lightly.
 	// The value has a format of a Kubernetes label name.
-	k8sNamespaceDimension = "k8s.kuma.io/namespace"
+	k8sNamespaceComponent = "k8s.kuma.io/namespace"
 
-	// k8sNameDimension identifies the name component of a resource name on Kubernetes.
+	// k8sNameComponent identifies the name component of a resource name on Kubernetes.
 	// The value is considered a part of user-facing Kuma API and should not be changed lightly.
 	// The value has a format of a Kubernetes label name.
-	k8sNameDimension = "k8s.kuma.io/name"
+	k8sNameComponent = "k8s.kuma.io/name"
 )
 
-func DimensionalResourceName(namespace, name string) core_model.DimensionalResourceName {
-	return core_model.DimensionalResourceName{
-		k8sNamespaceDimension: namespace,
-		k8sNameDimension:      name,
+func ResourceNameExtensions(namespace, name string) core_model.ResourceNameExtensions {
+	return core_model.ResourceNameExtensions{
+		k8sNamespaceComponent: namespace,
+		k8sNameComponent:      name,
 	}
 }

--- a/pkg/plugins/common/k8s/names.go
+++ b/pkg/plugins/common/k8s/names.go
@@ -1,0 +1,24 @@
+package k8s
+
+import (
+	core_model "github.com/Kong/kuma/pkg/core/resources/model"
+)
+
+const (
+	// k8sNamespaceDimension identifies the namespace component of a resource name on Kubernetes.
+	// The value is considered a part of user-facing Kuma API and should not be changed lightly.
+	// The value has a format of a Kubernetes label name.
+	k8sNamespaceDimension = "k8s.kuma.io/namespace"
+
+	// k8sNameDimension identifies the name component of a resource name on Kubernetes.
+	// The value is considered a part of user-facing Kuma API and should not be changed lightly.
+	// The value has a format of a Kubernetes label name.
+	k8sNameDimension = "k8s.kuma.io/name"
+)
+
+func DimensionalResourceName(namespace, name string) core_model.DimensionalResourceName {
+	return core_model.DimensionalResourceName{
+		k8sNamespaceDimension: namespace,
+		k8sNameDimension:      name,
+	}
+}

--- a/pkg/plugins/common/k8s/names_test.go
+++ b/pkg/plugins/common/k8s/names_test.go
@@ -1,0 +1,47 @@
+package k8s_test
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/ginkgo/extensions/table"
+	. "github.com/onsi/gomega"
+
+	. "github.com/Kong/kuma/pkg/plugins/common/k8s"
+
+	core_model "github.com/Kong/kuma/pkg/core/resources/model"
+)
+
+var _ = Describe("DimensionalResourceName()", func() {
+	type testCase struct {
+		namespace string
+		name      string
+		expected  core_model.DimensionalResourceName
+	}
+
+	DescribeTable("should return a correct dimensional name",
+		func(given testCase) {
+			// when
+			actual := DimensionalResourceName(given.namespace, given.name)
+			// then
+			Expect(actual).To(HaveKey("k8s.kuma.io/namespace"), "DO NOT change dimension identifiers lightly! They are considered a part of user-facing Kuma API")
+			Expect(actual).To(HaveKey("k8s.kuma.io/name"), "DO NOT change dimension identifiers lightly! They are considered a part of user-facing Kuma API")
+			// then
+			Expect(actual).To(Equal(given.expected))
+		},
+		Entry("namespace-scoped k8s resource", testCase{
+			namespace: "my-namespace",
+			name:      "my-policy",
+			expected: core_model.DimensionalResourceName{
+				"k8s.kuma.io/namespace": "my-namespace",
+				"k8s.kuma.io/name":      "my-policy",
+			},
+		}),
+		Entry("cluster-scoped k8s resource", testCase{
+			namespace: "",
+			name:      "my-policy",
+			expected: core_model.DimensionalResourceName{
+				"k8s.kuma.io/namespace": "",
+				"k8s.kuma.io/name":      "my-policy",
+			},
+		}),
+	)
+})

--- a/pkg/plugins/common/k8s/names_test.go
+++ b/pkg/plugins/common/k8s/names_test.go
@@ -10,27 +10,27 @@ import (
 	core_model "github.com/Kong/kuma/pkg/core/resources/model"
 )
 
-var _ = Describe("DimensionalResourceName()", func() {
+var _ = Describe("ResourceNameExtensions()", func() {
 	type testCase struct {
 		namespace string
 		name      string
-		expected  core_model.DimensionalResourceName
+		expected  core_model.ResourceNameExtensions
 	}
 
-	DescribeTable("should return a correct dimensional name",
+	DescribeTable("should return correct k8s name extensions",
 		func(given testCase) {
 			// when
-			actual := DimensionalResourceName(given.namespace, given.name)
+			actual := ResourceNameExtensions(given.namespace, given.name)
 			// then
-			Expect(actual).To(HaveKey("k8s.kuma.io/namespace"), "DO NOT change dimension identifiers lightly! They are considered a part of user-facing Kuma API")
-			Expect(actual).To(HaveKey("k8s.kuma.io/name"), "DO NOT change dimension identifiers lightly! They are considered a part of user-facing Kuma API")
+			Expect(actual).To(HaveKey("k8s.kuma.io/namespace"), "DO NOT change extension identifiers lightly! They are considered a part of user-facing Kuma API")
+			Expect(actual).To(HaveKey("k8s.kuma.io/name"), "DO NOT change extension identifiers lightly! They are considered a part of user-facing Kuma API")
 			// then
 			Expect(actual).To(Equal(given.expected))
 		},
 		Entry("namespace-scoped k8s resource", testCase{
 			namespace: "my-namespace",
 			name:      "my-policy",
-			expected: core_model.DimensionalResourceName{
+			expected: core_model.ResourceNameExtensions{
 				"k8s.kuma.io/namespace": "my-namespace",
 				"k8s.kuma.io/name":      "my-policy",
 			},
@@ -38,7 +38,7 @@ var _ = Describe("DimensionalResourceName()", func() {
 		Entry("cluster-scoped k8s resource", testCase{
 			namespace: "",
 			name:      "my-policy",
-			expected: core_model.DimensionalResourceName{
+			expected: core_model.ResourceNameExtensions{
 				"k8s.kuma.io/namespace": "",
 				"k8s.kuma.io/name":      "my-policy",
 			},

--- a/pkg/plugins/resources/k8s/store.go
+++ b/pkg/plugins/resources/k8s/store.go
@@ -3,8 +3,11 @@ package k8s
 import (
 	"context"
 	"fmt"
+	"time"
+
 	core_model "github.com/Kong/kuma/pkg/core/resources/model"
 	"github.com/Kong/kuma/pkg/core/resources/store"
+	common_k8s "github.com/Kong/kuma/pkg/plugins/common/k8s"
 	k8s_model "github.com/Kong/kuma/pkg/plugins/resources/k8s/native/pkg/model"
 	k8s_registry "github.com/Kong/kuma/pkg/plugins/resources/k8s/native/pkg/registry"
 	util_k8s "github.com/Kong/kuma/pkg/util/k8s"
@@ -13,7 +16,6 @@ import (
 	kube_apierrs "k8s.io/apimachinery/pkg/api/errors"
 	kube_meta "k8s.io/apimachinery/pkg/apis/meta/v1"
 	kube_client "sigs.k8s.io/controller-runtime/pkg/client"
-	"time"
 )
 
 var _ store.ResourceStore = &KubernetesStore{}
@@ -170,6 +172,10 @@ func (m *KubernetesMetaAdapter) GetName() string {
 		return m.ObjectMeta.Name
 	}
 	return util_k8s.K8sNamespacedNameToCoreName(m.ObjectMeta.Name, m.ObjectMeta.Namespace)
+}
+
+func (m *KubernetesMetaAdapter) GetDimensionalName() core_model.DimensionalResourceName {
+	return common_k8s.DimensionalResourceName(m.ObjectMeta.Namespace, m.ObjectMeta.Name)
 }
 
 func (m *KubernetesMetaAdapter) GetVersion() string {

--- a/pkg/plugins/resources/k8s/store.go
+++ b/pkg/plugins/resources/k8s/store.go
@@ -174,8 +174,8 @@ func (m *KubernetesMetaAdapter) GetName() string {
 	return util_k8s.K8sNamespacedNameToCoreName(m.ObjectMeta.Name, m.ObjectMeta.Namespace)
 }
 
-func (m *KubernetesMetaAdapter) GetDimensionalName() core_model.DimensionalResourceName {
-	return common_k8s.DimensionalResourceName(m.ObjectMeta.Namespace, m.ObjectMeta.Name)
+func (m *KubernetesMetaAdapter) GetNameExtensions() core_model.ResourceNameExtensions {
+	return common_k8s.ResourceNameExtensions(m.ObjectMeta.Namespace, m.ObjectMeta.Name)
 }
 
 func (m *KubernetesMetaAdapter) GetVersion() string {

--- a/pkg/plugins/resources/k8s/store_test.go
+++ b/pkg/plugins/resources/k8s/store_test.go
@@ -417,7 +417,7 @@ var _ = Describe("KubernetesStore", func() {
 			// and
 			Expect(actual.Meta.GetName()).To(Equal(coreName))
 			// and
-			Expect(actual.Meta.GetDimensionalName()).To(Equal(core_model.DimensionalResourceName{
+			Expect(actual.Meta.GetNameExtensions()).To(Equal(core_model.ResourceNameExtensions{
 				"k8s.kuma.io/namespace": ns,
 				"k8s.kuma.io/name":      name,
 			}))
@@ -451,7 +451,7 @@ var _ = Describe("KubernetesStore", func() {
 			// and
 			Expect(actual.Meta.GetName()).To(Equal(name))
 			// and
-			Expect(actual.Meta.GetDimensionalName()).To(Equal(core_model.DimensionalResourceName{
+			Expect(actual.Meta.GetNameExtensions()).To(Equal(core_model.ResourceNameExtensions{
 				"k8s.kuma.io/namespace": "",
 				"k8s.kuma.io/name":      name,
 			}))
@@ -583,7 +583,7 @@ var _ = Describe("KubernetesStore", func() {
 			// then
 			actualResourceOne := actualResources[fmt.Sprintf("one.%s", ns)]
 			Expect(actualResourceOne.Spec.Path).To(Equal("/example"))
-			Expect(actualResourceOne.Meta.GetDimensionalName()).To(Equal(core_model.DimensionalResourceName{
+			Expect(actualResourceOne.Meta.GetNameExtensions()).To(Equal(core_model.ResourceNameExtensions{
 				"k8s.kuma.io/namespace": ns,
 				"k8s.kuma.io/name":      "one",
 			}))
@@ -591,7 +591,7 @@ var _ = Describe("KubernetesStore", func() {
 			// and
 			actualResourceTwo := actualResources[fmt.Sprintf("two.%s", ns)]
 			Expect(actualResourceTwo.Spec.Path).To(Equal("/another"))
-			Expect(actualResourceTwo.Meta.GetDimensionalName()).To(Equal(core_model.DimensionalResourceName{
+			Expect(actualResourceTwo.Meta.GetNameExtensions()).To(Equal(core_model.ResourceNameExtensions{
 				"k8s.kuma.io/namespace": ns,
 				"k8s.kuma.io/name":      "two",
 			}))
@@ -632,13 +632,13 @@ var _ = Describe("KubernetesStore", func() {
 			}
 			// then
 			Expect(actualResources).To(HaveKey("demo-1"))
-			Expect(actualResources["demo-1"].Meta.GetDimensionalName()).To(Equal(core_model.DimensionalResourceName{
+			Expect(actualResources["demo-1"].Meta.GetNameExtensions()).To(Equal(core_model.ResourceNameExtensions{
 				"k8s.kuma.io/namespace": "",
 				"k8s.kuma.io/name":      "demo-1",
 			}))
 			// and
 			Expect(actualResources).To(HaveKey("demo-2"))
-			Expect(actualResources["demo-2"].Meta.GetDimensionalName()).To(Equal(core_model.DimensionalResourceName{
+			Expect(actualResources["demo-2"].Meta.GetNameExtensions()).To(Equal(core_model.ResourceNameExtensions{
 				"k8s.kuma.io/namespace": "",
 				"k8s.kuma.io/name":      "demo-2",
 			}))

--- a/pkg/plugins/resources/memory/store.go
+++ b/pkg/plugins/resources/memory/store.go
@@ -36,6 +36,9 @@ type memoryMeta struct {
 func (m memoryMeta) GetName() string {
 	return m.Name
 }
+func (m memoryMeta) GetDimensionalName() model.DimensionalResourceName {
+	return model.DimensionalResourceNameUnsupported
+}
 func (m memoryMeta) GetMesh() string {
 	return m.Mesh
 }

--- a/pkg/plugins/resources/memory/store.go
+++ b/pkg/plugins/resources/memory/store.go
@@ -36,8 +36,8 @@ type memoryMeta struct {
 func (m memoryMeta) GetName() string {
 	return m.Name
 }
-func (m memoryMeta) GetDimensionalName() model.DimensionalResourceName {
-	return model.DimensionalResourceNameUnsupported
+func (m memoryMeta) GetNameExtensions() model.ResourceNameExtensions {
+	return model.ResourceNameExtensionsUnsupported
 }
 func (m memoryMeta) GetMesh() string {
 	return m.Mesh

--- a/pkg/plugins/resources/postgres/store.go
+++ b/pkg/plugins/resources/postgres/store.go
@@ -262,6 +262,10 @@ func (r *resourceMetaObject) GetName() string {
 	return r.Name
 }
 
+func (r *resourceMetaObject) GetDimensionalName() model.DimensionalResourceName {
+	return model.DimensionalResourceNameUnsupported
+}
+
 func (r *resourceMetaObject) GetVersion() string {
 	return r.Version
 }

--- a/pkg/plugins/resources/postgres/store.go
+++ b/pkg/plugins/resources/postgres/store.go
@@ -262,8 +262,8 @@ func (r *resourceMetaObject) GetName() string {
 	return r.Name
 }
 
-func (r *resourceMetaObject) GetDimensionalName() model.DimensionalResourceName {
-	return model.DimensionalResourceNameUnsupported
+func (r *resourceMetaObject) GetNameExtensions() model.ResourceNameExtensions {
+	return model.ResourceNameExtensionsUnsupported
 }
 
 func (r *resourceMetaObject) GetVersion() string {

--- a/pkg/plugins/resources/remote/unmarshalling.go
+++ b/pkg/plugins/resources/remote/unmarshalling.go
@@ -19,8 +19,8 @@ type remoteMeta struct {
 func (m remoteMeta) GetName() string {
 	return m.Name
 }
-func (m remoteMeta) GetDimensionalName() model.DimensionalResourceName {
-	return model.DimensionalResourceNameUnsupported
+func (m remoteMeta) GetNameExtensions() model.ResourceNameExtensions {
+	return model.ResourceNameExtensionsUnsupported
 }
 func (m remoteMeta) GetMesh() string {
 	return m.Mesh

--- a/pkg/plugins/resources/remote/unmarshalling.go
+++ b/pkg/plugins/resources/remote/unmarshalling.go
@@ -2,9 +2,10 @@ package remote
 
 import (
 	"encoding/json"
+	"time"
+
 	"github.com/Kong/kuma/pkg/core/resources/model"
 	"github.com/Kong/kuma/pkg/core/resources/model/rest"
-	"time"
 )
 
 type remoteMeta struct {
@@ -17,6 +18,9 @@ type remoteMeta struct {
 
 func (m remoteMeta) GetName() string {
 	return m.Name
+}
+func (m remoteMeta) GetDimensionalName() model.DimensionalResourceName {
+	return model.DimensionalResourceNameUnsupported
 }
 func (m remoteMeta) GetMesh() string {
 	return m.Mesh

--- a/pkg/plugins/secrets/k8s/store.go
+++ b/pkg/plugins/secrets/k8s/store.go
@@ -11,6 +11,7 @@ import (
 	core_model "github.com/Kong/kuma/pkg/core/resources/model"
 	core_store "github.com/Kong/kuma/pkg/core/resources/store"
 	secret_store "github.com/Kong/kuma/pkg/core/secrets/store"
+	common_k8s "github.com/Kong/kuma/pkg/plugins/common/k8s"
 
 	kube_core "k8s.io/api/core/v1"
 	kube_apierrs "k8s.io/apimachinery/pkg/api/errors"
@@ -126,6 +127,10 @@ var _ core_model.ResourceMeta = &KubernetesMetaAdapter{}
 
 type KubernetesMetaAdapter struct {
 	kube_meta.ObjectMeta
+}
+
+func (m *KubernetesMetaAdapter) GetDimensionalName() core_model.DimensionalResourceName {
+	return common_k8s.DimensionalResourceName(m.ObjectMeta.Namespace, m.ObjectMeta.Name)
 }
 
 func (m *KubernetesMetaAdapter) GetVersion() string {

--- a/pkg/plugins/secrets/k8s/store.go
+++ b/pkg/plugins/secrets/k8s/store.go
@@ -129,8 +129,8 @@ type KubernetesMetaAdapter struct {
 	kube_meta.ObjectMeta
 }
 
-func (m *KubernetesMetaAdapter) GetDimensionalName() core_model.DimensionalResourceName {
-	return common_k8s.DimensionalResourceName(m.ObjectMeta.Namespace, m.ObjectMeta.Name)
+func (m *KubernetesMetaAdapter) GetNameExtensions() core_model.ResourceNameExtensions {
+	return common_k8s.ResourceNameExtensions(m.ObjectMeta.Namespace, m.ObjectMeta.Name)
 }
 
 func (m *KubernetesMetaAdapter) GetVersion() string {

--- a/pkg/test/resources/model/resource.go
+++ b/pkg/test/resources/model/resource.go
@@ -11,7 +11,7 @@ var _ core_model.ResourceMeta = &ResourceMeta{}
 type ResourceMeta struct {
 	Mesh             string
 	Name             string
-	DimensionalName  core_model.DimensionalResourceName
+	NameExtensions   core_model.ResourceNameExtensions
 	Version          string
 	CreationTime     time.Time
 	ModificationTime time.Time
@@ -23,8 +23,8 @@ func (m *ResourceMeta) GetMesh() string {
 func (m *ResourceMeta) GetName() string {
 	return m.Name
 }
-func (m *ResourceMeta) GetDimensionalName() core_model.DimensionalResourceName {
-	return m.DimensionalName
+func (m *ResourceMeta) GetNameExtensions() core_model.ResourceNameExtensions {
+	return m.NameExtensions
 }
 func (m *ResourceMeta) GetVersion() string {
 	return m.Version

--- a/pkg/test/resources/model/resource.go
+++ b/pkg/test/resources/model/resource.go
@@ -1,8 +1,9 @@
 package model
 
 import (
-	core_model "github.com/Kong/kuma/pkg/core/resources/model"
 	"time"
+
+	core_model "github.com/Kong/kuma/pkg/core/resources/model"
 )
 
 var _ core_model.ResourceMeta = &ResourceMeta{}
@@ -10,6 +11,7 @@ var _ core_model.ResourceMeta = &ResourceMeta{}
 type ResourceMeta struct {
 	Mesh             string
 	Name             string
+	DimensionalName  core_model.DimensionalResourceName
 	Version          string
 	CreationTime     time.Time
 	ModificationTime time.Time
@@ -20,6 +22,9 @@ func (m *ResourceMeta) GetMesh() string {
 }
 func (m *ResourceMeta) GetName() string {
 	return m.Name
+}
+func (m *ResourceMeta) GetDimensionalName() core_model.DimensionalResourceName {
+	return m.DimensionalName
 }
 func (m *ResourceMeta) GetVersion() string {
 	return m.Version

--- a/pkg/xds/topology/router.go
+++ b/pkg/xds/topology/router.go
@@ -2,13 +2,15 @@ package topology
 
 import (
 	"context"
+	"time"
+
 	mesh_proto "github.com/Kong/kuma/api/mesh/v1alpha1"
 	"github.com/Kong/kuma/pkg/core/policy"
 	mesh_core "github.com/Kong/kuma/pkg/core/resources/apis/mesh"
 	core_manager "github.com/Kong/kuma/pkg/core/resources/manager"
+	core_model "github.com/Kong/kuma/pkg/core/resources/model"
 	core_store "github.com/Kong/kuma/pkg/core/resources/store"
 	core_xds "github.com/Kong/kuma/pkg/core/xds"
-	"time"
 )
 
 type pseudoMeta struct {
@@ -20,6 +22,9 @@ func (m *pseudoMeta) GetMesh() string {
 }
 func (m *pseudoMeta) GetName() string {
 	return m.Name
+}
+func (m *pseudoMeta) GetDimensionalName() core_model.DimensionalResourceName {
+	return core_model.DimensionalResourceNameUnsupported
 }
 func (m *pseudoMeta) GetVersion() string {
 	return ""

--- a/pkg/xds/topology/router.go
+++ b/pkg/xds/topology/router.go
@@ -23,8 +23,8 @@ func (m *pseudoMeta) GetMesh() string {
 func (m *pseudoMeta) GetName() string {
 	return m.Name
 }
-func (m *pseudoMeta) GetDimensionalName() core_model.DimensionalResourceName {
-	return core_model.DimensionalResourceNameUnsupported
+func (m *pseudoMeta) GetNameExtensions() core_model.ResourceNameExtensions {
+	return core_model.ResourceNameExtensionsUnsupported
 }
 func (m *pseudoMeta) GetVersion() string {
 	return ""


### PR DESCRIPTION
### Summary

* include `k8s` namespace into a set of labels that describe a given `Dataplane` to `Prometheus`
