### PR TITLE
feat(kumactl) pagination

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # CHANGELOG
 
 ## master
+* feat: pagination in kumactl
+  [#690](https://github.com/Kong/kuma/pull/690)
 * chore: unify matching for TrafficPermission
   [#668](https://github.com/Kong/kuma/pull/668)
   ⚠️ warning: breaking change of matching mechanism

--- a/app/kumactl/cmd/get/get.go
+++ b/app/kumactl/cmd/get/get.go
@@ -59,6 +59,6 @@ func NewGetCmd(pctx *kumactl_cmd.RootContext) *cobra.Command {
 
 func withPaginationArgs(cmd *cobra.Command, ctx *listContext) *cobra.Command {
 	cmd.PersistentFlags().IntVarP(&ctx.args.size, "size", "", 0, "maximum number of elements to return")
-	cmd.PersistentFlags().StringVarP(&ctx.args.offset, "offset", "", "", "next offset")
+	cmd.PersistentFlags().StringVarP(&ctx.args.offset, "offset", "", "", "the offset that indicates starting element of the resources list to retrieve")
 	return cmd
 }

--- a/app/kumactl/cmd/get/get.go
+++ b/app/kumactl/cmd/get/get.go
@@ -16,6 +16,14 @@ type getContext struct {
 	}
 }
 
+type listContext struct {
+	*getContext
+	args struct {
+		size int
+		offset string
+	}
+}
+
 func NewGetCmd(pctx *kumactl_cmd.RootContext) *cobra.Command {
 	ctx := &getContext{RootContext: pctx}
 	cmd := &cobra.Command{
@@ -26,15 +34,17 @@ func NewGetCmd(pctx *kumactl_cmd.RootContext) *cobra.Command {
 	// flags
 	cmd.PersistentFlags().StringVarP(&ctx.args.outputFormat, "output", "o", string(output.TableFormat), kuma_cmd.UsageOptions("output format", output.TableFormat, output.YAMLFormat, output.JSONFormat))
 	// sub-commands
-	cmd.AddCommand(newGetMeshesCmd(ctx))
-	cmd.AddCommand(newGetDataplanesCmd(ctx))
-	cmd.AddCommand(newGetHealthChecksCmd(ctx))
-	cmd.AddCommand(newGetProxyTemplatesCmd(ctx))
-	cmd.AddCommand(newGetTrafficPermissionsCmd(ctx))
-	cmd.AddCommand(newGetTrafficRoutesCmd(ctx))
-	cmd.AddCommand(newGetTrafficLogsCmd(ctx))
-	cmd.AddCommand(newGetTrafficTracesCmd(ctx))
-	cmd.AddCommand(newGetFaultInjectionsCmd(ctx))
+	listCtx := &listContext{getContext: ctx}
+	cmd.AddCommand(withPaginationArgs(newGetMeshesCmd(listCtx), listCtx))
+	cmd.AddCommand(withPaginationArgs(newGetDataplanesCmd(listCtx), listCtx))
+	cmd.AddCommand(withPaginationArgs(newGetHealthChecksCmd(listCtx), listCtx))
+	cmd.AddCommand(withPaginationArgs(newGetProxyTemplatesCmd(listCtx), listCtx))
+	cmd.AddCommand(withPaginationArgs(newGetTrafficPermissionsCmd(listCtx), listCtx))
+	cmd.AddCommand(withPaginationArgs(newGetTrafficRoutesCmd(listCtx), listCtx))
+	cmd.AddCommand(withPaginationArgs(newGetTrafficLogsCmd(listCtx), listCtx))
+	cmd.AddCommand(withPaginationArgs(newGetTrafficTracesCmd(listCtx), listCtx))
+	cmd.AddCommand(withPaginationArgs(newGetFaultInjectionsCmd(listCtx), listCtx))
+
 	cmd.AddCommand(newGetFaultInjectionCmd(ctx))
 	cmd.AddCommand(newGetMeshCmd(ctx))
 	cmd.AddCommand(newGetDataplaneCmd(ctx))
@@ -44,5 +54,11 @@ func NewGetCmd(pctx *kumactl_cmd.RootContext) *cobra.Command {
 	cmd.AddCommand(newGetTrafficPermissionCmd(ctx))
 	cmd.AddCommand(newGetTrafficRouteCmd(ctx))
 	cmd.AddCommand(newGetTrafficTraceCmd(ctx))
+	return cmd
+}
+
+func withPaginationArgs(cmd *cobra.Command, ctx *listContext) *cobra.Command {
+	cmd.PersistentFlags().IntVarP(&ctx.args.size, "size", "", 0, "maximum number of elements to return")
+	cmd.PersistentFlags().StringVarP(&ctx.args.offset, "offset", "", "", "next offset")
 	return cmd
 }

--- a/app/kumactl/cmd/get/get.go
+++ b/app/kumactl/cmd/get/get.go
@@ -19,7 +19,7 @@ type getContext struct {
 type listContext struct {
 	*getContext
 	args struct {
-		size int
+		size   int
 		offset string
 	}
 }

--- a/app/kumactl/cmd/get/get_dataplane.go
+++ b/app/kumactl/cmd/get/get_dataplane.go
@@ -35,10 +35,12 @@ func newGetDataplaneCmd(pctx *getContext) *cobra.Command {
 				}
 				return errors.Wrapf(err, "failed to get mesh %s", currentMesh)
 			}
-			dataplanes := []*mesh.DataplaneResource{dataplane}
+			dataplanes := mesh.DataplaneResourceList{
+				Items: []*mesh.DataplaneResource{dataplane},
+			}
 			switch format := output.Format(pctx.args.outputFormat); format {
 			case output.TableFormat:
-				return printDataplanes(dataplanes, cmd.OutOrStdout())
+				return printDataplanes(&dataplanes, cmd.OutOrStdout())
 			default:
 				printer, err := printers.NewGenericPrinter(format)
 				if err != nil {

--- a/app/kumactl/cmd/get/get_dataplanes.go
+++ b/app/kumactl/cmd/get/get_dataplanes.go
@@ -20,7 +20,7 @@ func newGetDataplanesCmd(pctx *listContext) *cobra.Command {
 		Use:   "dataplanes",
 		Short: "Show Dataplanes",
 		Long:  `Show Dataplanes.`,
-		RunE: func(cmd *cobra.Command, x []string) error {
+		RunE: func(cmd *cobra.Command, _ []string) error {
 			rs, err := pctx.CurrentResourceStore()
 			if err != nil {
 				return err

--- a/app/kumactl/cmd/get/get_dataplanes.go
+++ b/app/kumactl/cmd/get/get_dataplanes.go
@@ -2,15 +2,17 @@ package get
 
 import (
 	"context"
+	"io"
+
+	"github.com/pkg/errors"
+	"github.com/spf13/cobra"
+
 	"github.com/Kong/kuma/app/kumactl/pkg/output"
 	"github.com/Kong/kuma/app/kumactl/pkg/output/printers"
 	"github.com/Kong/kuma/app/kumactl/pkg/output/table"
 	"github.com/Kong/kuma/pkg/core/resources/apis/mesh"
 	rest_types "github.com/Kong/kuma/pkg/core/resources/model/rest"
 	core_store "github.com/Kong/kuma/pkg/core/resources/store"
-	"github.com/pkg/errors"
-	"github.com/spf13/cobra"
-	"io"
 )
 
 func newGetDataplanesCmd(pctx *listContext) *cobra.Command {

--- a/app/kumactl/cmd/get/get_dataplanes_test.go
+++ b/app/kumactl/cmd/get/get_dataplanes_test.go
@@ -163,7 +163,7 @@ var _ = Describe("kumactl get dataplanes", func() {
 			Entry("should support pagination", testCase{
 				outputFormat: "-otable",
 				goldenFile:   "get-dataplanes.pagination.golden.txt",
-				pagination: "--size=1",
+				pagination:   "--size=1",
 				matcher: func(expected interface{}) gomega_types.GomegaMatcher {
 					return WithTransform(strings.TrimSpace, Equal(strings.TrimSpace(string(expected.([]byte)))))
 				},

--- a/app/kumactl/cmd/get/get_dataplanes_test.go
+++ b/app/kumactl/cmd/get/get_dataplanes_test.go
@@ -122,6 +122,7 @@ var _ = Describe("kumactl get dataplanes", func() {
 
 		type testCase struct {
 			outputFormat string
+			pagination   string
 			goldenFile   string
 			matcher      func(interface{}) gomega_types.GomegaMatcher
 		}
@@ -131,7 +132,7 @@ var _ = Describe("kumactl get dataplanes", func() {
 				// given
 				rootCmd.SetArgs(append([]string{
 					"--config-file", filepath.Join("..", "testdata", "sample-kumactl.config.yaml"),
-					"get", "dataplanes"}, given.outputFormat))
+					"get", "dataplanes"}, given.outputFormat, given.pagination))
 
 				// when
 				err := rootCmd.Execute()
@@ -155,6 +156,14 @@ var _ = Describe("kumactl get dataplanes", func() {
 			Entry("should support Table output explicitly", testCase{
 				outputFormat: "-otable",
 				goldenFile:   "get-dataplanes.golden.txt",
+				matcher: func(expected interface{}) gomega_types.GomegaMatcher {
+					return WithTransform(strings.TrimSpace, Equal(strings.TrimSpace(string(expected.([]byte)))))
+				},
+			}),
+			Entry("should support pagination", testCase{
+				outputFormat: "-otable",
+				goldenFile:   "get-dataplanes.pagination.golden.txt",
+				pagination: "--size=1",
 				matcher: func(expected interface{}) gomega_types.GomegaMatcher {
 					return WithTransform(strings.TrimSpace, Equal(strings.TrimSpace(string(expected.([]byte)))))
 				},

--- a/app/kumactl/cmd/get/get_fault_injection.go
+++ b/app/kumactl/cmd/get/get_fault_injection.go
@@ -35,7 +35,9 @@ func newGetFaultInjectionCmd(pctx *getContext) *cobra.Command {
 				}
 				return errors.Wrapf(err, "failed to get mesh %s", currentMesh)
 			}
-			faultInjections := []*mesh.FaultInjectionResource{faultInjection}
+			faultInjections := &mesh.FaultInjectionResourceList{
+				Items: []*mesh.FaultInjectionResource{faultInjection},
+			}
 			switch format := output.Format(pctx.args.outputFormat); format {
 			case output.TableFormat:
 				return printFaultInjections(faultInjections, cmd.OutOrStdout())

--- a/app/kumactl/cmd/get/get_fault_injections.go
+++ b/app/kumactl/cmd/get/get_fault_injections.go
@@ -2,8 +2,9 @@ package get
 
 import (
 	"context"
-	"github.com/Kong/kuma/app/kumactl/pkg/output/table"
 	"io"
+
+	"github.com/Kong/kuma/app/kumactl/pkg/output/table"
 
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"

--- a/app/kumactl/cmd/get/get_fault_injections.go
+++ b/app/kumactl/cmd/get/get_fault_injections.go
@@ -2,6 +2,7 @@ package get
 
 import (
 	"context"
+	"github.com/Kong/kuma/app/kumactl/pkg/output/table"
 	"io"
 
 	"github.com/pkg/errors"
@@ -14,7 +15,7 @@ import (
 	core_store "github.com/Kong/kuma/pkg/core/resources/store"
 )
 
-func newGetFaultInjectionsCmd(pctx *getContext) *cobra.Command {
+func newGetFaultInjectionsCmd(pctx *listContext) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "fault-injections",
 		Short: "Show FaultInjections",
@@ -26,13 +27,13 @@ func newGetFaultInjectionsCmd(pctx *getContext) *cobra.Command {
 			}
 
 			faultInjections := mesh.FaultInjectionResourceList{}
-			if err := rs.List(context.Background(), &faultInjections, core_store.ListByMesh(pctx.CurrentMesh())); err != nil {
+			if err := rs.List(context.Background(), &faultInjections, core_store.ListByMesh(pctx.CurrentMesh()), core_store.ListByPage(pctx.args.size, pctx.args.offset)); err != nil {
 				return errors.Wrapf(err, "failed to list FaultInjection")
 			}
 
-			switch format := output.Format(pctx.args.outputFormat); format {
+			switch format := output.Format(pctx.getContext.args.outputFormat); format {
 			case output.TableFormat:
-				return printFaultInjections(faultInjections.Items, cmd.OutOrStdout())
+				return printFaultInjections(&faultInjections, cmd.OutOrStdout())
 			default:
 				printer, err := printers.NewGenericPrinter(format)
 				if err != nil {
@@ -45,17 +46,17 @@ func newGetFaultInjectionsCmd(pctx *getContext) *cobra.Command {
 	return cmd
 }
 
-func printFaultInjections(faultInjections []*mesh.FaultInjectionResource, out io.Writer) error {
+func printFaultInjections(faultInjections *mesh.FaultInjectionResourceList, out io.Writer) error {
 	data := printers.Table{
 		Headers: []string{"MESH", "NAME"},
 		NextRow: func() func() []string {
 			i := 0
 			return func() []string {
 				defer func() { i++ }()
-				if len(faultInjections) <= i {
+				if len(faultInjections.Items) <= i {
 					return nil
 				}
-				faultInjection := faultInjections[i]
+				faultInjection := faultInjections.Items[i]
 
 				return []string{
 					faultInjection.GetMeta().GetMesh(), // MESH
@@ -63,6 +64,7 @@ func printFaultInjections(faultInjections []*mesh.FaultInjectionResource, out io
 				}
 			}
 		}(),
+		Footer: table.PaginationFooter(faultInjections),
 	}
 	return printers.NewTablePrinter().Print(data, out)
 }

--- a/app/kumactl/cmd/get/get_fault_injections_test.go
+++ b/app/kumactl/cmd/get/get_fault_injections_test.go
@@ -139,6 +139,7 @@ var _ = Describe("kumactl get fault-injections", func() {
 		type testCase struct {
 			outputFormat string
 			goldenFile   string
+			pagination   string
 			matcher      func(interface{}) gomega_types.GomegaMatcher
 		}
 
@@ -147,7 +148,7 @@ var _ = Describe("kumactl get fault-injections", func() {
 				// given
 				rootCmd.SetArgs(append([]string{
 					"--config-file", filepath.Join("..", "testdata", "sample-kumactl.config.yaml"),
-					"get", "fault-injections"}, given.outputFormat))
+					"get", "fault-injections"}, given.outputFormat, given.pagination))
 
 				// when
 				err := rootCmd.Execute()
@@ -171,6 +172,14 @@ var _ = Describe("kumactl get fault-injections", func() {
 			Entry("should support Table output explicitly", testCase{
 				outputFormat: "-otable",
 				goldenFile:   "get-fault-injections.golden.txt",
+				matcher: func(expected interface{}) gomega_types.GomegaMatcher {
+					return WithTransform(strings.TrimSpace, Equal(strings.TrimSpace(string(expected.([]byte)))))
+				},
+			}),
+			Entry("should support pagination", testCase{
+				outputFormat: "-otable",
+				goldenFile:   "get-fault-injections.pagination.golden.txt",
+				pagination:   "--size=1",
 				matcher: func(expected interface{}) gomega_types.GomegaMatcher {
 					return WithTransform(strings.TrimSpace, Equal(strings.TrimSpace(string(expected.([]byte)))))
 				},

--- a/app/kumactl/cmd/get/get_health_check.go
+++ b/app/kumactl/cmd/get/get_health_check.go
@@ -33,7 +33,9 @@ func newGetHealthCheckCmd(pctx *getContext) *cobra.Command {
 				}
 				return errors.Wrapf(err, "failed to get mesh %s", currentMesh)
 			}
-			healthchecks := []*mesh.HealthCheckResource{healthcheck}
+			healthchecks := &mesh.HealthCheckResourceList{
+				Items: []*mesh.HealthCheckResource{healthcheck},
+			}
 			switch format := output.Format(pctx.args.outputFormat); format {
 			case output.TableFormat:
 				return printHealthChecks(healthchecks, cmd.OutOrStdout())

--- a/app/kumactl/cmd/get/get_healthchecks.go
+++ b/app/kumactl/cmd/get/get_healthchecks.go
@@ -2,8 +2,9 @@ package get
 
 import (
 	"context"
-	"github.com/Kong/kuma/app/kumactl/pkg/output/table"
 	"io"
+
+	"github.com/Kong/kuma/app/kumactl/pkg/output/table"
 
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"

--- a/app/kumactl/cmd/get/get_healthchecks_test.go
+++ b/app/kumactl/cmd/get/get_healthchecks_test.go
@@ -132,7 +132,7 @@ var _ = Describe("kumactl get healthchecks", func() {
 			}),
 			Entry("should support pagination", testCase{
 				outputFormat: "-otable",
-				pagination: "--size=1",
+				pagination:   "--size=1",
 				goldenFile:   "get-healthchecks.pagination.golden.txt",
 				matcher: func(expected interface{}) gomega_types.GomegaMatcher {
 					return WithTransform(strings.TrimSpace, Equal(strings.TrimSpace(string(expected.([]byte)))))

--- a/app/kumactl/cmd/get/get_healthchecks_test.go
+++ b/app/kumactl/cmd/get/get_healthchecks_test.go
@@ -93,6 +93,7 @@ var _ = Describe("kumactl get healthchecks", func() {
 		type testCase struct {
 			outputFormat string
 			goldenFile   string
+			pagination   string
 			matcher      func(interface{}) gomega_types.GomegaMatcher
 		}
 
@@ -101,7 +102,7 @@ var _ = Describe("kumactl get healthchecks", func() {
 				// given
 				rootCmd.SetArgs(append([]string{
 					"--config-file", filepath.Join("..", "testdata", "sample-kumactl.config.yaml"),
-					"get", "healthchecks"}, given.outputFormat))
+					"get", "healthchecks"}, given.outputFormat, given.pagination))
 
 				// when
 				err := rootCmd.Execute()
@@ -125,6 +126,14 @@ var _ = Describe("kumactl get healthchecks", func() {
 			Entry("should support Table output explicitly", testCase{
 				outputFormat: "-otable",
 				goldenFile:   "get-healthchecks.golden.txt",
+				matcher: func(expected interface{}) gomega_types.GomegaMatcher {
+					return WithTransform(strings.TrimSpace, Equal(strings.TrimSpace(string(expected.([]byte)))))
+				},
+			}),
+			Entry("should support pagination", testCase{
+				outputFormat: "-otable",
+				pagination: "--size=1",
+				goldenFile:   "get-healthchecks.pagination.golden.txt",
 				matcher: func(expected interface{}) gomega_types.GomegaMatcher {
 					return WithTransform(strings.TrimSpace, Equal(strings.TrimSpace(string(expected.([]byte)))))
 				},

--- a/app/kumactl/cmd/get/get_mesh.go
+++ b/app/kumactl/cmd/get/get_mesh.go
@@ -35,7 +35,9 @@ func newGetMeshCmd(pctx *getContext) *cobra.Command {
 				}
 				return errors.Wrapf(err, "failed to get mesh %s", currentMesh)
 			}
-			meshes := []*core_mesh.MeshResource{mesh}
+			meshes := &core_mesh.MeshResourceList{
+				Items: []*core_mesh.MeshResource{mesh},
+			}
 			switch format := output.Format(pctx.args.outputFormat); format {
 			case output.TableFormat:
 				return printMeshes(meshes, cmd.OutOrStdout())

--- a/app/kumactl/cmd/get/get_meshes.go
+++ b/app/kumactl/cmd/get/get_meshes.go
@@ -2,9 +2,10 @@ package get
 
 import (
 	"context"
+	"io"
+
 	"github.com/Kong/kuma/app/kumactl/pkg/output/table"
 	core_store "github.com/Kong/kuma/pkg/core/resources/store"
-	"io"
 
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"

--- a/app/kumactl/cmd/get/get_meshes_test.go
+++ b/app/kumactl/cmd/get/get_meshes_test.go
@@ -189,6 +189,7 @@ var _ = Describe("kumactl get meshes", func() {
 		type testCase struct {
 			outputFormat string
 			goldenFile   string
+			pagination   string
 			matcher      func(interface{}) gomega_types.GomegaMatcher
 		}
 
@@ -197,7 +198,7 @@ var _ = Describe("kumactl get meshes", func() {
 				// given
 				rootCmd.SetArgs(append([]string{
 					"--config-file", filepath.Join("..", "testdata", "sample-kumactl.config.yaml"),
-					"get", "meshes"}, given.outputFormat))
+					"get", "meshes"}, given.outputFormat, given.pagination))
 
 				// when
 				err := rootCmd.Execute()
@@ -221,6 +222,14 @@ var _ = Describe("kumactl get meshes", func() {
 			Entry("should support Table output explicitly", testCase{
 				outputFormat: "-otable",
 				goldenFile:   "get-meshes.golden.txt",
+				matcher: func(expected interface{}) gomega_types.GomegaMatcher {
+					return WithTransform(strings.TrimSpace, Equal(strings.TrimSpace(string(expected.([]byte)))))
+				},
+			}),
+			Entry("should support pagination", testCase{
+				outputFormat: "-otable",
+				pagination: "--size=1",
+				goldenFile:   "get-meshes.pagination.golden.txt",
 				matcher: func(expected interface{}) gomega_types.GomegaMatcher {
 					return WithTransform(strings.TrimSpace, Equal(strings.TrimSpace(string(expected.([]byte)))))
 				},

--- a/app/kumactl/cmd/get/get_meshes_test.go
+++ b/app/kumactl/cmd/get/get_meshes_test.go
@@ -228,7 +228,7 @@ var _ = Describe("kumactl get meshes", func() {
 			}),
 			Entry("should support pagination", testCase{
 				outputFormat: "-otable",
-				pagination: "--size=1",
+				pagination:   "--size=1",
 				goldenFile:   "get-meshes.pagination.golden.txt",
 				matcher: func(expected interface{}) gomega_types.GomegaMatcher {
 					return WithTransform(strings.TrimSpace, Equal(strings.TrimSpace(string(expected.([]byte)))))

--- a/app/kumactl/cmd/get/get_proxytemplate.go
+++ b/app/kumactl/cmd/get/get_proxytemplate.go
@@ -35,7 +35,9 @@ func newGetProxyTemplateCmd(pctx *getContext) *cobra.Command {
 				}
 				return errors.Wrapf(err, "failed to get mesh %s", currentMesh)
 			}
-			proxyTemplates := []*mesh.ProxyTemplateResource{proxyTemplate}
+			proxyTemplates := &mesh.ProxyTemplateResourceList{
+				Items: []*mesh.ProxyTemplateResource{proxyTemplate},
+			}
 			switch format := output.Format(pctx.args.outputFormat); format {
 			case output.TableFormat:
 				return printProxyTemplates(proxyTemplates, cmd.OutOrStdout())

--- a/app/kumactl/cmd/get/get_proxytemplates.go
+++ b/app/kumactl/cmd/get/get_proxytemplates.go
@@ -2,8 +2,9 @@ package get
 
 import (
 	"context"
-	"github.com/Kong/kuma/app/kumactl/pkg/output/table"
 	"io"
+
+	"github.com/Kong/kuma/app/kumactl/pkg/output/table"
 
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"

--- a/app/kumactl/cmd/get/get_proxytemplates.go
+++ b/app/kumactl/cmd/get/get_proxytemplates.go
@@ -2,6 +2,7 @@ package get
 
 import (
 	"context"
+	"github.com/Kong/kuma/app/kumactl/pkg/output/table"
 	"io"
 
 	"github.com/pkg/errors"
@@ -14,7 +15,7 @@ import (
 	core_store "github.com/Kong/kuma/pkg/core/resources/store"
 )
 
-func newGetProxyTemplatesCmd(pctx *getContext) *cobra.Command {
+func newGetProxyTemplatesCmd(pctx *listContext) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "proxytemplates",
 		Short: "Show ProxyTemplates",
@@ -26,13 +27,13 @@ func newGetProxyTemplatesCmd(pctx *getContext) *cobra.Command {
 			}
 
 			proxyTemplates := &mesh_core.ProxyTemplateResourceList{}
-			if err := rs.List(context.Background(), proxyTemplates, core_store.ListByMesh(pctx.CurrentMesh())); err != nil {
+			if err := rs.List(context.Background(), proxyTemplates, core_store.ListByMesh(pctx.CurrentMesh()), core_store.ListByPage(pctx.args.size, pctx.args.offset)); err != nil {
 				return errors.Wrapf(err, "failed to list ProxyTemplates")
 			}
 
-			switch format := output.Format(pctx.args.outputFormat); format {
+			switch format := output.Format(pctx.getContext.args.outputFormat); format {
 			case output.TableFormat:
-				return printProxyTemplates(proxyTemplates.Items, cmd.OutOrStdout())
+				return printProxyTemplates(proxyTemplates, cmd.OutOrStdout())
 			default:
 				printer, err := printers.NewGenericPrinter(format)
 				if err != nil {
@@ -45,17 +46,17 @@ func newGetProxyTemplatesCmd(pctx *getContext) *cobra.Command {
 	return cmd
 }
 
-func printProxyTemplates(proxyTemplates []*mesh_core.ProxyTemplateResource, out io.Writer) error {
+func printProxyTemplates(proxyTemplates *mesh_core.ProxyTemplateResourceList, out io.Writer) error {
 	data := printers.Table{
 		Headers: []string{"MESH", "NAME"},
 		NextRow: func() func() []string {
 			i := 0
 			return func() []string {
 				defer func() { i++ }()
-				if len(proxyTemplates) <= i {
+				if len(proxyTemplates.Items) <= i {
 					return nil
 				}
-				proxyTemplate := proxyTemplates[i]
+				proxyTemplate := proxyTemplates.Items[i]
 
 				return []string{
 					proxyTemplate.GetMeta().GetMesh(), // MESH
@@ -63,6 +64,7 @@ func printProxyTemplates(proxyTemplates []*mesh_core.ProxyTemplateResource, out 
 				}
 			}
 		}(),
+		Footer: table.PaginationFooter(proxyTemplates),
 	}
 	return printers.NewTablePrinter().Print(data, out)
 }

--- a/app/kumactl/cmd/get/get_proxytemplates_test.go
+++ b/app/kumactl/cmd/get/get_proxytemplates_test.go
@@ -90,6 +90,7 @@ var _ = Describe("kumactl get proxytemplates", func() {
 
 		type testCase struct {
 			outputFormat string
+			pagination   string
 			goldenFile   string
 			matcher      func(interface{}) gomega_types.GomegaMatcher
 		}
@@ -99,7 +100,7 @@ var _ = Describe("kumactl get proxytemplates", func() {
 				// given
 				rootCmd.SetArgs(append([]string{
 					"--config-file", filepath.Join("..", "testdata", "sample-kumactl.config.yaml"),
-					"get", "proxytemplates"}, given.outputFormat))
+					"get", "proxytemplates"}, given.outputFormat, given.pagination))
 
 				// when
 				err := rootCmd.Execute()
@@ -123,6 +124,14 @@ var _ = Describe("kumactl get proxytemplates", func() {
 			Entry("should support Table output explicitly", testCase{
 				outputFormat: "-otable",
 				goldenFile:   "get-proxytemplates.golden.txt",
+				matcher: func(expected interface{}) gomega_types.GomegaMatcher {
+					return WithTransform(strings.TrimSpace, Equal(strings.TrimSpace(string(expected.([]byte)))))
+				},
+			}),
+			Entry("should support pagination", testCase{
+				outputFormat: "-otable",
+				pagination:   "--size=1",
+				goldenFile:   "get-proxytemplates.pagination.golden.txt",
 				matcher: func(expected interface{}) gomega_types.GomegaMatcher {
 					return WithTransform(strings.TrimSpace, Equal(strings.TrimSpace(string(expected.([]byte)))))
 				},

--- a/app/kumactl/cmd/get/get_traffic_log.go
+++ b/app/kumactl/cmd/get/get_traffic_log.go
@@ -2,7 +2,6 @@ package get
 
 import (
 	"context"
-
 	"github.com/pkg/errors"
 
 	"github.com/Kong/kuma/pkg/core/resources/apis/mesh"
@@ -35,7 +34,9 @@ func newGetTrafficLogCmd(pctx *getContext) *cobra.Command {
 				}
 				return errors.Wrapf(err, "failed to get mesh %s", currentMesh)
 			}
-			trafficLogs := []*mesh.TrafficLogResource{trafficLog}
+			trafficLogs := &mesh.TrafficLogResourceList{
+				Items: []*mesh.TrafficLogResource{trafficLog},
+			}
 			switch format := output.Format(pctx.args.outputFormat); format {
 			case output.TableFormat:
 				return printTrafficLogs(trafficLogs, cmd.OutOrStdout())

--- a/app/kumactl/cmd/get/get_traffic_log.go
+++ b/app/kumactl/cmd/get/get_traffic_log.go
@@ -2,6 +2,7 @@ package get
 
 import (
 	"context"
+
 	"github.com/pkg/errors"
 
 	"github.com/Kong/kuma/pkg/core/resources/apis/mesh"

--- a/app/kumactl/cmd/get/get_traffic_logs.go
+++ b/app/kumactl/cmd/get/get_traffic_logs.go
@@ -2,8 +2,9 @@ package get
 
 import (
 	"context"
-	"github.com/Kong/kuma/app/kumactl/pkg/output/table"
 	"io"
+
+	"github.com/Kong/kuma/app/kumactl/pkg/output/table"
 
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"

--- a/app/kumactl/cmd/get/get_traffic_logs.go
+++ b/app/kumactl/cmd/get/get_traffic_logs.go
@@ -2,6 +2,7 @@ package get
 
 import (
 	"context"
+	"github.com/Kong/kuma/app/kumactl/pkg/output/table"
 	"io"
 
 	"github.com/pkg/errors"
@@ -14,7 +15,7 @@ import (
 	core_store "github.com/Kong/kuma/pkg/core/resources/store"
 )
 
-func newGetTrafficLogsCmd(pctx *getContext) *cobra.Command {
+func newGetTrafficLogsCmd(pctx *listContext) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "traffic-logs",
 		Short: "Show TrafficLogs",
@@ -26,13 +27,13 @@ func newGetTrafficLogsCmd(pctx *getContext) *cobra.Command {
 			}
 
 			trafficLogging := mesh.TrafficLogResourceList{}
-			if err := rs.List(context.Background(), &trafficLogging, core_store.ListByMesh(pctx.CurrentMesh())); err != nil {
+			if err := rs.List(context.Background(), &trafficLogging, core_store.ListByMesh(pctx.CurrentMesh()), core_store.ListByPage(pctx.args.size, pctx.args.offset)); err != nil {
 				return errors.Wrapf(err, "failed to list TrafficLog")
 			}
 
-			switch format := output.Format(pctx.args.outputFormat); format {
+			switch format := output.Format(pctx.getContext.args.outputFormat); format {
 			case output.TableFormat:
-				return printTrafficLogs(trafficLogging.Items, cmd.OutOrStdout())
+				return printTrafficLogs(&trafficLogging, cmd.OutOrStdout())
 			default:
 				printer, err := printers.NewGenericPrinter(format)
 				if err != nil {
@@ -45,17 +46,17 @@ func newGetTrafficLogsCmd(pctx *getContext) *cobra.Command {
 	return cmd
 }
 
-func printTrafficLogs(trafficLogging []*mesh.TrafficLogResource, out io.Writer) error {
+func printTrafficLogs(trafficLogging *mesh.TrafficLogResourceList, out io.Writer) error {
 	data := printers.Table{
 		Headers: []string{"MESH", "NAME"},
 		NextRow: func() func() []string {
 			i := 0
 			return func() []string {
 				defer func() { i++ }()
-				if len(trafficLogging) <= i {
+				if len(trafficLogging.Items) <= i {
 					return nil
 				}
-				trafficLogging := trafficLogging[i]
+				trafficLogging := trafficLogging.Items[i]
 
 				return []string{
 					trafficLogging.GetMeta().GetMesh(), // MESH
@@ -63,6 +64,7 @@ func printTrafficLogs(trafficLogging []*mesh.TrafficLogResource, out io.Writer) 
 				}
 			}
 		}(),
+		Footer: table.PaginationFooter(trafficLogging),
 	}
 	return printers.NewTablePrinter().Print(data, out)
 }

--- a/app/kumactl/cmd/get/get_traffic_logs_test.go
+++ b/app/kumactl/cmd/get/get_traffic_logs_test.go
@@ -116,6 +116,7 @@ var _ = Describe("kumactl get traffic-logs", func() {
 
 		type testCase struct {
 			outputFormat string
+			pagination   string
 			goldenFile   string
 			matcher      func(interface{}) gomega_types.GomegaMatcher
 		}
@@ -125,7 +126,7 @@ var _ = Describe("kumactl get traffic-logs", func() {
 				// given
 				rootCmd.SetArgs(append([]string{
 					"--config-file", filepath.Join("..", "testdata", "sample-kumactl.config.yaml"),
-					"get", "traffic-logs"}, given.outputFormat))
+					"get", "traffic-logs"}, given.outputFormat, given.pagination))
 
 				// when
 				err := rootCmd.Execute()
@@ -149,6 +150,14 @@ var _ = Describe("kumactl get traffic-logs", func() {
 			Entry("should support Table output explicitly", testCase{
 				outputFormat: "-otable",
 				goldenFile:   "get-traffic-logs.golden.txt",
+				matcher: func(expected interface{}) gomega_types.GomegaMatcher {
+					return WithTransform(strings.TrimSpace, Equal(strings.TrimSpace(string(expected.([]byte)))))
+				},
+			}),
+			Entry("should support pagination", testCase{
+				outputFormat: "-otable",
+				pagination:   "--size=1",
+				goldenFile:   "get-traffic-logs.pagination.golden.txt",
 				matcher: func(expected interface{}) gomega_types.GomegaMatcher {
 					return WithTransform(strings.TrimSpace, Equal(strings.TrimSpace(string(expected.([]byte)))))
 				},

--- a/app/kumactl/cmd/get/get_traffic_route.go
+++ b/app/kumactl/cmd/get/get_traffic_route.go
@@ -2,7 +2,6 @@ package get
 
 import (
 	"context"
-
 	"github.com/pkg/errors"
 
 	"github.com/Kong/kuma/pkg/core/resources/apis/mesh"
@@ -35,7 +34,9 @@ func newGetTrafficRouteCmd(pctx *getContext) *cobra.Command {
 				}
 				return errors.Wrapf(err, "failed to get mesh %s", currentMesh)
 			}
-			trafficRoutes := []*mesh.TrafficRouteResource{trafficRoute}
+			trafficRoutes := &mesh.TrafficRouteResourceList{
+				Items: []*mesh.TrafficRouteResource{trafficRoute},
+			}
 			switch format := output.Format(pctx.args.outputFormat); format {
 			case output.TableFormat:
 				return printTrafficRoutes(trafficRoutes, cmd.OutOrStdout())

--- a/app/kumactl/cmd/get/get_traffic_route.go
+++ b/app/kumactl/cmd/get/get_traffic_route.go
@@ -2,6 +2,7 @@ package get
 
 import (
 	"context"
+
 	"github.com/pkg/errors"
 
 	"github.com/Kong/kuma/pkg/core/resources/apis/mesh"

--- a/app/kumactl/cmd/get/get_traffic_routes.go
+++ b/app/kumactl/cmd/get/get_traffic_routes.go
@@ -2,8 +2,9 @@ package get
 
 import (
 	"context"
-	"github.com/Kong/kuma/app/kumactl/pkg/output/table"
 	"io"
+
+	"github.com/Kong/kuma/app/kumactl/pkg/output/table"
 
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"

--- a/app/kumactl/cmd/get/get_traffic_routes_test.go
+++ b/app/kumactl/cmd/get/get_traffic_routes_test.go
@@ -92,6 +92,7 @@ var _ = Describe("kumactl get traffic-routes", func() {
 
 		type testCase struct {
 			outputFormat string
+			pagination   string
 			goldenFile   string
 			matcher      func(interface{}) gomega_types.GomegaMatcher
 		}
@@ -101,7 +102,7 @@ var _ = Describe("kumactl get traffic-routes", func() {
 				// given
 				rootCmd.SetArgs(append([]string{
 					"--config-file", filepath.Join("..", "testdata", "sample-kumactl.config.yaml"),
-					"get", "traffic-routes"}, given.outputFormat))
+					"get", "traffic-routes"}, given.outputFormat, given.pagination))
 
 				// when
 				err := rootCmd.Execute()
@@ -125,6 +126,14 @@ var _ = Describe("kumactl get traffic-routes", func() {
 			Entry("should support Table output explicitly", testCase{
 				outputFormat: "-otable",
 				goldenFile:   "get-traffic-routes.golden.txt",
+				matcher: func(expected interface{}) gomega_types.GomegaMatcher {
+					return WithTransform(strings.TrimSpace, Equal(strings.TrimSpace(string(expected.([]byte)))))
+				},
+			}),
+			Entry("should support pagination", testCase{
+				outputFormat: "-otable",
+				pagination:   "--size=1",
+				goldenFile:   "get-traffic-routes.pagination.golden.txt",
 				matcher: func(expected interface{}) gomega_types.GomegaMatcher {
 					return WithTransform(strings.TrimSpace, Equal(strings.TrimSpace(string(expected.([]byte)))))
 				},

--- a/app/kumactl/cmd/get/get_traffic_trace.go
+++ b/app/kumactl/cmd/get/get_traffic_trace.go
@@ -33,7 +33,9 @@ func newGetTrafficTraceCmd(pctx *getContext) *cobra.Command {
 				}
 				return errors.Wrapf(err, "failed to get mesh %s", currentMesh)
 			}
-			trafficTraces := []*mesh.TrafficTraceResource{trafficTrace}
+			trafficTraces := &mesh.TrafficTraceResourceList{
+				Items: []*mesh.TrafficTraceResource{trafficTrace},
+			}
 			switch format := output.Format(pctx.args.outputFormat); format {
 			case output.TableFormat:
 				return printTrafficTraces(trafficTraces, cmd.OutOrStdout())

--- a/app/kumactl/cmd/get/get_traffic_traces.go
+++ b/app/kumactl/cmd/get/get_traffic_traces.go
@@ -2,8 +2,9 @@ package get
 
 import (
 	"context"
-	"github.com/Kong/kuma/app/kumactl/pkg/output/table"
 	"io"
+
+	"github.com/Kong/kuma/app/kumactl/pkg/output/table"
 
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"

--- a/app/kumactl/cmd/get/get_traffic_traces.go
+++ b/app/kumactl/cmd/get/get_traffic_traces.go
@@ -2,6 +2,7 @@ package get
 
 import (
 	"context"
+	"github.com/Kong/kuma/app/kumactl/pkg/output/table"
 	"io"
 
 	"github.com/pkg/errors"
@@ -14,7 +15,7 @@ import (
 	core_store "github.com/Kong/kuma/pkg/core/resources/store"
 )
 
-func newGetTrafficTracesCmd(pctx *getContext) *cobra.Command {
+func newGetTrafficTracesCmd(pctx *listContext) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "traffic-traces",
 		Short: "Show TrafficTraces",
@@ -26,13 +27,13 @@ func newGetTrafficTracesCmd(pctx *getContext) *cobra.Command {
 			}
 
 			trafficTraces := mesh.TrafficTraceResourceList{}
-			if err := rs.List(context.Background(), &trafficTraces, core_store.ListByMesh(pctx.CurrentMesh())); err != nil {
+			if err := rs.List(context.Background(), &trafficTraces, core_store.ListByMesh(pctx.CurrentMesh()), core_store.ListByPage(pctx.args.size, pctx.args.offset)); err != nil {
 				return errors.Wrapf(err, "failed to list TrafficTrace")
 			}
 
-			switch format := output.Format(pctx.args.outputFormat); format {
+			switch format := output.Format(pctx.getContext.args.outputFormat); format {
 			case output.TableFormat:
-				return printTrafficTraces(trafficTraces.Items, cmd.OutOrStdout())
+				return printTrafficTraces(&trafficTraces, cmd.OutOrStdout())
 			default:
 				printer, err := printers.NewGenericPrinter(format)
 				if err != nil {
@@ -45,17 +46,17 @@ func newGetTrafficTracesCmd(pctx *getContext) *cobra.Command {
 	return cmd
 }
 
-func printTrafficTraces(trafficTraces []*mesh.TrafficTraceResource, out io.Writer) error {
+func printTrafficTraces(trafficTraces *mesh.TrafficTraceResourceList, out io.Writer) error {
 	data := printers.Table{
 		Headers: []string{"MESH", "NAME"},
 		NextRow: func() func() []string {
 			i := 0
 			return func() []string {
 				defer func() { i++ }()
-				if len(trafficTraces) <= i {
+				if len(trafficTraces.Items) <= i {
 					return nil
 				}
-				trafficTraces := trafficTraces[i]
+				trafficTraces := trafficTraces.Items[i]
 
 				return []string{
 					trafficTraces.GetMeta().GetMesh(), // MESH
@@ -63,6 +64,7 @@ func printTrafficTraces(trafficTraces []*mesh.TrafficTraceResource, out io.Write
 				}
 			}
 		}(),
+		Footer: table.PaginationFooter(trafficTraces),
 	}
 	return printers.NewTablePrinter().Print(data, out)
 }

--- a/app/kumactl/cmd/get/get_traffic_traces_test.go
+++ b/app/kumactl/cmd/get/get_traffic_traces_test.go
@@ -100,6 +100,7 @@ var _ = Describe("kumactl get traffic-traces", func() {
 
 		type testCase struct {
 			outputFormat string
+			pagination   string
 			goldenFile   string
 			matcher      func(interface{}) gomega_types.GomegaMatcher
 		}
@@ -109,7 +110,7 @@ var _ = Describe("kumactl get traffic-traces", func() {
 				// given
 				rootCmd.SetArgs(append([]string{
 					"--config-file", filepath.Join("..", "testdata", "sample-kumactl.config.yaml"),
-					"get", "traffic-traces"}, given.outputFormat))
+					"get", "traffic-traces"}, given.outputFormat, given.pagination))
 
 				// when
 				err := rootCmd.Execute()
@@ -133,6 +134,14 @@ var _ = Describe("kumactl get traffic-traces", func() {
 			Entry("should support Table output explicitly", testCase{
 				outputFormat: "-otable",
 				goldenFile:   "get-traffic-traces.golden.txt",
+				matcher: func(expected interface{}) gomega_types.GomegaMatcher {
+					return WithTransform(strings.TrimSpace, Equal(strings.TrimSpace(string(expected.([]byte)))))
+				},
+			}),
+			Entry("should support pagination", testCase{
+				outputFormat: "-otable",
+				pagination:   "--size=1",
+				goldenFile:   "get-traffic-traces.pagination.golden.txt",
 				matcher: func(expected interface{}) gomega_types.GomegaMatcher {
 					return WithTransform(strings.TrimSpace, Equal(strings.TrimSpace(string(expected.([]byte)))))
 				},

--- a/app/kumactl/cmd/get/get_trafficpermission.go
+++ b/app/kumactl/cmd/get/get_trafficpermission.go
@@ -2,7 +2,6 @@ package get
 
 import (
 	"context"
-
 	"github.com/pkg/errors"
 
 	"github.com/Kong/kuma/pkg/core/resources/apis/mesh"
@@ -35,7 +34,9 @@ func newGetTrafficPermissionCmd(pctx *getContext) *cobra.Command {
 				}
 				return errors.Wrapf(err, "failed to get mesh %s", currentMesh)
 			}
-			trafficPermissions := []*mesh.TrafficPermissionResource{trafficPermission}
+			trafficPermissions := &mesh.TrafficPermissionResourceList{
+				Items: []*mesh.TrafficPermissionResource{trafficPermission},
+			}
 			switch format := output.Format(pctx.args.outputFormat); format {
 			case output.TableFormat:
 				return printTrafficPermissions(trafficPermissions, cmd.OutOrStdout())

--- a/app/kumactl/cmd/get/get_trafficpermission.go
+++ b/app/kumactl/cmd/get/get_trafficpermission.go
@@ -2,6 +2,7 @@ package get
 
 import (
 	"context"
+
 	"github.com/pkg/errors"
 
 	"github.com/Kong/kuma/pkg/core/resources/apis/mesh"

--- a/app/kumactl/cmd/get/get_trafficpermissions.go
+++ b/app/kumactl/cmd/get/get_trafficpermissions.go
@@ -2,8 +2,9 @@ package get
 
 import (
 	"context"
-	"github.com/Kong/kuma/app/kumactl/pkg/output/table"
 	"io"
+
+	"github.com/Kong/kuma/app/kumactl/pkg/output/table"
 
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"

--- a/app/kumactl/cmd/get/get_trafficpermissions.go
+++ b/app/kumactl/cmd/get/get_trafficpermissions.go
@@ -2,6 +2,7 @@ package get
 
 import (
 	"context"
+	"github.com/Kong/kuma/app/kumactl/pkg/output/table"
 	"io"
 
 	"github.com/pkg/errors"
@@ -14,7 +15,7 @@ import (
 	core_store "github.com/Kong/kuma/pkg/core/resources/store"
 )
 
-func newGetTrafficPermissionsCmd(pctx *getContext) *cobra.Command {
+func newGetTrafficPermissionsCmd(pctx *listContext) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "traffic-permissions",
 		Short: "Show TrafficPermissions",
@@ -26,13 +27,13 @@ func newGetTrafficPermissionsCmd(pctx *getContext) *cobra.Command {
 			}
 
 			trafficPermissions := mesh.TrafficPermissionResourceList{}
-			if err := rs.List(context.Background(), &trafficPermissions, core_store.ListByMesh(pctx.CurrentMesh())); err != nil {
+			if err := rs.List(context.Background(), &trafficPermissions, core_store.ListByMesh(pctx.CurrentMesh()), core_store.ListByPage(pctx.args.size, pctx.args.offset)); err != nil {
 				return errors.Wrapf(err, "failed to list TrafficPermissions")
 			}
 
-			switch format := output.Format(pctx.args.outputFormat); format {
+			switch format := output.Format(pctx.getContext.args.outputFormat); format {
 			case output.TableFormat:
-				return printTrafficPermissions(trafficPermissions.Items, cmd.OutOrStdout())
+				return printTrafficPermissions(&trafficPermissions, cmd.OutOrStdout())
 			default:
 				printer, err := printers.NewGenericPrinter(format)
 				if err != nil {
@@ -45,17 +46,17 @@ func newGetTrafficPermissionsCmd(pctx *getContext) *cobra.Command {
 	return cmd
 }
 
-func printTrafficPermissions(trafficPermissions []*mesh.TrafficPermissionResource, out io.Writer) error {
+func printTrafficPermissions(trafficPermissions *mesh.TrafficPermissionResourceList, out io.Writer) error {
 	data := printers.Table{
 		Headers: []string{"MESH", "NAME"},
 		NextRow: func() func() []string {
 			i := 0
 			return func() []string {
 				defer func() { i++ }()
-				if len(trafficPermissions) <= i {
+				if len(trafficPermissions.Items) <= i {
 					return nil
 				}
-				trafficPermission := trafficPermissions[i]
+				trafficPermission := trafficPermissions.Items[i]
 
 				return []string{
 					trafficPermission.GetMeta().GetMesh(), // MESH
@@ -63,6 +64,7 @@ func printTrafficPermissions(trafficPermissions []*mesh.TrafficPermissionResourc
 				}
 			}
 		}(),
+		Footer: table.PaginationFooter(trafficPermissions),
 	}
 	return printers.NewTablePrinter().Print(data, out)
 }

--- a/app/kumactl/cmd/get/get_trafficpermissions_test.go
+++ b/app/kumactl/cmd/get/get_trafficpermissions_test.go
@@ -110,6 +110,7 @@ var _ = Describe("kumactl get traffic-permissions", func() {
 
 		type testCase struct {
 			outputFormat string
+			pagination   string
 			goldenFile   string
 			matcher      func(interface{}) gomega_types.GomegaMatcher
 		}
@@ -119,7 +120,7 @@ var _ = Describe("kumactl get traffic-permissions", func() {
 				// given
 				rootCmd.SetArgs(append([]string{
 					"--config-file", filepath.Join("..", "testdata", "sample-kumactl.config.yaml"),
-					"get", "traffic-permissions"}, given.outputFormat))
+					"get", "traffic-permissions"}, given.outputFormat, given.pagination))
 
 				// when
 				err := rootCmd.Execute()
@@ -143,6 +144,14 @@ var _ = Describe("kumactl get traffic-permissions", func() {
 			Entry("should support Table output explicitly", testCase{
 				outputFormat: "-otable",
 				goldenFile:   "get-traffic-permissions.golden.txt",
+				matcher: func(expected interface{}) gomega_types.GomegaMatcher {
+					return WithTransform(strings.TrimSpace, Equal(strings.TrimSpace(string(expected.([]byte)))))
+				},
+			}),
+			Entry("should support pagination", testCase{
+				outputFormat: "-otable",
+				pagination:   "--size=1",
+				goldenFile:   "get-traffic-permissions.pagination.golden.txt",
 				matcher: func(expected interface{}) gomega_types.GomegaMatcher {
 					return WithTransform(strings.TrimSpace, Equal(strings.TrimSpace(string(expected.([]byte)))))
 				},

--- a/app/kumactl/cmd/get/testdata/get-dataplanes.pagination.golden.txt
+++ b/app/kumactl/cmd/get/testdata/get-dataplanes.pagination.golden.txt
@@ -1,0 +1,4 @@
+MESH      NAME         TAGS
+default   experiment   service=metrics,mobile version=v1
+
+Rerun command with --offset=1 argument to retrieve more resources

--- a/app/kumactl/cmd/get/testdata/get-fault-injections.pagination.golden.txt
+++ b/app/kumactl/cmd/get/testdata/get-fault-injections.pagination.golden.txt
@@ -1,0 +1,4 @@
+MESH      NAME
+default   fi1
+
+Rerun command with --offset=1 argument to retrieve more resources

--- a/app/kumactl/cmd/get/testdata/get-healthchecks.pagination.golden.txt
+++ b/app/kumactl/cmd/get/testdata/get-healthchecks.pagination.golden.txt
@@ -1,0 +1,4 @@
+MESH      NAME
+default   web-to-backend
+
+Rerun command with --offset=1 argument to retrieve more resources

--- a/app/kumactl/cmd/get/testdata/get-meshes.pagination.golden.txt
+++ b/app/kumactl/cmd/get/testdata/get-meshes.pagination.golden.txt
@@ -1,0 +1,4 @@
+NAME    mTLS      METRICS   LOGGING   TRACING
+mesh1   builtin   off       off       off
+
+Rerun command with --offset=1 argument to retrieve more resources

--- a/app/kumactl/cmd/get/testdata/get-proxytemplates.pagination.golden.txt
+++ b/app/kumactl/cmd/get/testdata/get-proxytemplates.pagination.golden.txt
@@ -1,0 +1,4 @@
+MESH      NAME
+default   custom-template
+
+Rerun command with --offset=1 argument to retrieve more resources

--- a/app/kumactl/cmd/get/testdata/get-traffic-logs.pagination.golden.txt
+++ b/app/kumactl/cmd/get/testdata/get-traffic-logs.pagination.golden.txt
@@ -1,0 +1,4 @@
+MESH      NAME
+default   web1-to-backend1
+
+Rerun command with --offset=1 argument to retrieve more resources

--- a/app/kumactl/cmd/get/testdata/get-traffic-permissions.pagination.golden.txt
+++ b/app/kumactl/cmd/get/testdata/get-traffic-permissions.pagination.golden.txt
@@ -1,0 +1,4 @@
+MESH      NAME
+default   web1-to-backend1
+
+Rerun command with --offset=1 argument to retrieve more resources

--- a/app/kumactl/cmd/get/testdata/get-traffic-routes.pagination.golden.txt
+++ b/app/kumactl/cmd/get/testdata/get-traffic-routes.pagination.golden.txt
@@ -1,0 +1,4 @@
+MESH      NAME
+default   web-to-backend
+
+Rerun command with --offset=1 argument to retrieve more resources

--- a/app/kumactl/cmd/get/testdata/get-traffic-traces.pagination.golden.txt
+++ b/app/kumactl/cmd/get/testdata/get-traffic-traces.pagination.golden.txt
@@ -1,0 +1,4 @@
+MESH      NAME
+default   web1
+
+Rerun command with --offset=1 argument to retrieve more resources

--- a/app/kumactl/pkg/output/table/pagination.go
+++ b/app/kumactl/pkg/output/table/pagination.go
@@ -1,0 +1,14 @@
+package table
+
+import (
+	"fmt"
+
+	"github.com/Kong/kuma/pkg/core/resources/model"
+)
+
+func PaginationFooter(list model.ResourceList) string {
+	if list.GetPagination().NextOffset == "" {
+		return ""
+	}
+	return fmt.Sprintf("Rerun command with --offset=%s argument to retrieve more resources", list.GetPagination().NextOffset)
+}

--- a/app/kumactl/pkg/output/table/printer.go
+++ b/app/kumactl/pkg/output/table/printer.go
@@ -11,7 +11,7 @@ type Printer interface {
 type Table struct {
 	Headers []string
 	NextRow func() []string
-	Footer string
+	Footer  string
 }
 
 func NewPrinter() Printer {

--- a/app/kumactl/pkg/output/table/printer.go
+++ b/app/kumactl/pkg/output/table/printer.go
@@ -11,6 +11,7 @@ type Printer interface {
 type Table struct {
 	Headers []string
 	NextRow func() []string
+	Footer string
 }
 
 func NewPrinter() Printer {
@@ -31,17 +32,22 @@ func (p *printer) Print(data Table, out io.Writer) error {
 		}
 	}
 
-	if data.NextRow == nil {
-		return nil
+	if data.NextRow != nil {
+		for {
+			row := data.NextRow()
+			if row == nil {
+				break
+			}
+			if err := table.Row(row...); err != nil {
+				return err
+			}
+		}
 	}
 
-	for {
-		row := data.NextRow()
-		if row == nil {
-			return nil
-		}
-		if err := table.Row(row...); err != nil {
+	if data.Footer != "" {
+		if err := table.Footer(data.Footer); err != nil {
 			return err
 		}
 	}
+	return nil
 }

--- a/app/kumactl/pkg/output/table/writer.go
+++ b/app/kumactl/pkg/output/table/writer.go
@@ -10,6 +10,7 @@ import (
 type TableWriter interface {
 	Headers(...string) error
 	Row(...string) error
+	Footer(string) error
 	Flush() error
 }
 
@@ -35,5 +36,10 @@ func (p *writer) Headers(columns ...string) error {
 
 func (p *writer) Row(columns ...string) error {
 	_, err := fmt.Fprintf(p.out, "%s\n", strings.Join(columns, "\t"))
+	return err
+}
+
+func (p *writer) Footer(footer string) error {
+	_, err := fmt.Fprintf(p.out, "\n%s\n", footer)
 	return err
 }

--- a/docs/cmd/kumactl/HELP.md
+++ b/docs/cmd/kumactl/HELP.md
@@ -387,7 +387,9 @@ Usage:
   kumactl get meshes [flags]
 
 Flags:
-  -h, --help   help for meshes
+  -h, --help            help for meshes
+      --offset string   next offset
+      --size int        maximum number of elements to return
 
 Global Flags:
       --config-file string   path to the configuration file to use
@@ -405,7 +407,9 @@ Usage:
   kumactl get dataplanes [flags]
 
 Flags:
-  -h, --help   help for dataplanes
+  -h, --help            help for dataplanes
+      --offset string   next offset
+      --size int        maximum number of elements to return
 
 Global Flags:
       --config-file string   path to the configuration file to use
@@ -423,7 +427,9 @@ Usage:
   kumactl get healthchecks [flags]
 
 Flags:
-  -h, --help   help for healthchecks
+  -h, --help            help for healthchecks
+      --offset string   next offset
+      --size int        maximum number of elements to return
 
 Global Flags:
       --config-file string   path to the configuration file to use
@@ -441,7 +447,9 @@ Usage:
   kumactl get proxytemplates [flags]
 
 Flags:
-  -h, --help   help for proxytemplates
+  -h, --help            help for proxytemplates
+      --offset string   next offset
+      --size int        maximum number of elements to return
 
 Global Flags:
       --config-file string   path to the configuration file to use
@@ -459,7 +467,9 @@ Usage:
   kumactl get traffic-logs [flags]
 
 Flags:
-  -h, --help   help for traffic-logs
+  -h, --help            help for traffic-logs
+      --offset string   next offset
+      --size int        maximum number of elements to return
 
 Global Flags:
       --config-file string   path to the configuration file to use
@@ -477,7 +487,9 @@ Usage:
   kumactl get traffic-permissions [flags]
 
 Flags:
-  -h, --help   help for traffic-permissions
+  -h, --help            help for traffic-permissions
+      --offset string   next offset
+      --size int        maximum number of elements to return
 
 Global Flags:
       --config-file string   path to the configuration file to use
@@ -495,7 +507,9 @@ Usage:
   kumactl get traffic-routes [flags]
 
 Flags:
-  -h, --help   help for traffic-routes
+  -h, --help            help for traffic-routes
+      --offset string   next offset
+      --size int        maximum number of elements to return
 
 Global Flags:
       --config-file string   path to the configuration file to use
@@ -513,7 +527,9 @@ Usage:
   kumactl get traffic-traces [flags]
 
 Flags:
-  -h, --help   help for traffic-traces
+  -h, --help            help for traffic-traces
+      --offset string   next offset
+      --size int        maximum number of elements to return
 
 Global Flags:
       --config-file string   path to the configuration file to use
@@ -531,7 +547,9 @@ Usage:
   kumactl get fault-injections [flags]
 
 Flags:
-  -h, --help   help for fault-injections
+  -h, --help            help for fault-injections
+      --offset string   next offset
+      --size int        maximum number of elements to return
 
 Global Flags:
       --config-file string   path to the configuration file to use

--- a/docs/cmd/kumactl/HELP.md
+++ b/docs/cmd/kumactl/HELP.md
@@ -388,7 +388,7 @@ Usage:
 
 Flags:
   -h, --help            help for meshes
-      --offset string   next offset
+      --offset string   the offset that indicates starting element of the resources list to retrieve
       --size int        maximum number of elements to return
 
 Global Flags:
@@ -408,7 +408,7 @@ Usage:
 
 Flags:
   -h, --help            help for dataplanes
-      --offset string   next offset
+      --offset string   the offset that indicates starting element of the resources list to retrieve
       --size int        maximum number of elements to return
 
 Global Flags:
@@ -428,7 +428,7 @@ Usage:
 
 Flags:
   -h, --help            help for healthchecks
-      --offset string   next offset
+      --offset string   the offset that indicates starting element of the resources list to retrieve
       --size int        maximum number of elements to return
 
 Global Flags:
@@ -448,7 +448,7 @@ Usage:
 
 Flags:
   -h, --help            help for proxytemplates
-      --offset string   next offset
+      --offset string   the offset that indicates starting element of the resources list to retrieve
       --size int        maximum number of elements to return
 
 Global Flags:
@@ -468,7 +468,7 @@ Usage:
 
 Flags:
   -h, --help            help for traffic-logs
-      --offset string   next offset
+      --offset string   the offset that indicates starting element of the resources list to retrieve
       --size int        maximum number of elements to return
 
 Global Flags:
@@ -488,7 +488,7 @@ Usage:
 
 Flags:
   -h, --help            help for traffic-permissions
-      --offset string   next offset
+      --offset string   the offset that indicates starting element of the resources list to retrieve
       --size int        maximum number of elements to return
 
 Global Flags:
@@ -508,7 +508,7 @@ Usage:
 
 Flags:
   -h, --help            help for traffic-routes
-      --offset string   next offset
+      --offset string   the offset that indicates starting element of the resources list to retrieve
       --size int        maximum number of elements to return
 
 Global Flags:
@@ -528,7 +528,7 @@ Usage:
 
 Flags:
   -h, --help            help for traffic-traces
-      --offset string   next offset
+      --offset string   the offset that indicates starting element of the resources list to retrieve
       --size int        maximum number of elements to return
 
 Global Flags:
@@ -548,7 +548,7 @@ Usage:
 
 Flags:
   -h, --help            help for fault-injections
-      --offset string   next offset
+      --offset string   the offset that indicates starting element of the resources list to retrieve
       --size int        maximum number of elements to return
 
 Global Flags:

--- a/pkg/core/resources/model/rest/resource.go
+++ b/pkg/core/resources/model/rest/resource.go
@@ -78,6 +78,7 @@ func (rec *ResourceListReceiver) UnmarshalJSON(data []byte) error {
 	}
 	type List struct {
 		Items []*json.RawMessage `json:"items"`
+		Next  *string            `json:"next"`
 	}
 	list := List{}
 	if err := json.Unmarshal(data, &list); err != nil {
@@ -99,5 +100,6 @@ func (rec *ResourceListReceiver) UnmarshalJSON(data []byte) error {
 		}
 		rec.ResourceList.Items[i] = r
 	}
+	rec.ResourceList.Next = list.Next
 	return nil
 }

--- a/pkg/core/resources/model/rest/resource_test.go
+++ b/pkg/core/resources/model/rest/resource_test.go
@@ -81,7 +81,8 @@ var _ = Describe("Rest Resource", func() {
 					"name": "two",
 					"path": "/another"
 				 }
-				]
+				],
+				"next": "http://localhost:5681/meshes/default/traffic-routes?offset=1"
 			}`
 
 				// when
@@ -118,7 +119,9 @@ var _ = Describe("Rest Resource", func() {
 						Spec: &sample_proto.TrafficRoute{
 							Path: "/another",
 						},
-					}))
+					}),
+				)
+				Expect(*rs.Next).To(Equal("http://localhost:5681/meshes/default/traffic-routes?offset=1"))
 			})
 		})
 	})

--- a/pkg/plugins/bootstrap/k8s/plugin.go
+++ b/pkg/plugins/bootstrap/k8s/plugin.go
@@ -30,7 +30,7 @@ func (p *plugin) Bootstrap(b *core_runtime.Builder, _ core_plugins.PluginConfig)
 			Scheme: scheme,
 			NewClient: func(_ kube_cache.Cache, config *kube_rest.Config, options kube_client.Options) (kube_client.Client, error) {
 				// Use client without cache for two reasons
-				// 1) K8S Cached client does not support chinking (pagination)
+				// 1) K8S Cached client does not support chunking (pagination)
 				// 2) We maintain our cache in Kuma so we don't want to have duplicated entries in the memory
 				return kube_client.New(config, options)
 			},

--- a/pkg/plugins/bootstrap/k8s/plugin.go
+++ b/pkg/plugins/bootstrap/k8s/plugin.go
@@ -4,10 +4,14 @@ import (
 	core_plugins "github.com/Kong/kuma/pkg/core/plugins"
 	core_runtime "github.com/Kong/kuma/pkg/core/runtime"
 	"github.com/Kong/kuma/pkg/core/runtime/component"
-	k8s_runtime "github.com/Kong/kuma/pkg/runtime/k8s"
 
 	kube_runtime "k8s.io/apimachinery/pkg/runtime"
+	kube_rest "k8s.io/client-go/rest"
 	kube_ctrl "sigs.k8s.io/controller-runtime"
+	kube_cache "sigs.k8s.io/controller-runtime/pkg/cache"
+	kube_client "sigs.k8s.io/controller-runtime/pkg/client"
+
+	k8s_runtime "github.com/Kong/kuma/pkg/runtime/k8s"
 )
 
 var _ core_plugins.BootstrapPlugin = &plugin{}
@@ -24,6 +28,12 @@ func (p *plugin) Bootstrap(b *core_runtime.Builder, _ core_plugins.PluginConfig)
 		kube_ctrl.GetConfigOrDie(),
 		kube_ctrl.Options{
 			Scheme: scheme,
+			NewClient: func(_ kube_cache.Cache, config *kube_rest.Config, options kube_client.Options) (kube_client.Client, error) {
+				// Use client without cache for two reasons
+				// 1) K8S Cached client does not support chinking (pagination)
+				// 2) We maintain our cache in Kuma so we don't want to have duplicated entries in the memory
+				return kube_client.New(config, options)
+			},
 			// Admission WebHook Server
 			Host:    b.Config().Runtime.Kubernetes.AdmissionServer.Address,
 			Port:    int(b.Config().Runtime.Kubernetes.AdmissionServer.Port),

--- a/pkg/plugins/resources/remote/store.go
+++ b/pkg/plugins/resources/remote/store.go
@@ -4,10 +4,11 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
-	"github.com/pkg/errors"
 	"io/ioutil"
 	"net/http"
 	"strconv"
+
+	"github.com/pkg/errors"
 
 	"github.com/Kong/kuma/pkg/core/resources/model"
 	"github.com/Kong/kuma/pkg/core/resources/model/rest"

--- a/pkg/plugins/resources/remote/store.go
+++ b/pkg/plugins/resources/remote/store.go
@@ -4,10 +4,10 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"github.com/pkg/errors"
 	"io/ioutil"
 	"net/http"
-
-	"github.com/pkg/errors"
+	"strconv"
 
 	"github.com/Kong/kuma/pkg/core/resources/model"
 	"github.com/Kong/kuma/pkg/core/resources/model/rest"
@@ -142,6 +142,15 @@ func (s *remoteStore) List(ctx context.Context, rs model.ResourceList, fs ...sto
 	if err != nil {
 		return err
 	}
+	query := req.URL.Query()
+	if opts.PageOffset != "" {
+		query.Add("offset", opts.PageOffset)
+	}
+	if opts.PageSize != 0 {
+		query.Add("size", strconv.Itoa(opts.PageSize))
+	}
+	req.URL.RawQuery = query.Encode()
+
 	statusCode, b, err := s.doRequest(ctx, req)
 	if err != nil {
 		return err

--- a/pkg/plugins/resources/remote/store_test.go
+++ b/pkg/plugins/resources/remote/store_test.go
@@ -377,6 +377,28 @@ var _ = Describe("RemoteStore", func() {
 			Expect(rs.Items[1].Spec.Path).To(Equal("/another"))
 		})
 
+		It("should list known resources using pagination", func() {
+			// given
+			store := setupStore("list-pagination.json", func(req *http.Request) {
+				Expect(req.URL.Path).To(Equal(fmt.Sprintf("/meshes/demo/traffic-routes")))
+				Expect(req.URL.Query().Get("size")).To(Equal("1"))
+				Expect(req.URL.Query().Get("offset")).To(Equal("2"))
+			})
+
+			// when
+			rs := sample_core.TrafficRouteResourceList{}
+			err := store.List(context.Background(), &rs, core_store.ListByMesh("demo"), core_store.ListByPage(1, "2"))
+
+			// then
+			Expect(err).ToNot(HaveOccurred())
+			Expect(rs.Items).To(HaveLen(1))
+			// and
+			Expect(rs.Items[0].Meta.GetName()).To(Equal("one"))
+			Expect(rs.Items[0].Meta.GetMesh()).To(Equal("default"))
+			Expect(rs.Items[0].Meta.GetVersion()).To(Equal(""))
+			Expect(rs.Items[0].Spec.Path).To(Equal("/example"))
+		})
+
 		It("should list meshes", func() {
 			// given
 			store := setupStore("list-meshes.json", func(req *http.Request) {

--- a/pkg/plugins/resources/remote/testdata/list-pagination.json
+++ b/pkg/plugins/resources/remote/testdata/list-pagination.json
@@ -5,13 +5,7 @@
             "mesh": "default",
             "name": "one",
             "path": "/example"
-        },
-        {
-            "type": "TrafficRoute",
-            "mesh": "demo",
-            "name": "two",
-            "path": "/another"
         }
     ],
-    "next": null
+    "next": "http://localhost:5681/meshes/default/traffic-routes?size=1&offset=2"
 }

--- a/pkg/plugins/resources/remote/unmarshalling.go
+++ b/pkg/plugins/resources/remote/unmarshalling.go
@@ -2,9 +2,10 @@ package remote
 
 import (
 	"encoding/json"
-	"github.com/pkg/errors"
 	"net/url"
 	"time"
+
+	"github.com/pkg/errors"
 
 	"github.com/Kong/kuma/pkg/core/resources/model"
 	"github.com/Kong/kuma/pkg/core/resources/model/rest"


### PR DESCRIPTION
### Summary

Introducing pagination in kumactl.

Examples

**Universal**
```
❯❯❯ kumactl get dataplanes --size=1
MESH      NAME     TAGS
default   web-01   service=web

Rerun command with --offset=1 argument to retrieve more resources

❯❯❯ kumactl get dataplanes --size=1 --offset=1
MESH      NAME         TAGS
default   backend-01   env=production protocol=http service=backend version=2.0
```

**Kubernetes**
```
❯❯❯ kumactl get dataplanes --size=3
MESH      NAME                                              TAGS
default   kuma-demo-app-68758d8d5d-ptfgl.kuma-demo          app=kuma-demo-frontend env=prod pod-template-hash=68758d8d5d protocol=http service=frontend.kuma-demo.svc:8080 version=v8
default   kuma-demo-backend-v0-6fdb79ddfd-ms566.kuma-demo   app=kuma-demo-backend env=prod pod-template-hash=6fdb79ddfd protocol=http service=backend.kuma-demo.svc:3001 version=v0
default   postgres-master-78d9c9c8c9-fvdr2.kuma-demo        app=postgres pod-template-hash=78d9c9c8c9 protocol=tcp service=postgres.kuma-demo.svc:5432

Rerun command with --offset=eyJ2IjoibWV0YS5rOHMuaW8vdjEiLCJydiI6MTAwMzMsInN0YXJ0Ijoia3VtYS1kZW1vL3Bvc3RncmVzLW1hc3Rlci03OGQ5YzljOGM5LWZ2ZHIyXHUwMDAwIn0 argument to retrieve more resources

❯❯❯ kumactl get dataplanes --size=3 --offset=eyJ2IjoibWV0YS5rOHMuaW8vdjEiLCJydiI6MTAwMzMsInN0YXJ0Ijoia3VtYS1kZW1vL3Bvc3RncmVzLW1hc3Rlci03OGQ5YzljOGM5LWZ2ZHIyXHUwMDAwIn0
MESH      NAME                                      TAGS
default   redis-master-657c58c859-xzldf.kuma-demo   app=redis pod-template-hash=657c58c859 protocol=tcp role=master service=redis.kuma-demo.svc:6379 tier=backend
```

Sidenotes:
By default, the size is 1000 (defined in API Server)

I turned off Kubernetes cache in client
1) It didn't support chunking (pagination)
2) We maintain our cache for resources so we won't store "same" objects twice.