### PR TITLE
go.mod: add replace for fsnotify dependency

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -62,4 +62,5 @@ replace (
 	github.com/Kong/kuma/pkg/plugins/resources/k8s/native => ./pkg/plugins/resources/k8s/native
 
 	github.com/prometheus/prometheus => ./vendor/github.com/prometheus/prometheus
+	gopkg.in/fsnotify.v1 => gopkg.in/fsnotify.v1 v1.4.7
 )


### PR DESCRIPTION
### Summary

`make dev/install/ginkgo` fails with 
```
go: gopkg.in/fsnotify.v1@v1.4.8: go.mod has non-....v1 module path "github.com/fsnotify/fsnotify" at revision v1.4.8
```

As a workaround added `replace` to `go.mod` file

Related issue: https://github.com/onsi/ginkgo/issues/650