### PR TITLE
fix(injector) explicitly set parameters in securityContext

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,8 @@
 # CHANGELOG
 
 ## master
-
+* fix: explicitly set parameters in securityContext of kuma-init
+  [#631](https://github.com/Kong/kuma/pull/631)
 * feature: log requests to external services
   [#630](https://github.com/Kong/kuma/pull/630)
 * feature: added flag `--dry-run` for `kumactl apply`

--- a/app/kuma-injector/pkg/injector/injector.go
+++ b/app/kuma-injector/pkg/injector/injector.go
@@ -253,6 +253,8 @@ func (i *KumaInjector) NewInitContainer(pod *kube_core.Pod) kube_core.Container 
 			inboundPortsToIntercept,
 		},
 		SecurityContext: &kube_core.SecurityContext{
+			RunAsUser:  new(int64), // way to get pointer to int64(0)
+			RunAsGroup: new(int64),
 			Capabilities: &kube_core.Capabilities{
 				Add: []kube_core.Capability{
 					kube_core.Capability("NET_ADMIN"),

--- a/app/kuma-injector/pkg/injector/testdata/inject.01.golden.yaml
+++ b/app/kuma-injector/pkg/injector/testdata/inject.01.golden.yaml
@@ -117,6 +117,8 @@ spec:
       capabilities:
         add:
         - NET_ADMIN
+      runAsGroup: 0
+      runAsUser: 0
   volumes:
   - name: default-token-w7dxf
     secret:

--- a/app/kuma-injector/pkg/injector/testdata/inject.02.golden.yaml
+++ b/app/kuma-injector/pkg/injector/testdata/inject.02.golden.yaml
@@ -125,6 +125,8 @@ spec:
       capabilities:
         add:
         - NET_ADMIN
+      runAsGroup: 0
+      runAsUser: 0
   volumes:
   - name: default-token-w7dxf
     secret:

--- a/app/kuma-injector/pkg/injector/testdata/inject.03.golden.yaml
+++ b/app/kuma-injector/pkg/injector/testdata/inject.03.golden.yaml
@@ -179,6 +179,8 @@ spec:
       capabilities:
         add:
         - NET_ADMIN
+      runAsGroup: 0
+      runAsUser: 0
   nodeSelector:
     beta.kubernetes.io/os: linux
   priority: 2000000000

--- a/app/kuma-injector/pkg/injector/testdata/inject.04.golden.yaml
+++ b/app/kuma-injector/pkg/injector/testdata/inject.04.golden.yaml
@@ -117,6 +117,8 @@ spec:
       capabilities:
         add:
         - NET_ADMIN
+      runAsGroup: 0
+      runAsUser: 0
   volumes:
   - name: default-token-w7dxf
     secret:

--- a/app/kuma-injector/pkg/injector/testdata/inject.05.golden.yaml
+++ b/app/kuma-injector/pkg/injector/testdata/inject.05.golden.yaml
@@ -110,4 +110,6 @@ spec:
       capabilities:
         add:
         - NET_ADMIN
+      runAsGroup: 0
+      runAsUser: 0
 status: {}

--- a/app/kuma-injector/pkg/injector/testdata/inject.06.golden.yaml
+++ b/app/kuma-injector/pkg/injector/testdata/inject.06.golden.yaml
@@ -118,6 +118,8 @@ spec:
       capabilities:
         add:
         - NET_ADMIN
+      runAsGroup: 0
+      runAsUser: 0
   volumes:
   - name: default-token-w7dxf
     secret:

--- a/app/kuma-injector/pkg/injector/testdata/inject.07.golden.yaml
+++ b/app/kuma-injector/pkg/injector/testdata/inject.07.golden.yaml
@@ -120,6 +120,8 @@ spec:
       capabilities:
         add:
         - NET_ADMIN
+      runAsGroup: 0
+      runAsUser: 0
   volumes:
   - name: default-token-w7dxf
     secret:

--- a/app/kuma-injector/pkg/injector/testdata/inject.08.golden.yaml
+++ b/app/kuma-injector/pkg/injector/testdata/inject.08.golden.yaml
@@ -120,6 +120,8 @@ spec:
       capabilities:
         add:
         - NET_ADMIN
+      runAsGroup: 0
+      runAsUser: 0
   volumes:
   - name: default-token-w7dxf
     secret:

--- a/app/kuma-injector/pkg/injector/testdata/inject.09.golden.yaml
+++ b/app/kuma-injector/pkg/injector/testdata/inject.09.golden.yaml
@@ -122,6 +122,8 @@ spec:
       capabilities:
         add:
         - NET_ADMIN
+      runAsGroup: 0
+      runAsUser: 0
   volumes:
   - name: default-token-w7dxf
     secret:

--- a/app/kuma-injector/pkg/injector/testdata/inject.11.golden.yaml
+++ b/app/kuma-injector/pkg/injector/testdata/inject.11.golden.yaml
@@ -118,6 +118,8 @@ spec:
       capabilities:
         add:
         - NET_ADMIN
+      runAsGroup: 0
+      runAsUser: 0
   volumes:
   - name: default-token-w7dxf
     secret:


### PR DESCRIPTION
### Summary

`kuma-init` didn't set `runAsUser` and `runAsGroup` explicitly, that's why pod-level securityContext could override them.

### Full changelog

* Explicitly set `runAsUser` and `runAsGroup` to 0.

### Issues resolved

Fix https://github.com/Kong/kuma/issues/571
