### PR TITLE
feat(kuma-cp) add response flag to default format

### DIFF
--- a/pkg/xds/envoy/listeners/network_access_log_configurer.go
+++ b/pkg/xds/envoy/listeners/network_access_log_configurer.go
@@ -8,7 +8,7 @@ import (
 	core_xds "github.com/Kong/kuma/pkg/core/xds"
 )
 
-const defaultNetworkAccessLogFormat = `[%START_TIME%] %KUMA_MESH% %KUMA_SOURCE_ADDRESS_WITHOUT_PORT%(%KUMA_SOURCE_SERVICE%)->%UPSTREAM_HOST%(%KUMA_DESTINATION_SERVICE%) took %DURATION%ms, sent %BYTES_SENT% bytes, received: %BYTES_RECEIVED% bytes
+const defaultNetworkAccessLogFormat = `[%START_TIME%] %RESPONSE_FLAGS% %KUMA_MESH% %KUMA_SOURCE_ADDRESS_WITHOUT_PORT%(%KUMA_SOURCE_SERVICE%)->%UPSTREAM_HOST%(%KUMA_DESTINATION_SERVICE%) took %DURATION%ms, sent %BYTES_SENT% bytes, received: %BYTES_RECEIVED% bytes
 ` // intentional newline at the end
 
 func NetworkAccessLog(mesh string, sourceService string, destinationService string, backend *v1alpha1.LoggingBackend, proxy *core_xds.Proxy) FilterChainBuilderOpt {

--- a/pkg/xds/envoy/listeners/network_access_log_configurer_test.go
+++ b/pkg/xds/envoy/listeners/network_access_log_configurer_test.go
@@ -128,7 +128,7 @@ var _ = Describe("NetworkAccessLogConfigurer", func() {
                     typedConfig:
                       '@type': type.googleapis.com/envoy.config.accesslog.v2.FileAccessLog
                       format: |
-                        [%START_TIME%] demo 192.168.0.1(backend)->%UPSTREAM_HOST%(db) took %DURATION%ms, sent %BYTES_SENT% bytes, received: %BYTES_RECEIVED% bytes
+                        [%START_TIME%] %RESPONSE_FLAGS% demo 192.168.0.1(backend)->%UPSTREAM_HOST%(db) took %DURATION%ms, sent %BYTES_SENT% bytes, received: %BYTES_RECEIVED% bytes
                       path: /tmp/log
                   cluster: db
                   statPrefix: db

--- a/pkg/xds/generator/testdata/outbound-proxy/09.envoy.golden.yaml
+++ b/pkg/xds/generator/testdata/outbound-proxy/09.envoy.golden.yaml
@@ -240,7 +240,7 @@ resources:
                   envoyGrpc:
                     clusterName: access_log_sink
                 logName: |
-                  logstash:1234;[%START_TIME%] mesh1 10.0.0.1(gateway)->%UPSTREAM_HOST%(api-tcp) took %DURATION%ms, sent %BYTES_SENT% bytes, received: %BYTES_RECEIVED% bytes
+                  logstash:1234;[%START_TIME%] %RESPONSE_FLAGS% mesh1 10.0.0.1(gateway)->%UPSTREAM_HOST%(api-tcp) took %DURATION%ms, sent %BYTES_SENT% bytes, received: %BYTES_RECEIVED% bytes
           cluster: api-tcp
           statPrefix: api-tcp
     name: outbound:127.0.0.1:40002

--- a/pkg/xds/generator/testdata/outbound-proxy/10.envoy.golden.yaml
+++ b/pkg/xds/generator/testdata/outbound-proxy/10.envoy.golden.yaml
@@ -388,7 +388,7 @@ resources:
                   envoyGrpc:
                     clusterName: access_log_sink
                 logName: |
-                  logstash:1234;[%START_TIME%] mesh1 10.0.0.1(web)->%UPSTREAM_HOST%(api-tcp) took %DURATION%ms, sent %BYTES_SENT% bytes, received: %BYTES_RECEIVED% bytes
+                  logstash:1234;[%START_TIME%] %RESPONSE_FLAGS% mesh1 10.0.0.1(web)->%UPSTREAM_HOST%(api-tcp) took %DURATION%ms, sent %BYTES_SENT% bytes, received: %BYTES_RECEIVED% bytes
           cluster: api-tcp
           statPrefix: api-tcp
     name: outbound:127.0.0.1:40002

--- a/pkg/xds/generator/transparent_proxy_generator_test.go
+++ b/pkg/xds/generator/transparent_proxy_generator_test.go
@@ -168,7 +168,7 @@ var _ = Describe("TransparentProxyGenerator", func() {
                     typedConfig:
                       '@type': type.googleapis.com/envoy.config.accesslog.v2.FileAccessLog
                       format: |
-                        [%START_TIME%] default (unknown)->%UPSTREAM_HOST%(external) took %DURATION%ms, sent %BYTES_SENT% bytes, received: %BYTES_RECEIVED% bytes
+                        [%START_TIME%] %RESPONSE_FLAGS% default (unknown)->%UPSTREAM_HOST%(external) took %DURATION%ms, sent %BYTES_SENT% bytes, received: %BYTES_RECEIVED% bytes
                       path: /var/log
                   cluster: pass_through
                   statPrefix: pass_through


### PR DESCRIPTION
### Summary

Add response flag to the default logging format.

Response flag for HTTP logging is already in place.