### PR TITLE
fix: remove the requirement to a `Pod` to explicitly list container ports in a case where a `Service` defines target port by number

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 Changes:
 
+* fix: remove the requirement to a `Pod` to explicitly list container ports in a case where a `Service` defines target port by number
+  [#605](https://github.com/Kong/kuma/pull/605)
 * feature: extend embedded gRPC Access Log Server to support the entire Envoy access log format
   [#595](https://github.com/Kong/kuma/pull/595)
 * feature: generate HTTP-specific configuration of access log

--- a/pkg/plugins/discovery/k8s/controllers/pod_converter.go
+++ b/pkg/plugins/discovery/k8s/controllers/pod_converter.go
@@ -104,6 +104,7 @@ func InboundInterfacesFor(pod *kube_core.Pod, services []*kube_core.Service, isG
 			}
 			containerPort, err := util_k8s.FindPort(pod, &svcPort)
 			if err != nil {
+				converterLog.Error(err, "failed to find a container port in a given Pod that would match a given Service port", "namespace", pod.Namespace, "podName", pod.Name, "serviceName", svc.Name, "servicePortName", svcPort.Name)
 				// ignore those cases where a Pod doesn't have all the ports a Service has
 				continue
 			}

--- a/pkg/plugins/discovery/k8s/util/util.go
+++ b/pkg/plugins/discovery/k8s/util/util.go
@@ -52,14 +52,7 @@ func FindPort(pod *kube_core.Pod, svcPort *kube_core.ServicePort) (int, error) {
 			}
 		}
 	case kube_intstr.Int:
-		value := portName.IntVal
-		for _, container := range pod.Spec.Containers {
-			for _, port := range container.Ports {
-				if port.ContainerPort == value && givenOrDefault(port.Protocol) == givenOrDefault(svcPort.Protocol) {
-					return int(port.ContainerPort), nil
-				}
-			}
-		}
+		return portName.IntValue(), nil
 	}
 
 	return 0, fmt.Errorf("no suitable port for manifest: %s", pod.UID)

--- a/pkg/plugins/discovery/k8s/util/util_test.go
+++ b/pkg/plugins/discovery/k8s/util/util_test.go
@@ -2,12 +2,15 @@ package util_test
 
 import (
 	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/ginkgo/extensions/table"
 	. "github.com/onsi/gomega"
 
 	. "github.com/Kong/kuma/pkg/plugins/discovery/k8s/util"
 
 	kube_core "k8s.io/api/core/v1"
 	kube_meta "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/ghodss/yaml"
 )
 
 var _ = Describe("Util", func() {
@@ -127,6 +130,323 @@ var _ = Describe("Util", func() {
 			// then
 			Expect(copy).To(Equal(original))
 			Expect(copy).ToNot(BeIdenticalTo(original))
+		})
+	})
+
+	Describe("FindPort()", func() {
+		Describe("should return a correct port number", func() {
+			type testCase struct {
+				pod      string
+				svcPort  string
+				expected int
+			}
+
+			DescribeTable("should correctly find a matching port in a given Pod",
+				func(given testCase) {
+					// setup
+					pod := kube_core.Pod{}
+					svcPort := kube_core.ServicePort{}
+
+					// when
+					err := yaml.Unmarshal([]byte(given.pod), &pod)
+					// then
+					Expect(err).ToNot(HaveOccurred())
+
+					// when
+					err = yaml.Unmarshal([]byte(given.svcPort), &svcPort)
+					// then
+					Expect(err).ToNot(HaveOccurred())
+
+					// when
+					actual, err := FindPort(&pod, &svcPort)
+					// then
+					Expect(err).ToNot(HaveOccurred())
+					// and
+					Expect(actual).To(Equal(given.expected))
+				},
+				Entry("Service with `targetPort` as a number (TCP)", testCase{
+					pod: `
+                    spec:
+                      containers:
+                      - name: container-1
+                        ports: [] # notice that actual container ports become irrelevant when Service has 'targetPort' as a number
+`,
+					svcPort: `
+                    name: http
+                    port: 8080
+                    protocol: TCP
+                    targetPort: 8080
+`,
+					expected: 8080,
+				}),
+				Entry("Service with `targetPort` as a number (UDP)", testCase{
+					pod: `
+                    spec:
+                      containers:
+                      - name: container-1
+                        ports: [] # notice that actual container ports become irrelevant when Service has 'targetPort' as a number
+`,
+					svcPort: `
+                    name: dns
+                    port: 53
+                    protocol: UDP
+                    targetPort: 53
+`,
+					expected: 53,
+				}),
+				Entry("Service with `targetPort` as a name (container port protocol is omitted)", testCase{
+					pod: `
+                    spec:
+                      containers:
+                      - name: container-1
+                        ports: []
+                      - name: container-2
+                        ports:
+                        - containerPort: 8080 # should be ignored
+                          protocol: TCP
+                      - name: container-3
+                        ports:
+                        - containerPort: 7070
+                          name: http-api      # should match
+                          # no protocol should default to 'TCP'
+`,
+					svcPort: `
+                    name: http
+                    port: 8080
+                    protocol: TCP
+                    targetPort: http-api
+`,
+					expected: 7070,
+				}),
+				Entry("Service with `targetPort` as a name (container port protocol is set to TCP)", testCase{
+					pod: `
+                    spec:
+                      containers:
+                      - name: container-1
+                        ports: []
+                      - name: container-2
+                        ports:
+                        - containerPort: 8080 # should be ignored
+                          protocol: TCP
+                      - name: container-3
+                        ports:
+                        - containerPort: 7070
+                          name: http-api      # should match
+                          protocol: TCP
+`,
+					svcPort: `
+                    name: http
+                    port: 8080
+                    protocol: TCP
+                    targetPort: http-api
+`,
+					expected: 7070,
+				}),
+				Entry("Service with `targetPort` as a name (container port protocol is set to UDP)", testCase{
+					pod: `
+                    spec:
+                      containers:
+                      - name: container-1
+                        ports: []
+                      - name: container-2
+                        ports:
+                        - containerPort: 53   # should be ignored
+                          protocol: UDP
+                      - name: container-3
+                        ports:
+                        - containerPort: 1053
+                          name: dns-port      # should match
+                          protocol: UDP
+`,
+					svcPort: `
+                    name: dns
+                    port: 53
+                    protocol: UDP
+                    targetPort: dns-port
+`,
+					expected: 1053,
+				}),
+				Entry("Service with `targetPort` as a name (service port protocol is omitted and container port protocol is omitted)", testCase{
+					pod: `
+                    spec:
+                      containers:
+                      - name: container-1
+                        ports: []
+                      - name: container-2
+                        ports:
+                        - containerPort: 8080 # should be ignored
+                          protocol: TCP
+                      - name: container-3
+                        ports:
+                        - containerPort: 7070
+                          name: http-api      # should match
+                          # no protocol should default to 'TCP'
+`,
+					svcPort: `
+                    name: http
+                    port: 8080
+                    targetPort: http-api
+`,
+					expected: 7070,
+				}),
+				Entry("Service with `targetPort` as a name (service port protocol is omitted while container port protocol set to TCP)", testCase{
+					pod: `
+                    spec:
+                      containers:
+                      - name: container-1
+                        ports: []
+                      - name: container-2
+                        ports:
+                        - containerPort: 8080 # should be ignored
+                          protocol: TCP
+                      - name: container-3
+                        ports:
+                        - containerPort: 7070
+                          name: http-api      # should match
+                          protocol: TCP
+`,
+					svcPort: `
+                    name: http
+                    port: 8080
+                    targetPort: http-api
+`,
+					expected: 7070,
+				}),
+			)
+		})
+
+		Describe("should return an error if a Pod doesn't have a matching container port", func() {
+			type testCase struct {
+				pod         string
+				svcPort     string
+				expectedErr string
+			}
+
+			DescribeTable("should return a proper error",
+				func(given testCase) {
+					// setup
+					pod := kube_core.Pod{}
+					svcPort := kube_core.ServicePort{}
+
+					// when
+					err := yaml.Unmarshal([]byte(given.pod), &pod)
+					// then
+					Expect(err).ToNot(HaveOccurred())
+
+					// when
+					err = yaml.Unmarshal([]byte(given.svcPort), &svcPort)
+					// then
+					Expect(err).ToNot(HaveOccurred())
+
+					// when
+					actual, err := FindPort(&pod, &svcPort)
+					// then
+					Expect(err).To(HaveOccurred())
+					// and
+					Expect(err.Error()).To(Equal(given.expectedErr))
+					// and
+					Expect(actual).To(Equal(0))
+				},
+				Entry("Pod has no container port with such name", testCase{
+					pod: `
+                    metadata:
+                      uid: 8648e081-576d-4a23-861b-8f2d94d28d34
+                    spec:
+                      containers:
+                      - name: container-1
+                        ports: []
+                      - name: container-2
+                        ports:
+                        - containerPort: 8080 # should be ignored
+                          protocol: TCP
+`,
+					svcPort: `
+                    name: http
+                    port: 8080
+                    protocol: TCP
+                    targetPort: http-api
+`,
+					expectedErr: `no suitable port for manifest: 8648e081-576d-4a23-861b-8f2d94d28d34`,
+				}),
+				Entry("Pod has no container port with such name and protocol (TCP)", testCase{
+					pod: `
+                    metadata:
+                      uid: 8648e081-576d-4a23-861b-8f2d94d28d34
+                    spec:
+                      containers:
+                      - name: container-1
+                        ports: []
+                      - name: container-2
+                        ports:
+                        - containerPort: 8080 # should be ignored
+                          protocol: TCP
+                      - name: container-3
+                        ports:
+                        - containerPort: 7070
+                          name: http-api      # should be ignored
+                          protocol: UDP
+`,
+					svcPort: `
+                    name: http
+                    port: 8080
+                    protocol: TCP
+                    targetPort: http-api
+`,
+					expectedErr: `no suitable port for manifest: 8648e081-576d-4a23-861b-8f2d94d28d34`,
+				}),
+				Entry("Pod has no container port with such name and protocol (UDP)", testCase{
+					pod: `
+                    metadata:
+                      uid: 8648e081-576d-4a23-861b-8f2d94d28d34
+                    spec:
+                      containers:
+                      - name: container-1
+                        ports: []
+                      - name: container-2
+                        ports:
+                        - containerPort: 53 # should be ignored
+                          protocol: UDP
+                      - name: container-3
+                        ports:
+                        - containerPort: 1053
+                          name: dns-port      # should be ignored
+                          protocol: TCP
+`,
+					svcPort: `
+                    name: dns
+                    port: 53
+                    protocol: UDP
+                    targetPort: dns-port
+`,
+					expectedErr: `no suitable port for manifest: 8648e081-576d-4a23-861b-8f2d94d28d34`,
+				}),
+				Entry("Pod has no container port with such name and protocol (TCP)", testCase{
+					pod: `
+                    metadata:
+                      uid: 8648e081-576d-4a23-861b-8f2d94d28d34
+                    spec:
+                      containers:
+                      - name: container-1
+                        ports: []
+                      - name: container-2
+                        ports:
+                        - containerPort: 8080 # should be ignored
+                          protocol: TCP
+                      - name: container-3
+                        ports:
+                        - containerPort: 7070
+                          name: http-api      # should be ignored
+                          protocol: UDP
+`,
+					svcPort: `
+                    name: http
+                    port: 8080
+                    # no protocol defaults to TCP
+                    targetPort: http-api
+`,
+					expectedErr: `no suitable port for manifest: 8648e081-576d-4a23-861b-8f2d94d28d34`,
+				}),
+			)
 		})
 	})
 })


### PR DESCRIPTION
### Summary

* remove the requirement to a `Pod` to explicitly list container ports in a case where a `Service` defines target port by number
