### PR TITLE
chore(conf) update protoc version up to 3.8.0

### DIFF
--- a/api/Makefile
+++ b/api/Makefile
@@ -19,7 +19,7 @@ define go_mod_latest_version
 	find $(GOPATH_DIR)/pkg/mod/$(1) -maxdepth 1 -name '$(2)@*' | xargs -L 1 basename | sort -r | head -1 | awk -F@ '{print $$2}'
 endef
 
-PROTOC_VERSION := 3.6.1
+PROTOC_VERSION := 3.8.0
 PROTOC_PGV_VERSION := v0.3.0-java
 GOLANG_PROTOBUF_VERSION := v1.3.2
 DATAPLANE_API_LATEST_VERSION := master


### PR DESCRIPTION
### Summary

Envoy extended validation rules with `strict` keyword, we have the following error during `api_check`:
```
...
envoy/api/v2/core/base.proto:240:12: Error while parsing option value for "string": Message type "validate.StringRules" has no field named "strict".
...
```
Probably current protoc version 3.6.1 is too old and doesn't support new keywords.