### PR TITLE
kumactl apply: add support of --dry-run flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # CHANGELOG
 
+## master
+
+* feature: added flag `--dry-run` for `kumactl apply`
+  [#622](https://github.com/Kong/kuma/pull/622)
+
 ## [0.4.0]
 
 > Released on 2020/02/28

--- a/app/kumactl/cmd/apply/apply.go
+++ b/app/kumactl/cmd/apply/apply.go
@@ -2,24 +2,26 @@ package apply
 
 import (
 	"context"
-	"github.com/Kong/kuma/app/kumactl/pkg/output"
-	"github.com/Kong/kuma/app/kumactl/pkg/output/printers"
 	"io/ioutil"
 	"net/http"
 	"strings"
 	"time"
 
-	kumactl_cmd "github.com/Kong/kuma/app/kumactl/pkg/cmd"
-	"github.com/Kong/kuma/pkg/core/resources/apis/mesh"
-	"github.com/Kong/kuma/pkg/core/resources/model"
-	"github.com/Kong/kuma/pkg/core/resources/model/rest"
-	"github.com/Kong/kuma/pkg/core/resources/registry"
-	"github.com/Kong/kuma/pkg/core/resources/store"
-	"github.com/Kong/kuma/pkg/util/proto"
 	"github.com/ghodss/yaml"
 	"github.com/hoisie/mustache"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
+
+	kumactl_cmd "github.com/Kong/kuma/app/kumactl/pkg/cmd"
+	"github.com/Kong/kuma/app/kumactl/pkg/output"
+	"github.com/Kong/kuma/app/kumactl/pkg/output/printers"
+	"github.com/Kong/kuma/pkg/core/resources/apis/mesh"
+	"github.com/Kong/kuma/pkg/core/resources/model"
+	"github.com/Kong/kuma/pkg/core/resources/model/rest"
+	rest_types "github.com/Kong/kuma/pkg/core/resources/model/rest"
+	"github.com/Kong/kuma/pkg/core/resources/registry"
+	"github.com/Kong/kuma/pkg/core/resources/store"
+	"github.com/Kong/kuma/pkg/util/proto"
 )
 
 const (
@@ -95,7 +97,7 @@ func NewApplyCmd(pctx *kumactl_cmd.RootContext) *cobra.Command {
 				if err != nil {
 					return err
 				}
-				if err := p.Print(res, cmd.OutOrStdout()); err != nil {
+				if err := p.Print(rest_types.From.Resource(res), cmd.OutOrStdout()); err != nil {
 					return err
 				}
 				return nil

--- a/app/kumactl/cmd/apply/apply_test.go
+++ b/app/kumactl/cmd/apply/apply_test.go
@@ -333,12 +333,11 @@ var _ = Describe("kumactl apply", func() {
 
 		// then
 		Expect(buf.String()).To(Equal(
-			`Meta:
-  Mesh: default
-  Name: sample
-Spec:
-  networking:
-    address: 2.2.2.2
+			`mesh: default
+name: sample
+networking:
+  address: 2.2.2.2
+type: Dataplane
 `))
 	})
 

--- a/app/kumactl/cmd/apply/testdata/apply-dataplane-template.yaml
+++ b/app/kumactl/cmd/apply/testdata/apply-dataplane-template.yaml
@@ -1,0 +1,5 @@
+name: sample
+mesh: default
+type: Dataplane
+networking:
+  address: "{{ address }}"

--- a/docs/cmd/kumactl/HELP.md
+++ b/docs/cmd/kumactl/HELP.md
@@ -36,6 +36,7 @@ Usage:
   kumactl apply [flags]
 
 Flags:
+      --dry-run              Resolve variable and prints result out without actual applying
   -f, --file string          Path to file to apply
   -h, --help                 help for apply
   -v, --var stringToString   Variable to replace in configuration (default [])


### PR DESCRIPTION
### Summary

Provide support of `--dry-run` mode to print out effective resources after all variables have been resolved

### Full changelog
* kumactl apply: add support of --dry-run flag

### Issues resolved

Fix https://github.com/Kong/kuma/issues/615
