### PR TITLE
fix(kumactl) added shorthand command name for mesh

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,8 @@
   [#630](https://github.com/Kong/kuma/pull/630)
 * feature: added flag `--dry-run` for `kumactl apply`
   [#622](https://github.com/Kong/kuma/pull/622)
+* fix: added shorthand command name for mesh in kumactl
+  [#664](https://github.com/Kong/kuma/pull/664)
 
 ## [0.4.0]
 

--- a/app/kumactl/cmd/root.go
+++ b/app/kumactl/cmd/root.go
@@ -53,7 +53,7 @@ func NewRootCmd(root *kumactl_cmd.RootContext) *cobra.Command {
 	}
 	// root flags
 	cmd.PersistentFlags().StringVar(&root.Args.ConfigFile, "config-file", "", "path to the configuration file to use")
-	cmd.PersistentFlags().StringVar(&root.Args.Mesh, "mesh", "default", "mesh to use")
+	cmd.PersistentFlags().StringVarP(&root.Args.Mesh, "mesh", "m", "default", "mesh to use")
 	cmd.PersistentFlags().StringVar(&args.logLevel, "log-level", kuma_log.OffLevel.String(), kuma_cmd.UsageOptions("log level", kuma_log.OffLevel, kuma_log.InfoLevel, kuma_log.DebugLevel))
 	// sub-commands
 	cmd.AddCommand(install.NewInstallCmd(root))

--- a/docs/cmd/kumactl/HELP.md
+++ b/docs/cmd/kumactl/HELP.md
@@ -22,7 +22,7 @@ Flags:
       --config-file string   path to the configuration file to use
   -h, --help                 help for kumactl
       --log-level string     log level: one of off|info|debug (default "off")
-      --mesh string          mesh to use (default "default")
+  -m, --mesh string          mesh to use (default "default")
 
 Use "kumactl [command] --help" for more information about a command.
 ```
@@ -44,7 +44,7 @@ Flags:
 Global Flags:
       --config-file string   path to the configuration file to use
       --log-level string     log level: one of off|info|debug (default "off")
-      --mesh string          mesh to use (default "default")
+  -m, --mesh string          mesh to use (default "default")
 ```
 
 ## kumactl config
@@ -65,7 +65,7 @@ Flags:
 Global Flags:
       --config-file string   path to the configuration file to use
       --log-level string     log level: one of off|info|debug (default "off")
-      --mesh string          mesh to use (default "default")
+  -m, --mesh string          mesh to use (default "default")
 
 Use "kumactl config [command] --help" for more information about a command.
 ```
@@ -84,7 +84,7 @@ Flags:
 Global Flags:
       --config-file string   path to the configuration file to use
       --log-level string     log level: one of off|info|debug (default "off")
-      --mesh string          mesh to use (default "default")
+  -m, --mesh string          mesh to use (default "default")
 ```
 
 ### kumactl config control-planes
@@ -107,7 +107,7 @@ Flags:
 Global Flags:
       --config-file string   path to the configuration file to use
       --log-level string     log level: one of off|info|debug (default "off")
-      --mesh string          mesh to use (default "default")
+  -m, --mesh string          mesh to use (default "default")
 
 Use "kumactl config control-planes [command] --help" for more information about a command.
 ```
@@ -126,7 +126,7 @@ Flags:
 Global Flags:
       --config-file string   path to the configuration file to use
       --log-level string     log level: one of off|info|debug (default "off")
-      --mesh string          mesh to use (default "default")
+  -m, --mesh string          mesh to use (default "default")
 ```
 
 #### kumactl config control-planes add
@@ -148,7 +148,7 @@ Flags:
 Global Flags:
       --config-file string   path to the configuration file to use
       --log-level string     log level: one of off|info|debug (default "off")
-      --mesh string          mesh to use (default "default")
+  -m, --mesh string          mesh to use (default "default")
 ```
 
 #### kumactl config control-planes remove
@@ -166,7 +166,7 @@ Flags:
 Global Flags:
       --config-file string   path to the configuration file to use
       --log-level string     log level: one of off|info|debug (default "off")
-      --mesh string          mesh to use (default "default")
+  -m, --mesh string          mesh to use (default "default")
 ```
 
 #### kumactl config control-planes switch
@@ -184,7 +184,7 @@ Flags:
 Global Flags:
       --config-file string   path to the configuration file to use
       --log-level string     log level: one of off|info|debug (default "off")
-      --mesh string          mesh to use (default "default")
+  -m, --mesh string          mesh to use (default "default")
 ```
 
 ## kumactl install
@@ -205,7 +205,7 @@ Flags:
 Global Flags:
       --config-file string   path to the configuration file to use
       --log-level string     log level: one of off|info|debug (default "off")
-      --mesh string          mesh to use (default "default")
+  -m, --mesh string          mesh to use (default "default")
 
 Use "kumactl install [command] --help" for more information about a command.
 ```
@@ -240,7 +240,7 @@ Flags:
 Global Flags:
       --config-file string   path to the configuration file to use
       --log-level string     log level: one of off|info|debug (default "off")
-      --mesh string          mesh to use (default "default")
+  -m, --mesh string          mesh to use (default "default")
 ```
 
 ### kumactl install metrics
@@ -261,7 +261,7 @@ Flags:
 Global Flags:
       --config-file string   path to the configuration file to use
       --log-level string     log level: one of off|info|debug (default "off")
-      --mesh string          mesh to use (default "default")
+  -m, --mesh string          mesh to use (default "default")
 ```
 
 ### kumactl generate tls-certificate
@@ -290,7 +290,7 @@ Flags:
 Global Flags:
       --config-file string   path to the configuration file to use
       --log-level string     log level: one of off|info|debug (default "off")
-      --mesh string          mesh to use (default "default")
+  -m, --mesh string          mesh to use (default "default")
 ```
 
 ### kumactl generate dp-token
@@ -311,7 +311,7 @@ Flags:
 Global Flags:
       --config-file string   path to the configuration file to use
       --log-level string     log level: one of off|info|debug (default "off")
-      --mesh string          mesh to use (default "default")
+  -m, --mesh string          mesh to use (default "default")
 
 Use "kumactl generate [command] --help" for more information about a command.
 ```
@@ -342,7 +342,7 @@ Flags:
 Global Flags:
       --config-file string   path to the configuration file to use
       --log-level string     log level: one of off|info|debug (default "off")
-      --mesh string          mesh to use (default "default")
+  -m, --mesh string          mesh to use (default "default")
 
 Use "kumactl get [command] --help" for more information about a command.
 ```
@@ -361,7 +361,7 @@ Flags:
 Global Flags:
       --config-file string   path to the configuration file to use
       --log-level string     log level: one of off|info|debug (default "off")
-      --mesh string          mesh to use (default "default")
+  -m, --mesh string          mesh to use (default "default")
   -o, --output string        output format: one of table|yaml|json (default "table")
 ```
 
@@ -379,7 +379,7 @@ Flags:
 Global Flags:
       --config-file string   path to the configuration file to use
       --log-level string     log level: one of off|info|debug (default "off")
-      --mesh string          mesh to use (default "default")
+  -m, --mesh string          mesh to use (default "default")
   -o, --output string        output format: one of table|yaml|json (default "table")
 ```
 
@@ -397,7 +397,7 @@ Flags:
 Global Flags:
       --config-file string   path to the configuration file to use
       --log-level string     log level: one of off|info|debug (default "off")
-      --mesh string          mesh to use (default "default")
+  -m, --mesh string          mesh to use (default "default")
   -o, --output string        output format: one of table|yaml|json (default "table")
 ```
 
@@ -415,7 +415,7 @@ Flags:
 Global Flags:
       --config-file string   path to the configuration file to use
       --log-level string     log level: one of off|info|debug (default "off")
-      --mesh string          mesh to use (default "default")
+  -m, --mesh string          mesh to use (default "default")
   -o, --output string        output format: one of table|yaml|json (default "table")
 ```
 
@@ -433,7 +433,7 @@ Flags:
 Global Flags:
       --config-file string   path to the configuration file to use
       --log-level string     log level: one of off|info|debug (default "off")
-      --mesh string          mesh to use (default "default")
+  -m, --mesh string          mesh to use (default "default")
   -o, --output string        output format: one of table|yaml|json (default "table")
 ```
 
@@ -451,7 +451,7 @@ Flags:
 Global Flags:
       --config-file string   path to the configuration file to use
       --log-level string     log level: one of off|info|debug (default "off")
-      --mesh string          mesh to use (default "default")
+  -m, --mesh string          mesh to use (default "default")
   -o, --output string        output format: one of table|yaml|json (default "table")
 ```
 
@@ -469,7 +469,7 @@ Flags:
 Global Flags:
       --config-file string   path to the configuration file to use
       --log-level string     log level: one of off|info|debug (default "off")
-      --mesh string          mesh to use (default "default")
+  -m, --mesh string          mesh to use (default "default")
   -o, --output string        output format: one of table|yaml|json (default "table")
 ```
 
@@ -487,7 +487,7 @@ Flags:
 Global Flags:
       --config-file string   path to the configuration file to use
       --log-level string     log level: one of off|info|debug (default "off")
-      --mesh string          mesh to use (default "default")
+  -m, --mesh string          mesh to use (default "default")
   -o, --output string        output format: one of table|yaml|json (default "table")
 ```
 
@@ -505,7 +505,7 @@ Flags:
 Global Flags:
       --config-file string   path to the configuration file to use
       --log-level string     log level: one of off|info|debug (default "off")
-      --mesh string          mesh to use (default "default")
+  -m, --mesh string          mesh to use (default "default")
   -o, --output string        output format: one of table|yaml|json (default "table")
 ```
 
@@ -523,7 +523,7 @@ Flags:
 Global Flags:
       --config-file string   path to the configuration file to use
       --log-level string     log level: one of off|info|debug (default "off")
-      --mesh string          mesh to use (default "default")
+  -m, --mesh string          mesh to use (default "default")
 ```
 
 ## kumactl inspect
@@ -544,7 +544,7 @@ Flags:
 Global Flags:
       --config-file string   path to the configuration file to use
       --log-level string     log level: one of off|info|debug (default "off")
-      --mesh string          mesh to use (default "default")
+  -m, --mesh string          mesh to use (default "default")
 
 Use "kumactl inspect [command] --help" for more information about a command.
 ```
@@ -564,7 +564,7 @@ Flags:
 Global Flags:
       --config-file string   path to the configuration file to use
       --log-level string     log level: one of off|info|debug (default "off")
-      --mesh string          mesh to use (default "default")
+  -m, --mesh string          mesh to use (default "default")
   -o, --output string        output format: one of table|yaml|json (default "table")
 ```
 
@@ -585,7 +585,7 @@ Flags:
 Global Flags:
       --config-file string   path to the configuration file to use
       --log-level string     log level: one of off|info|debug (default "off")
-      --mesh string          mesh to use (default "default")
+  -m, --mesh string          mesh to use (default "default")
 
 Use "kumactl manage [command] --help" for more information about a command.
 ```
@@ -607,7 +607,7 @@ Flags:
 Global Flags:
       --config-file string   path to the configuration file to use
       --log-level string     log level: one of off|info|debug (default "off")
-      --mesh string          mesh to use (default "default")
+  -m, --mesh string          mesh to use (default "default")
 
 Use "kumactl manage ca [command] --help" for more information about a command.
 ```
@@ -629,7 +629,7 @@ Flags:
 Global Flags:
       --config-file string   path to the configuration file to use
       --log-level string     log level: one of off|info|debug (default "off")
-      --mesh string          mesh to use (default "default")
+  -m, --mesh string          mesh to use (default "default")
 
 Use "kumactl manage ca provided [command] --help" for more information about a command.
 ```
@@ -653,7 +653,7 @@ Flags:
 Global Flags:
       --config-file string   path to the configuration file to use
       --log-level string     log level: one of off|info|debug (default "off")
-      --mesh string          mesh to use (default "default")
+  -m, --mesh string          mesh to use (default "default")
 
 Use "kumactl manage ca provided certificates [command] --help" for more information about a command.
 ```
@@ -672,7 +672,7 @@ Flags:
 Global Flags:
       --config-file string   path to the configuration file to use
       --log-level string     log level: one of off|info|debug (default "off")
-      --mesh string          mesh to use (default "default")
+  -m, --mesh string          mesh to use (default "default")
 ```
 
 ###### kumactl manage ca provided certificates delete
@@ -690,7 +690,7 @@ Flags:
 Global Flags:
       --config-file string   path to the configuration file to use
       --log-level string     log level: one of off|info|debug (default "off")
-      --mesh string          mesh to use (default "default")
+  -m, --mesh string          mesh to use (default "default")
 ```
 
 ###### kumactl manage ca provided certificates add
@@ -709,7 +709,7 @@ Flags:
 Global Flags:
       --config-file string   path to the configuration file to use
       --log-level string     log level: one of off|info|debug (default "off")
-      --mesh string          mesh to use (default "default")
+  -m, --mesh string          mesh to use (default "default")
 ```
 
 ## kumactl version
@@ -727,6 +727,6 @@ Flags:
 Global Flags:
       --config-file string   path to the configuration file to use
       --log-level string     log level: one of off|info|debug (default "off")
-      --mesh string          mesh to use (default "default")
+  -m, --mesh string          mesh to use (default "default")
 ```
 


### PR DESCRIPTION
* added shorthand message for mesh argument in kumactl
Fix #662

### Summary
added the shorthand name for mesh argument

SUMMARY_GOES_HERE

### Full changelog

* Added shorthand name for mesh argument in kumactl

### Issues resolved

Fix #662

Open Question:
 We don't have a test for `inspect dataplane` with mesh name other than the default name. Is it worth adding?