### PR TITLE
chore(*) prevent dataplane creation with a headless services and provide more descriptive error message on pod converter error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,12 +1,14 @@
 # CHANGELOG
 
 ## master
-* chore: upgrade Envoy to 1.13.1 
-  [#653](https://github.com/Kong/kuma/pull/653)
 * chore: replace deprected field ORIGINAL_DST_LB to CLUSTER_PROVIDED 
   [#656](https://github.com/Kong/kuma/pull/656)
+* chore: upgrade Envoy to 1.13.1 
+  [#653](https://github.com/Kong/kuma/pull/653)
 * chore: migrate deprecated Envoy config to support newest version of Envoy 
   [#652](https://github.com/Kong/kuma/pull/652)
+* chore: prevent dataplane creation with a headless services and provide more descriptive error message on pod converter error
+  [#651](https://github.com/Kong/kuma/pull/651)
 * feat: save service's tags to header for L7-traffic
   [#647](https://github.com/Kong/kuma/pull/647/files)
 * chore: the API root `/` now returns the hostname

--- a/app/kuma-dp/pkg/dataplane/envoy/remote_bootstrap.go
+++ b/app/kuma-dp/pkg/dataplane/envoy/remote_bootstrap.go
@@ -50,7 +50,7 @@ func (b *remoteBootstrap) Generate(url string, cfg kuma_dp.Config) (proto.Messag
 	defer resp.Body.Close()
 	if resp.StatusCode != 200 {
 		if resp.StatusCode == 404 {
-			return nil, errors.New("Dataplane not found. If you are running on Universal, make sure you applied the Dataplane definition. If you are running on Kubernetes check the Control Plane logs why Dataplane was not created.")
+			return nil, errors.New("Dataplane entity not found. If you are running on Universal please create a Dataplane entity on kuma-cp before starting kuma-dp. If you are running on Kubernetes, please check the kuma-cp logs to determine why the Dataplane entity could not be created by the automatic sidecar injection.")
 		}
 		return nil, errors.Errorf("unexpected status code: %d", resp.StatusCode)
 	}

--- a/app/kuma-dp/pkg/dataplane/envoy/remote_bootstrap.go
+++ b/app/kuma-dp/pkg/dataplane/envoy/remote_bootstrap.go
@@ -50,7 +50,7 @@ func (b *remoteBootstrap) Generate(url string, cfg kuma_dp.Config) (proto.Messag
 	defer resp.Body.Close()
 	if resp.StatusCode != 200 {
 		if resp.StatusCode == 404 {
-			return nil, errors.New("status: 404. Did you first apply a Dataplane resource?")
+			return nil, errors.New("Dataplane not found. If you are running on Universal, make sure you applied the Dataplane definition. If you are running on Kubernetes check the Control Plane logs why Dataplane was not created.")
 		}
 		return nil, errors.Errorf("unexpected status code: %d", resp.StatusCode)
 	}

--- a/pkg/plugins/discovery/k8s/controllers/pod_controller_test.go
+++ b/pkg/plugins/discovery/k8s/controllers/pod_controller_test.go
@@ -87,6 +87,7 @@ var _ = Describe("PodReconciler", func() {
 					},
 				},
 				Spec: kube_core.ServiceSpec{
+					ClusterIP: "192.168.0.1",
 					Ports: []kube_core.ServicePort{
 						{
 							Port: 80,

--- a/pkg/plugins/discovery/k8s/controllers/pod_converter.go
+++ b/pkg/plugins/discovery/k8s/controllers/pod_converter.go
@@ -3,6 +3,7 @@ package controllers
 import (
 	"context"
 	"fmt"
+	"net"
 	"sort"
 	"strings"
 
@@ -103,6 +104,9 @@ func InboundInterfacesFor(pod *kube_core.Pod, services []*kube_core.Service, isG
 				converterLog.Error(err, "failed to find a container port in a given Pod that would match a given Service port", "namespace", pod.Namespace, "podName", pod.Name, "serviceName", svc.Name, "servicePortName", svcPort.Name)
 				// ignore those cases where a Pod doesn't have all the ports a Service has
 				continue
+			}
+			if net.ParseIP(svc.Spec.ClusterIP) == nil {
+				return nil, errors.Errorf("Kuma requires Service associated with Pod to has a valid IP address in ClusterIP field. Value of ClusterIP of Service %s.%s is %q. Support for headless services is coming soon. You can either change the Service definition or exclude this Pod from having Dataplane injected https://kuma.io/docs/0.4.0/documentation/dps-and-data-model/#kubernetes", svc.Name, svc.Namespace, svc.Spec.ClusterIP)
 			}
 
 			tags := InboundTagsFor(pod, svc, &svcPort, isGateway)

--- a/pkg/plugins/discovery/k8s/controllers/pod_converter.go
+++ b/pkg/plugins/discovery/k8s/controllers/pod_converter.go
@@ -106,7 +106,7 @@ func InboundInterfacesFor(pod *kube_core.Pod, services []*kube_core.Service, isG
 				continue
 			}
 			if net.ParseIP(svc.Spec.ClusterIP) == nil {
-				return nil, errors.Errorf("Kuma requires Service associated with Pod to has a valid IP address in ClusterIP field. Value of ClusterIP of Service %s.%s is %q. Support for headless services is coming soon. You can either change the Service definition or exclude this Pod from having Dataplane injected https://kuma.io/docs/0.4.0/documentation/dps-and-data-model/#kubernetes", svc.Name, svc.Namespace, svc.Spec.ClusterIP)
+				return nil, errors.Errorf("Kuma requires a Kubernetes Service entity associated with a Pod with a valid IP address in the ClusterIP field. Service %s.%s has a ClusterIP value of %q. At the moment Kuma does not support headless services, to continue please add the missing Service definition or - alternatively - exclude this Pod from the automatic sidecar injection by following the instructions at: https://kuma.io/docs/latest/documentation/dps-and-data-model/#kubernetes", svc.Name, svc.Namespace, svc.Spec.ClusterIP)
 			}
 
 			tags := InboundTagsFor(pod, svc, &svcPort, isGateway)

--- a/pkg/plugins/discovery/k8s/controllers/pod_converter_test.go
+++ b/pkg/plugins/discovery/k8s/controllers/pod_converter_test.go
@@ -406,7 +406,7 @@ var _ = Describe("PodToDataplane(..)", func() {
                     port: 80
                     targetPort: 7070
 `},
-				expectedErr: `Kuma requires Service associated with Pod to has a valid IP address in ClusterIP field. Value of ClusterIP of Service sample.demo is "None". Support for headless services is coming soon. You can either change the Service definition or exclude this Pod from having Dataplane injected https://kuma.io/docs/0.4.0/documentation/dps-and-data-model/#kubernetes`,
+				expectedErr: `Kuma requires a Kubernetes Service entity associated with a Pod with a valid IP address in the ClusterIP field. Service sample.demo has a ClusterIP value of "None". At the moment Kuma does not support headless services, to continue please add the missing Service definition or - alternatively - exclude this Pod from the automatic sidecar injection by following the instructions at: https://kuma.io/docs/latest/documentation/dps-and-data-model/#kubernetes`,
 			}),
 		)
 	})

--- a/pkg/plugins/discovery/k8s/controllers/pod_converter_test.go
+++ b/pkg/plugins/discovery/k8s/controllers/pod_converter_test.go
@@ -149,6 +149,7 @@ var _ = Describe("PodToDataplane(..)", func() {
                   annotations:
                     80.service.kuma.io/protocol: http
                 spec:
+                  clusterIP: 192.168.0.1
                   ports:
                   - # protocol defaults to TCP
                     port: 80
@@ -164,6 +165,7 @@ var _ = Describe("PodToDataplane(..)", func() {
                   annotations:
                     7071.service.kuma.io/protocol: MONGO
                 spec:
+                  clusterIP: 192.168.0.1
                   ports:
                   - protocol: TCP
                     port: 7071
@@ -214,6 +216,7 @@ var _ = Describe("PodToDataplane(..)", func() {
               namespace: demo
               name: example
             spec:
+              clusterIP: 192.168.0.1
               ports:
               - # protocol defaults to TCP
                 port: 80
@@ -303,6 +306,7 @@ var _ = Describe("PodToDataplane(..)", func() {
               annotations:
                 80.service.kuma.io/protocol: http # should be ignored in case of a gateway
             spec:
+              clusterIP: 192.168.0.1
               ports:
               - # protocol defaults to TCP
                 port: 80
@@ -372,6 +376,7 @@ var _ = Describe("PodToDataplane(..)", func() {
 				pod: pod,
 				services: []string{`
                 spec:
+                  clusterIP: 192.168.0.1
                   ports:
                   - protocol: UDP    # all non-TCP ports should be ignored
                     port: 80
@@ -387,6 +392,21 @@ var _ = Describe("PodToDataplane(..)", func() {
                     targetPort: diagnostics
 `},
 				expectedErr: `Kuma requires every Pod in a Mesh to be a part of at least one Service. However, this Pod doesn't have any container ports that would satisfy matching Service(s).`,
+			}),
+			Entry("Pod with a headless Service", testCase{ // Remove after providing support for Headless Services https://github.com/Kong/kuma/issues/561
+				pod: pod,
+				services: []string{`
+                metadata:
+                  name: sample
+                  namespace: demo
+                spec:
+                  clusterIP: None
+                  ports:
+                  - protocol: TCP
+                    port: 80
+                    targetPort: 7070
+`},
+				expectedErr: `Kuma requires Service associated with Pod to has a valid IP address in ClusterIP field. Value of ClusterIP of Service sample.demo is "None". Support for headless services is coming soon. You can either change the Service definition or exclude this Pod from having Dataplane injected https://kuma.io/docs/0.4.0/documentation/dps-and-data-model/#kubernetes`,
 			}),
 		)
 	})


### PR DESCRIPTION
### Summary

This change covers a couple of things:
* Provide more descriptive error message in Kuma DP on K8S when Pod was not converted to Dataplane in K8S
* Prevent creating a Dataplane with Headless Service. Otherwise other dataplanes will create outbound listeners to it and they will fail with doing so, because outbound address is not valid.
* Provide a message suggesting what can be done with such situation (either change the service or exclude Pod from the mesh)