### PR TITLE
chore(kumactl): merge mTLS and CA status into one column, closes #629

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # CHANGELOG
 
 ## master
+* chore: merge mTLS and CA status into one column
+  [#637](https://github.com/Kong/kuma/pull/637)
 * feat: read only cached manager
   [#634](https://github.com/Kong/kuma/pull/634)
 * fix: explicitly set parameters in securityContext of kuma-init

--- a/app/kumactl/cmd/get/get_meshes.go
+++ b/app/kumactl/cmd/get/get_meshes.go
@@ -10,7 +10,6 @@ import (
 	mesh_proto "github.com/Kong/kuma/api/mesh/v1alpha1"
 	"github.com/Kong/kuma/app/kumactl/pkg/output"
 	"github.com/Kong/kuma/app/kumactl/pkg/output/printers"
-	"github.com/Kong/kuma/app/kumactl/pkg/output/table"
 	"github.com/Kong/kuma/pkg/core/resources/apis/mesh"
 	rest_types "github.com/Kong/kuma/pkg/core/resources/model/rest"
 )
@@ -48,7 +47,7 @@ func newGetMeshesCmd(pctx *getContext) *cobra.Command {
 
 func printMeshes(meshes *mesh.MeshResourceList, out io.Writer) error {
 	data := printers.Table{
-		Headers: []string{"NAME", "mTLS", "CA", "METRICS"},
+		Headers: []string{"NAME", "mTLS", "METRICS"},
 		NextRow: func() func() []string {
 			i := 0
 			return func() []string {
@@ -58,14 +57,14 @@ func printMeshes(meshes *mesh.MeshResourceList, out io.Writer) error {
 				}
 				mesh := meshes.Items[i]
 
-				ca := ""
-				switch mesh.Spec.GetMtls().GetCa().GetType().(type) {
-				case *mesh_proto.CertificateAuthority_Provided_:
-					ca = "provided"
-				case *mesh_proto.CertificateAuthority_Builtin_:
-					ca = "builtin"
-				default:
-					ca = "unknown"
+				mtls := "off"
+				if mesh.Spec.Mtls.GetEnabled() {
+					switch mesh.Spec.GetMtls().GetCa().GetType().(type) {
+					case *mesh_proto.CertificateAuthority_Provided_:
+						mtls = "provided"
+					case *mesh_proto.CertificateAuthority_Builtin_:
+						mtls = "builtin"
+					}
 				}
 
 				metrics := "off"
@@ -75,10 +74,9 @@ func printMeshes(meshes *mesh.MeshResourceList, out io.Writer) error {
 				}
 
 				return []string{
-					mesh.GetMeta().GetName(),                 // NAME
-					table.OnOff(mesh.Spec.Mtls.GetEnabled()), // mTLS
-					ca,                                       // CA
-					metrics,                                  // METRICS
+					mesh.GetMeta().GetName(), // NAME
+					mtls,                     // mTLS
+					metrics,                  // METRICS
 				}
 			}
 		}(),

--- a/app/kumactl/cmd/get/get_meshes_test.go
+++ b/app/kumactl/cmd/get/get_meshes_test.go
@@ -47,6 +47,22 @@ var _ = Describe("kumactl get meshes", func() {
 		{
 			Spec: v1alpha1.Mesh{
 				Mtls: &v1alpha1.Mesh_Mtls{
+					Enabled: true,
+					Ca: &v1alpha1.CertificateAuthority{
+						Type: &v1alpha1.CertificateAuthority_Provided_{
+							Provided: &v1alpha1.CertificateAuthority_Provided{},
+						},
+					},
+				},
+			},
+			Meta: &test_model.ResourceMeta{
+				Mesh: "mesh2",
+				Name: "mesh2",
+			},
+		},
+		{
+			Spec: v1alpha1.Mesh{
+				Mtls: &v1alpha1.Mesh_Mtls{
 					Enabled: false,
 					Ca: &v1alpha1.CertificateAuthority{
 						Type: &v1alpha1.CertificateAuthority_Provided_{
@@ -62,8 +78,8 @@ var _ = Describe("kumactl get meshes", func() {
 				},
 			},
 			Meta: &test_model.ResourceMeta{
-				Mesh: "mesh2",
-				Name: "mesh2",
+				Mesh: "mesh3",
+				Name: "mesh3",
 			},
 		},
 	}

--- a/app/kumactl/cmd/get/testdata/get-meshes.golden.json
+++ b/app/kumactl/cmd/get/testdata/get-meshes.golden.json
@@ -11,6 +11,16 @@
       "type": "Mesh"
     },
     {
+      "mtls": {
+        "enabled": true,
+        "ca": {
+          "provided": {}
+        }
+      },
+      "name": "mesh2",
+      "type": "Mesh"
+    },
+    {
       "metrics": {
         "prometheus": {
           "port": 1234,
@@ -22,7 +32,7 @@
           "provided": {}
         }
       },
-      "name": "mesh2",
+      "name": "mesh3",
       "type": "Mesh"
     }
   ]

--- a/app/kumactl/cmd/get/testdata/get-meshes.golden.txt
+++ b/app/kumactl/cmd/get/testdata/get-meshes.golden.txt
@@ -1,3 +1,4 @@
-NAME    mTLS   CA         METRICS
-mesh1   on     builtin    off
-mesh2   off    provided   prometheus
+NAME    mTLS       METRICS
+mesh1   builtin    off
+mesh2   provided   off
+mesh3   off        prometheus

--- a/app/kumactl/cmd/get/testdata/get-meshes.golden.yaml
+++ b/app/kumactl/cmd/get/testdata/get-meshes.golden.yaml
@@ -5,6 +5,12 @@ items:
         builtin: {}
     name: mesh1
     type: Mesh
+  - mtls:
+      enabled: true
+      ca:
+        provided: {}
+    name: mesh2
+    type: Mesh
   - metrics:
       prometheus:
         path: /non-standard-path
@@ -12,5 +18,5 @@ items:
     mtls:
       ca:
         provided: {}
-    name: mesh2
+    name: mesh3
     type: Mesh


### PR DESCRIPTION
Closes #629.

Goes in hand with https://github.com/Kong/kuma-website/pull/158