### PR TITLE
kuma-cp: on `k8s`, when a Dataplane cannot be generated automatically for a particular Pod, emit `k8s` Events to make the error state apparent to a user

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 Changes:
 
+* feature: on `k8s`, when a Dataplane cannot be generated automatically for a particular `Pod`, emit `k8s` `Events` to make the error state apparent to a user
+  [#609](https://github.com/Kong/kuma/pull/609)
 * feature: include `k8s` namespace into a set of labels that describe a `Dataplane` to `Prometheus`
   [#601](https://github.com/Kong/kuma/pull/601)
 * feature: provision Grafana with Kuma Dashboards

--- a/pkg/core/validators/types.go
+++ b/pkg/core/validators/types.go
@@ -71,6 +71,24 @@ func (v *ValidationError) AddError(rootField string, validationErr ValidationErr
 	}
 }
 
+// Transform returns a new ValidationError with every violation
+// transformed by a given transformFunc.
+func (v *ValidationError) Transform(transformFunc func(Violation) Violation) *ValidationError {
+	if v == nil {
+		return nil
+	}
+	if transformFunc == nil || len(v.Violations) == 0 {
+		return &(*v)
+	}
+	result := ValidationError{
+		Violations: make([]Violation, len(v.Violations)),
+	}
+	for i := range v.Violations {
+		result.Violations[i] = transformFunc(v.Violations[i])
+	}
+	return &result
+}
+
 func IsValidationError(err error) bool {
 	_, ok := err.(*ValidationError)
 	return ok

--- a/pkg/core/validators/types.go
+++ b/pkg/core/validators/types.go
@@ -78,7 +78,7 @@ func (v *ValidationError) Transform(transformFunc func(Violation) Violation) *Va
 		return nil
 	}
 	if transformFunc == nil || len(v.Violations) == 0 {
-		return &(*v)
+		return &(*v) // we want to guarantee that Transform always returns a new object
 	}
 	result := ValidationError{
 		Violations: make([]Violation, len(v.Violations)),

--- a/pkg/plugins/discovery/k8s/controllers/pod_controller.go
+++ b/pkg/plugins/discovery/k8s/controllers/pod_controller.go
@@ -141,7 +141,7 @@ func (r *PodReconciler) createOrUpdateDataplane(pod *kube_core.Pod, services []*
 	}
 	operationResult, err := kube_controllerutil.CreateOrUpdate(ctx, r.Client, dataplane, func() error {
 		if err := PodToDataplane(dataplane, pod, services, others, r.Client); err != nil {
-			return errors.Wrap(err, "unable to translate Pod to Dataplane")
+			return errors.Wrap(err, "unable to translate a Pod into a Dataplane")
 		}
 		if err := kube_controllerutil.SetControllerReference(pod, dataplane, r.Scheme); err != nil {
 			return errors.Wrap(err, "unable to set Dataplane's controller reference to Pod")

--- a/pkg/plugins/discovery/k8s/controllers/pod_controller_test.go
+++ b/pkg/plugins/discovery/k8s/controllers/pod_controller_test.go
@@ -23,6 +23,7 @@ import (
 	kube_core "k8s.io/api/core/v1"
 	kube_meta "k8s.io/apimachinery/pkg/apis/meta/v1"
 	kube_intstr "k8s.io/apimachinery/pkg/util/intstr"
+	kube_record "k8s.io/client-go/tools/record"
 
 	mesh_k8s "github.com/Kong/kuma/pkg/plugins/resources/k8s/native/api/v1alpha1"
 )
@@ -107,9 +108,10 @@ var _ = Describe("PodReconciler", func() {
 			})
 
 		reconciler = &PodReconciler{
-			Client: kubeClient,
-			Scheme: k8sClientScheme,
-			Log:    core.Log.WithName("test"),
+			Client:        kubeClient,
+			EventRecorder: kube_record.NewFakeRecorder(10),
+			Scheme:        k8sClientScheme,
+			Log:           core.Log.WithName("test"),
 		}
 	})
 

--- a/pkg/plugins/discovery/k8s/plugin.go
+++ b/pkg/plugins/discovery/k8s/plugin.go
@@ -30,9 +30,10 @@ func (p *plugin) StartDiscovering(pc core_plugins.PluginContext, _ core_plugins.
 
 func addPodReconciler(mgr kube_ctrl.Manager) error {
 	reconciler := &controllers.PodReconciler{
-		Client: mgr.GetClient(),
-		Scheme: mgr.GetScheme(),
-		Log:    core.Log.WithName("controllers").WithName("Pod"),
+		Client:        mgr.GetClient(),
+		EventRecorder: mgr.GetEventRecorderFor("k8s.kuma.io/dataplane-generator"),
+		Scheme:        mgr.GetScheme(),
+		Log:           core.Log.WithName("controllers").WithName("Pod"),
 	}
 	return reconciler.SetupWithManager(mgr)
 }

--- a/pkg/plugins/runtime/k8s/webhooks/validation_test.go
+++ b/pkg/plugins/runtime/k8s/webhooks/validation_test.go
@@ -134,7 +134,7 @@ var _ = Describe("Validation", func() {
 					Allowed: false,
 					Result: &kube_meta.Status{
 						Status:  "Failure",
-						Message: "path: cannot be empty",
+						Message: "spec.path: cannot be empty",
 						Reason:  "Invalid",
 						Details: &kube_meta.StatusDetails{
 							Name: "empty",
@@ -143,7 +143,7 @@ var _ = Describe("Validation", func() {
 								{
 									Type:    "FieldValueInvalid",
 									Message: "cannot be empty",
-									Field:   "path",
+									Field:   "spec.path",
 								},
 							},
 						},


### PR DESCRIPTION
### Summary

* on `k8s`, when a `Dataplane` cannot be generated automatically for a particular `Pod`, emit `k8s` `Events` to make the error state apparent to a user
