### PR TITLE
docs(governance): introducing open-governance to the project

### DIFF
--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -1,0 +1,52 @@
+# Kuma Governance
+
+This document defines governance policies for the Kuma project.
+
+## Maintainers
+
+Kuma Maintainers have write access to the Kuma GitHub repository https://github.com/Kong/kuma.
+They can merge their own patches or patches from others. The current maintainers can be found in [CODEOWNERS](./CODEOWNERS).
+
+This privilege is granted with some expectation of responsibility: maintainers are people who care about the Kuma project and want to help it grow and improve. A maintainer is not just someone who can make changes, but someone who has demonstrated his or her ability to collaborate with the team, get the most knowledgeable people to review code, contribute high-quality code, and follow through to fix issues (in code or tests).
+
+A maintainer is a contributor to the Kuma project's success and a citizen helping the project succeed.
+
+## Becoming a Maintainer
+
+To become a maintainer you need to demonstrate the following:
+
+  * commitment to the project
+    * participate in discussions, contributions, code reviews for 3 months or more,
+    * perform code reviews for 10 non-trivial pull requests,
+    * contribute 10 non-trivial pull requests and have them merged into master,
+  * ability to write good code,
+  * ability to collaborate with the team,
+  * understanding of how the team works (policies, processes for testing and code review, etc), 
+  * understanding of the projects' code base and coding style.
+
+A new maintainer must be proposed by an existing maintainer by opening an issue (with title `Maintainer Nomination`) to the Kuma Github repository (https://github.com/Kong/kuma) containing the following information:
+
+  * nominee's first and last name,
+  * nominee's email address and GitHub user name,
+  * an explanation of why the nominee should be a committer,
+  * a list of links to non-trivial pull requests (top 10) authored by the nominee.
+
+Two other maintainers need to second the nomination. If no one objects in 5 working days (U.S.), the nomination is accepted. If anyone objects or wants more information, the maintainers discuss and usually come to a consensus (within the 5 working days). If issues can't be resolved, there's a simple majority vote among current maintainers.
+
+## Changes in Maintainership
+
+Maintainers can be removed by a 2/3 majority vote by maintainers.
+
+## GitHub Project Administration
+
+Maintainers will be added to the GitHub @Kong/kuma-maintainers team, and made a GitHub maintainer of that team.
+They will be given write permission to the Kuma GitHub repository https://github.com/Kong/kuma.
+
+## Changes in Governance
+
+All changes in Governance require a 2/3 majority vote by maintainers.
+
+## Other Changes
+
+Unless specified above, all other changes to the project require a 2/3 majority vote by maintainers.
+Additionally, any maintainer may request that any change require a 2/3 majority vote by maintainers.

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -22,7 +22,7 @@ To become a maintainer you need to demonstrate the following:
   * ability to write good code,
   * ability to collaborate with the team,
   * understanding of how the team works (policies, processes for testing and code review, etc), 
-  * understanding of the projects' code base and coding style.
+  * understanding of the project's code base and coding style.
 
 A new maintainer must be proposed by an existing maintainer by opening an issue (with title `Maintainer Nomination`) to the Kuma Github repository (https://github.com/Kong/kuma) containing the following information:
 


### PR DESCRIPTION
I am very excited to introduce **open governance** guidelines for Kuma and a clear path for third-party contributors to become maintainers of the project!

⭐️ As part of this effort we will also start scheduling **bi-weekly community calls** on Kuma to determine the roadmap of the project, high-priority items and more generally to create an inclusive and diverse collaborative community around Kuma. 

I will update this PR with more information about this in the following days.