### PR TITLE
kuma-injector: add support for `kuma.io/sidecar-injection: disabled` annotation on Pods to let users selectively opt out of side-car injection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 Changes:
 
+* feature: add support for `kuma.io/sidecar-injection: disabled` annotation on `Pods` to let users selectively opt out of side-car injection on `k8s`
+  [#607](https://github.com/Kong/kuma/pull/607)
 * fix: remove the requirement to a `Pod` to explicitly list container ports in a case where a `Service` defines target port by number
   [#605](https://github.com/Kong/kuma/pull/605)
 * feature: extend embedded gRPC Access Log Server to support the entire Envoy access log format

--- a/app/kuma-injector/pkg/injector/injector.go
+++ b/app/kuma-injector/pkg/injector/injector.go
@@ -44,6 +44,10 @@ type KumaInjector struct {
 }
 
 func (i *KumaInjector) InjectKuma(pod *kube_core.Pod) error {
+	// first, give users a chance to opt out of side-car injection into a given Pod
+	if pod.Annotations[metadata.KumaSidecarInjectionAnnotation] == metadata.KumaSidecarInjectionDisabled {
+		return nil
+	}
 	// sidecar container
 	if pod.Spec.Containers == nil {
 		pod.Spec.Containers = []kube_core.Container{}

--- a/app/kuma-injector/pkg/injector/injector_test.go
+++ b/app/kuma-injector/pkg/injector/injector_test.go
@@ -3,9 +3,7 @@ package injector_test
 import (
 	"context"
 	"fmt"
-	"github.com/Kong/kuma/pkg/plugins/resources/k8s/native/api/v1alpha1"
 	"io/ioutil"
-	"k8s.io/apimachinery/pkg/runtime/serializer"
 	"path/filepath"
 
 	. "github.com/onsi/ginkgo"
@@ -15,9 +13,12 @@ import (
 	inject "github.com/Kong/kuma/app/kuma-injector/pkg/injector"
 	"github.com/Kong/kuma/pkg/config"
 	conf "github.com/Kong/kuma/pkg/config/app/kuma-injector"
+	"github.com/Kong/kuma/pkg/plugins/resources/k8s/native/api/v1alpha1"
+
+	kube_core "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/runtime/serializer"
 
 	"github.com/ghodss/yaml"
-	kube_core "k8s.io/api/core/v1"
 )
 
 var _ = Describe("Injector", func() {
@@ -172,6 +173,24 @@ var _ = Describe("Injector", func() {
                   prometheus:
                     port: 1234
                     path: /metrics`,
+		}),
+		Entry("10. Pod with `kuma.io/sidecar-injection: disabled` annotation", testCase{
+			num: "10",
+			mesh: `
+              apiVersion: kuma.io/v1alpha1
+              kind: Mesh
+              metadata:
+                name: default
+              spec: {}`,
+		}),
+		Entry("11. Pod with `kuma.io/sidecar-injection: any-value-other-than-disabled` annotation", testCase{
+			num: "11",
+			mesh: `
+              apiVersion: kuma.io/v1alpha1
+              kind: Mesh
+              metadata:
+                name: default
+              spec: {}`,
 		}),
 	)
 })

--- a/app/kuma-injector/pkg/injector/metadata/annotations.go
+++ b/app/kuma-injector/pkg/injector/metadata/annotations.go
@@ -2,10 +2,18 @@ package metadata
 
 // Annotations that can be used by the end users.
 const (
-	// KumaMeshAnnotation defines an annotation that can be put on Pods
-	// in order to associate them with a particular Mesh.
-	// Annotation value must be a name of a Mesh resource.
+	// KumaMeshAnnotation defines a Pod annotation that
+	// associates a given Pod with a particular Mesh.
+	// Annotation value must be the name of a Mesh resource.
 	KumaMeshAnnotation = "kuma.io/mesh"
+
+	// KumaSidecarInjectionAnnotation defines a Pod annotation that
+	// gives users a chance to opt out of side-car injection
+	// into a given Pod by setting its value to KumaSidecarInjectionDisabled.
+	KumaSidecarInjectionAnnotation = "kuma.io/sidecar-injection"
+	// KumaSidecarInjectionDisabled defines a value of KumaSidecarInjectionAnnotation
+	// that will prevent Kuma from injecting a side-car into that Pod.
+	KumaSidecarInjectionDisabled = "disabled"
 )
 
 // Annotations that are being automatically set by the Kuma Sidecar Injector.

--- a/app/kuma-injector/pkg/injector/testdata/inject.10.golden.yaml
+++ b/app/kuma-injector/pkg/injector/testdata/inject.10.golden.yaml
@@ -1,0 +1,23 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  annotations:
+    kuma.io/sidecar-injection: disabled
+  creationTimestamp: null
+  labels:
+    run: busybox
+  name: busybox
+spec:
+  containers:
+  - image: busybox
+    name: busybox
+    resources: {}
+    volumeMounts:
+    - mountPath: /var/run/secrets/kubernetes.io/serviceaccount
+      name: default-token-w7dxf
+      readOnly: true
+  volumes:
+  - name: default-token-w7dxf
+    secret:
+      secretName: default-token-w7dxf
+status: {}

--- a/app/kuma-injector/pkg/injector/testdata/inject.10.input.yaml
+++ b/app/kuma-injector/pkg/injector/testdata/inject.10.input.yaml
@@ -1,0 +1,21 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: busybox
+  labels:
+    run: busybox
+  annotations:
+    kuma.io/sidecar-injection: disabled
+spec:
+  volumes:
+  - name: default-token-w7dxf
+    secret:
+      secretName: default-token-w7dxf
+  containers:
+  - name: busybox
+    image: busybox
+    resources: {}
+    volumeMounts:
+    - name: default-token-w7dxf
+      readOnly: true
+      mountPath: "/var/run/secrets/kubernetes.io/serviceaccount"

--- a/app/kuma-injector/pkg/injector/testdata/inject.11.golden.yaml
+++ b/app/kuma-injector/pkg/injector/testdata/inject.11.golden.yaml
@@ -1,0 +1,125 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  annotations:
+    kuma.io/mesh: default
+    kuma.io/sidecar-injected: "true"
+    kuma.io/sidecar-injection: any-value-other-than-disabled
+    kuma.io/transparent-proxying: enabled
+    kuma.io/transparent-proxying-port: "15001"
+  creationTimestamp: null
+  labels:
+    run: busybox
+  name: busybox
+spec:
+  containers:
+  - image: busybox
+    name: busybox
+    resources: {}
+    volumeMounts:
+    - mountPath: /var/run/secrets/kubernetes.io/serviceaccount
+      name: default-token-w7dxf
+      readOnly: true
+  - args:
+    - run
+    - --log-level=info
+    env:
+    - name: POD_NAME
+      valueFrom:
+        fieldRef:
+          apiVersion: v1
+          fieldPath: metadata.name
+    - name: POD_NAMESPACE
+      valueFrom:
+        fieldRef:
+          apiVersion: v1
+          fieldPath: metadata.namespace
+    - name: INSTANCE_IP
+      valueFrom:
+        fieldRef:
+          apiVersion: v1
+          fieldPath: status.podIP
+    - name: KUMA_CONTROL_PLANE_API_SERVER_URL
+      value: http://kuma-control-plane.kuma-system:5681
+    - name: KUMA_DATAPLANE_MESH
+      value: default
+    - name: KUMA_DATAPLANE_NAME
+      value: $(POD_NAME).$(POD_NAMESPACE)
+    - name: KUMA_DATAPLANE_ADMIN_PORT
+      value: "9901"
+    - name: KUMA_DATAPLANE_DRAIN_TIME
+      value: 31s
+    - name: KUMA_DATAPLANE_RUNTIME_TOKEN_PATH
+      value: /var/run/secrets/kubernetes.io/serviceaccount/token
+    image: kuma/kuma-sidecar:latest
+    imagePullPolicy: IfNotPresent
+    livenessProbe:
+      exec:
+        command:
+        - wget
+        - -qO-
+        - http://localhost:9901
+      failureThreshold: 212
+      initialDelaySeconds: 260
+      periodSeconds: 25
+      successThreshold: 1
+      timeoutSeconds: 23
+    name: kuma-sidecar
+    readinessProbe:
+      exec:
+        command:
+        - wget
+        - -qO-
+        - http://localhost:9901
+      failureThreshold: 112
+      initialDelaySeconds: 11
+      periodSeconds: 15
+      successThreshold: 11
+      timeoutSeconds: 13
+    resources:
+      limits:
+        cpu: 1100m
+        memory: 1512Mi
+      requests:
+        cpu: 150m
+        memory: 164Mi
+    securityContext:
+      runAsGroup: 5678
+      runAsUser: 5678
+    volumeMounts:
+    - mountPath: /var/run/secrets/kubernetes.io/serviceaccount
+      name: default-token-w7dxf
+      readOnly: true
+  initContainers:
+  - args:
+    - -p
+    - "15001"
+    - -u
+    - "5678"
+    - -g
+    - "5678"
+    - -m
+    - REDIRECT
+    - -i
+    - '*'
+    - -b
+    - '*'
+    image: kuma/kuma-init:latest
+    imagePullPolicy: IfNotPresent
+    name: kuma-init
+    resources:
+      limits:
+        cpu: 100m
+        memory: 50M
+      requests:
+        cpu: 10m
+        memory: 10M
+    securityContext:
+      capabilities:
+        add:
+        - NET_ADMIN
+  volumes:
+  - name: default-token-w7dxf
+    secret:
+      secretName: default-token-w7dxf
+status: {}

--- a/app/kuma-injector/pkg/injector/testdata/inject.11.input.yaml
+++ b/app/kuma-injector/pkg/injector/testdata/inject.11.input.yaml
@@ -1,0 +1,21 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: busybox
+  labels:
+    run: busybox
+  annotations:
+    kuma.io/sidecar-injection: any-value-other-than-disabled
+spec:
+  volumes:
+  - name: default-token-w7dxf
+    secret:
+      secretName: default-token-w7dxf
+  containers:
+  - name: busybox
+    image: busybox
+    resources: {}
+    volumeMounts:
+    - name: default-token-w7dxf
+      readOnly: true
+      mountPath: "/var/run/secrets/kubernetes.io/serviceaccount"


### PR DESCRIPTION
### Summary

* add support for `kuma.io/sidecar-injection: disabled` annotation on Pods to let users selectively opt out of side-car injection

