### PR TITLE
feat(kuma-cp) log external services

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## master
 
+* feature: log requests to external services
+  [#630](https://github.com/Kong/kuma/pull/630)
 * feature: added flag `--dry-run` for `kumactl apply`
   [#622](https://github.com/Kong/kuma/pull/622)
 

--- a/pkg/core/logs/matcher_test.go
+++ b/pkg/core/logs/matcher_test.go
@@ -142,6 +142,8 @@ var _ = Describe("Matcher", func() {
 		Expect(log["backend"]).To(Equal(backendFile2))
 		// should match because *->* rule and default backend file1
 		Expect(log["web"]).To(Equal(backendFile1))
+		// should match implicit pass through because service *->* rule and default backend file1
+		Expect(log[core_mesh.PassThroughService]).To(Equal(backendFile1))
 	})
 
 	It("should not match services", func() {

--- a/pkg/core/policy/matcher.go
+++ b/pkg/core/policy/matcher.go
@@ -21,8 +21,12 @@ func (f ServiceIteratorFunc) Next() (core_xds.ServiceName, bool) {
 func ToOutboundServicesOf(dataplane *mesh_core.DataplaneResource) ServiceIteratorFunc {
 	idx := 0
 	return ServiceIteratorFunc(func() (core_xds.ServiceName, bool) {
-		if len(dataplane.Spec.Networking.GetOutbound()) <= idx {
+		if len(dataplane.Spec.Networking.GetOutbound()) < idx {
 			return "", false
+		}
+		if len(dataplane.Spec.Networking.GetOutbound()) == idx { // add additional implicit pass through service
+			idx++
+			return mesh_core.PassThroughService, true
 		}
 		oface := dataplane.Spec.Networking.GetOutbound()[idx]
 		idx++

--- a/pkg/core/resources/apis/mesh/dataplane_helpers.go
+++ b/pkg/core/resources/apis/mesh/dataplane_helpers.go
@@ -46,6 +46,9 @@ var SupportedProtocols = ProtocolList{
 	ProtocolTCP,
 }
 
+// Service that indicates L4 pass through cluster
+const PassThroughService = "pass_through"
+
 var ipv4loopback = net.IPv4(127, 0, 0, 1)
 
 func (d *DataplaneResource) UsesInterface(address net.IP, port uint32) bool {


### PR DESCRIPTION
### Summary

For TrafficLog, we configure Dataplanes that match sources to log requests for a matching destination. We also want to log now the requests for external services. Such requests with transparent proxying (only on K8S for now) goes through `pass_through` L4 cluster and `catch_all` listener, therefore we want to configure such listener with access logs.

This will only be placed when in the destination section we will have the `*`.

In the future, this will be improved with more sophisticated handling of external services that will let apply L7 policies/metrics/logging etc.