### PR TITLE
fix(injector) change local address for probes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # CHANGELOG
 
 ## master
+* fix: make Envoy 1.13.1 work on Kind
+  [#660](https://github.com/Kong/kuma/pull/660)
 * feat: added a new `kumactl install tracing` CLI command
   [#655](https://github.com/Kong/kuma/pull/655)
 * chore: replace deprected field ORIGINAL_DST_LB to CLUSTER_PROVIDED 

--- a/app/kuma-injector/pkg/injector/injector.go
+++ b/app/kuma-injector/pkg/injector/injector.go
@@ -163,7 +163,7 @@ func (i *KumaInjector) NewSidecarContainer(pod *kube_core.Pod) kube_core.Contain
 					Command: []string{
 						"wget",
 						"-qO-",
-						fmt.Sprintf("http://localhost:%d", i.cfg.SidecarContainer.AdminPort),
+						fmt.Sprintf("http://127.0.0.1:%d", i.cfg.SidecarContainer.AdminPort),
 					},
 				},
 			},
@@ -179,7 +179,7 @@ func (i *KumaInjector) NewSidecarContainer(pod *kube_core.Pod) kube_core.Contain
 					Command: []string{
 						"wget",
 						"-qO-",
-						fmt.Sprintf("http://localhost:%d", i.cfg.SidecarContainer.AdminPort),
+						fmt.Sprintf("http://127.0.0.1:%d", i.cfg.SidecarContainer.AdminPort),
 					},
 				},
 			},

--- a/app/kuma-injector/pkg/injector/testdata/inject.01.golden.yaml
+++ b/app/kuma-injector/pkg/injector/testdata/inject.01.golden.yaml
@@ -57,7 +57,7 @@ spec:
         command:
         - wget
         - -qO-
-        - http://localhost:9901
+        - http://127.0.0.1:9901
       failureThreshold: 212
       initialDelaySeconds: 260
       periodSeconds: 25
@@ -69,7 +69,7 @@ spec:
         command:
         - wget
         - -qO-
-        - http://localhost:9901
+        - http://127.0.0.1:9901
       failureThreshold: 112
       initialDelaySeconds: 11
       periodSeconds: 15

--- a/app/kuma-injector/pkg/injector/testdata/inject.02.golden.yaml
+++ b/app/kuma-injector/pkg/injector/testdata/inject.02.golden.yaml
@@ -58,7 +58,7 @@ spec:
         command:
         - wget
         - -qO-
-        - http://localhost:9901
+        - http://127.0.0.1:9901
       failureThreshold: 212
       initialDelaySeconds: 260
       periodSeconds: 25
@@ -70,7 +70,7 @@ spec:
         command:
         - wget
         - -qO-
-        - http://localhost:9901
+        - http://127.0.0.1:9901
       failureThreshold: 112
       initialDelaySeconds: 11
       periodSeconds: 15

--- a/app/kuma-injector/pkg/injector/testdata/inject.03.golden.yaml
+++ b/app/kuma-injector/pkg/injector/testdata/inject.03.golden.yaml
@@ -117,7 +117,7 @@ spec:
         command:
         - wget
         - -qO-
-        - http://localhost:9901
+        - http://127.0.0.1:9901
       failureThreshold: 212
       initialDelaySeconds: 260
       periodSeconds: 25
@@ -129,7 +129,7 @@ spec:
         command:
         - wget
         - -qO-
-        - http://localhost:9901
+        - http://127.0.0.1:9901
       failureThreshold: 112
       initialDelaySeconds: 11
       periodSeconds: 15

--- a/app/kuma-injector/pkg/injector/testdata/inject.04.golden.yaml
+++ b/app/kuma-injector/pkg/injector/testdata/inject.04.golden.yaml
@@ -57,7 +57,7 @@ spec:
         command:
         - wget
         - -qO-
-        - http://localhost:9901
+        - http://127.0.0.1:9901
       failureThreshold: 212
       initialDelaySeconds: 260
       periodSeconds: 25
@@ -69,7 +69,7 @@ spec:
         command:
         - wget
         - -qO-
-        - http://localhost:9901
+        - http://127.0.0.1:9901
       failureThreshold: 112
       initialDelaySeconds: 11
       periodSeconds: 15

--- a/app/kuma-injector/pkg/injector/testdata/inject.05.golden.yaml
+++ b/app/kuma-injector/pkg/injector/testdata/inject.05.golden.yaml
@@ -54,7 +54,7 @@ spec:
         command:
         - wget
         - -qO-
-        - http://localhost:9901
+        - http://127.0.0.1:9901
       failureThreshold: 212
       initialDelaySeconds: 260
       periodSeconds: 25
@@ -66,7 +66,7 @@ spec:
         command:
         - wget
         - -qO-
-        - http://localhost:9901
+        - http://127.0.0.1:9901
       failureThreshold: 112
       initialDelaySeconds: 11
       periodSeconds: 15

--- a/app/kuma-injector/pkg/injector/testdata/inject.06.golden.yaml
+++ b/app/kuma-injector/pkg/injector/testdata/inject.06.golden.yaml
@@ -58,7 +58,7 @@ spec:
         command:
         - wget
         - -qO-
-        - http://localhost:9901
+        - http://127.0.0.1:9901
       failureThreshold: 212
       initialDelaySeconds: 260
       periodSeconds: 25
@@ -70,7 +70,7 @@ spec:
         command:
         - wget
         - -qO-
-        - http://localhost:9901
+        - http://127.0.0.1:9901
       failureThreshold: 112
       initialDelaySeconds: 11
       periodSeconds: 15

--- a/app/kuma-injector/pkg/injector/testdata/inject.07.golden.yaml
+++ b/app/kuma-injector/pkg/injector/testdata/inject.07.golden.yaml
@@ -60,7 +60,7 @@ spec:
         command:
         - wget
         - -qO-
-        - http://localhost:9901
+        - http://127.0.0.1:9901
       failureThreshold: 212
       initialDelaySeconds: 260
       periodSeconds: 25
@@ -72,7 +72,7 @@ spec:
         command:
         - wget
         - -qO-
-        - http://localhost:9901
+        - http://127.0.0.1:9901
       failureThreshold: 112
       initialDelaySeconds: 11
       periodSeconds: 15

--- a/app/kuma-injector/pkg/injector/testdata/inject.08.golden.yaml
+++ b/app/kuma-injector/pkg/injector/testdata/inject.08.golden.yaml
@@ -60,7 +60,7 @@ spec:
         command:
         - wget
         - -qO-
-        - http://localhost:9901
+        - http://127.0.0.1:9901
       failureThreshold: 212
       initialDelaySeconds: 260
       periodSeconds: 25
@@ -72,7 +72,7 @@ spec:
         command:
         - wget
         - -qO-
-        - http://localhost:9901
+        - http://127.0.0.1:9901
       failureThreshold: 112
       initialDelaySeconds: 11
       periodSeconds: 15

--- a/app/kuma-injector/pkg/injector/testdata/inject.09.golden.yaml
+++ b/app/kuma-injector/pkg/injector/testdata/inject.09.golden.yaml
@@ -62,7 +62,7 @@ spec:
         command:
         - wget
         - -qO-
-        - http://localhost:9901
+        - http://127.0.0.1:9901
       failureThreshold: 212
       initialDelaySeconds: 260
       periodSeconds: 25
@@ -74,7 +74,7 @@ spec:
         command:
         - wget
         - -qO-
-        - http://localhost:9901
+        - http://127.0.0.1:9901
       failureThreshold: 112
       initialDelaySeconds: 11
       periodSeconds: 15

--- a/app/kuma-injector/pkg/injector/testdata/inject.11.golden.yaml
+++ b/app/kuma-injector/pkg/injector/testdata/inject.11.golden.yaml
@@ -58,7 +58,7 @@ spec:
         command:
         - wget
         - -qO-
-        - http://localhost:9901
+        - http://127.0.0.1:9901
       failureThreshold: 212
       initialDelaySeconds: 260
       periodSeconds: 25
@@ -70,7 +70,7 @@ spec:
         command:
         - wget
         - -qO-
-        - http://localhost:9901
+        - http://127.0.0.1:9901
       failureThreshold: 112
       initialDelaySeconds: 11
       periodSeconds: 15


### PR DESCRIPTION
### Summary

`kuma-dp` refuses to work on Kind after updating Envoy up to 1.13.1, current PR fixes that issue

Readiness and liveness probes didn't work as expected and failed with: `Readiness probe failed: wget: can't connect to remote host: Connection refused`.

For some reason, `localhost` resolves to `127.0.0.1` on envoy-alpine 1.12.2 and resolves to `::1` on further versions.

According to envoy source code, admin server listener starts at `0.0.0.0:9901` so it binds to IPv4 interface. So in order to avoid ambiguous behavior, makes sense to change localhost to 127.0.0.1
