### PR TITLE
feat(kuma-cp) friendly response in K8s mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # CHANGELOG
 
 ## master
+* feat(kuma-cp) friendly response in K8s mode
+  [#712](https://github.com/Kong/kuma/pull/712)
 * chore: upgrade go-control-plane up to v0.9.5
   [#707](https://github.com/Kong/kuma/pull/707)
 * fix: kuma-cp migrate help text

--- a/pkg/api-server/read_only_resource_endpoints_test.go
+++ b/pkg/api-server/read_only_resource_endpoints_test.go
@@ -1,6 +1,8 @@
 package api_server_test
 
 import (
+	"io/ioutil"
+
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 
@@ -83,6 +85,13 @@ var _ = Describe("Read only Resource Endpoints", func() {
 
 			// then
 			Expect(response.StatusCode).To(Equal(405))
+			body, err := ioutil.ReadAll(response.Body)
+
+			Expect(err).NotTo(HaveOccurred())
+			Expect(string(body)).To(Equal(
+				"On Kubernetes you cannot change the state of Kuma resources with 'kumactl apply' or via the HTTP API." +
+					" As a best practice, you should always be using 'kubectl apply' instead." +
+					" You can still use 'kumactl' or the HTTP API to make read-only operations. On Universal this limitation does not apply.\n"))
 		})
 	})
 
@@ -93,6 +102,13 @@ var _ = Describe("Read only Resource Endpoints", func() {
 
 			// then
 			Expect(response.StatusCode).To(Equal(405))
+			body, err := ioutil.ReadAll(response.Body)
+
+			Expect(err).NotTo(HaveOccurred())
+			Expect(string(body)).To(Equal(
+				"On Kubernetes you cannot change the state of Kuma resources with 'kumactl apply' or via the HTTP API." +
+					" As a best practice, you should always be using 'kubectl apply' instead." +
+					" You can still use 'kumactl' or the HTTP API to make read-only operations. On Universal this limitation does not apply.\n"))
 		})
 	})
 })

--- a/pkg/api-server/resource_endpoints.go
+++ b/pkg/api-server/resource_endpoints.go
@@ -155,9 +155,10 @@ func (r *resourceEndpoints) addCreateOrUpdateEndpointReadOnly(ws *restful.WebSer
 }
 
 func (r *resourceEndpoints) createOrUpdateResourceReadOnly(request *restful.Request, response *restful.Response) {
-	err := response.WriteErrorString(http.StatusMethodNotAllowed,"On Kubernetes you cannot change the state of Kuma resources with 'kumactl apply'."+
-		" As a best practice, you should be using 'kubectl apply' instead." +
-		" You can still use 'kumactl' to make read-only operations. On Universal this limitation does not apply.\n")
+	err := response.WriteErrorString(http.StatusMethodNotAllowed,
+		"On Kubernetes you cannot change the state of Kuma resources with 'kumactl apply'."+
+			" As a best practice, you should be using 'kubectl apply' instead."+
+			" You can still use 'kumactl' to make read-only operations. On Universal this limitation does not apply.\n")
 	if err != nil {
 		core.Log.Error(err, "Could not write the response")
 	}
@@ -187,9 +188,10 @@ func (r *resourceEndpoints) addDeleteEndpointReadOnly(ws *restful.WebService, pa
 }
 
 func (r *resourceEndpoints) deleteResourceReadOnly(request *restful.Request, response *restful.Response) {
-	err := response.WriteErrorString(http.StatusMethodNotAllowed, "On Kubernetes you cannot change the state of Kuma resources with 'kumactl apply'."+
-		" As a best practice, you should be using 'kubectl apply' instead." +
-		" You can still use 'kumactl' to make read-only operations. On Universal this limitation does not apply.\n")
+	err := response.WriteErrorString(http.StatusMethodNotAllowed,
+		"On Kubernetes you cannot change the state of Kuma resources with 'kumactl apply'."+
+			" As a best practice, you should be using 'kubectl apply' instead."+
+			" You can still use 'kumactl' to make read-only operations. On Universal this limitation does not apply.\n")
 	if err != nil {
 		core.Log.Error(err, "Could not write the response")
 	}

--- a/pkg/api-server/resource_endpoints.go
+++ b/pkg/api-server/resource_endpoints.go
@@ -156,9 +156,9 @@ func (r *resourceEndpoints) addCreateOrUpdateEndpointReadOnly(ws *restful.WebSer
 
 func (r *resourceEndpoints) createOrUpdateResourceReadOnly(request *restful.Request, response *restful.Response) {
 	err := response.WriteErrorString(http.StatusMethodNotAllowed,
-		"On Kubernetes you cannot change the state of Kuma resources with 'kumactl apply'."+
-			" As a best practice, you should be using 'kubectl apply' instead."+
-			" You can still use 'kumactl' to make read-only operations. On Universal this limitation does not apply.\n")
+		"On Kubernetes you cannot change the state of Kuma resources with 'kumactl apply' or via the HTTP API."+
+			" As a best practice, you should always be using 'kubectl apply' instead."+
+			" You can still use 'kumactl' or the HTTP API to make read-only operations. On Universal this limitation does not apply.\n")
 	if err != nil {
 		core.Log.Error(err, "Could not write the response")
 	}
@@ -189,9 +189,9 @@ func (r *resourceEndpoints) addDeleteEndpointReadOnly(ws *restful.WebService, pa
 
 func (r *resourceEndpoints) deleteResourceReadOnly(request *restful.Request, response *restful.Response) {
 	err := response.WriteErrorString(http.StatusMethodNotAllowed,
-		"On Kubernetes you cannot change the state of Kuma resources with 'kumactl apply'."+
-			" As a best practice, you should be using 'kubectl apply' instead."+
-			" You can still use 'kumactl' to make read-only operations. On Universal this limitation does not apply.\n")
+		"On Kubernetes you cannot change the state of Kuma resources with 'kumactl apply' or via the HTTP API."+
+			" As a best practice, you should always be using 'kubectl apply' instead."+
+			" You can still use 'kumactl' or the HTTP API to make read-only operations. On Universal this limitation does not apply.\n")
 	if err != nil {
 		core.Log.Error(err, "Could not write the response")
 	}

--- a/pkg/api-server/server.go
+++ b/pkg/api-server/server.go
@@ -111,6 +111,9 @@ func addResourcesEndpoints(ws *restful.WebService, defs []definitions.ResourceWs
 			if !config.ReadOnly {
 				endpoints.addCreateOrUpdateEndpoint(ws, "/meshes/{mesh}/"+definition.Path)
 				endpoints.addDeleteEndpoint(ws, "/meshes/{mesh}/"+definition.Path)
+			} else {
+				endpoints.addCreateOrUpdateEndpointReadOnly(ws, "/meshes/{mesh}/"+definition.Path)
+				endpoints.addDeleteEndpointReadOnly(ws, "/meshes/{mesh}/"+definition.Path)
 			}
 			endpoints.addFindEndpoint(ws, "/meshes/{mesh}/"+definition.Path)
 			endpoints.addListEndpoint(ws, "/meshes/{mesh}/"+definition.Path)
@@ -125,6 +128,9 @@ func addResourcesEndpoints(ws *restful.WebService, defs []definitions.ResourceWs
 			if !config.ReadOnly {
 				endpoints.addCreateOrUpdateEndpoint(ws, "/meshes")
 				endpoints.addDeleteEndpoint(ws, "/meshes")
+			} else {
+				endpoints.addCreateOrUpdateEndpointReadOnly(ws, "/meshes")
+				endpoints.addDeleteEndpointReadOnly(ws, "/meshes")
 			}
 			endpoints.addFindEndpoint(ws, "/meshes")
 			endpoints.addListEndpoint(ws, "/meshes")

--- a/pkg/plugins/resources/remote/store.go
+++ b/pkg/plugins/resources/remote/store.go
@@ -78,7 +78,11 @@ func (s *remoteStore) upsert(ctx context.Context, res model.Resource, meta rest.
 		return err
 	}
 	if statusCode != http.StatusOK && statusCode != http.StatusCreated {
-		return errors.Errorf("(%d): %s", statusCode, string(b))
+		if statusCode == http.StatusMethodNotAllowed {
+			return errors.Errorf("%s", string(b))
+		} else {
+			return errors.Errorf("(%d): %s", statusCode, string(b))
+		}
 	}
 	res.SetMeta(remoteMeta{
 		Name:    meta.Name,
@@ -105,7 +109,11 @@ func (s *remoteStore) Delete(ctx context.Context, res model.Resource, fs ...stor
 		return err
 	}
 	if statusCode != http.StatusOK {
-		return errors.Errorf("(%d): %s", statusCode, string(b))
+		if statusCode == http.StatusMethodNotAllowed {
+			return errors.Errorf("%s", string(b))
+		} else {
+			return errors.Errorf("(%d): %s", statusCode, string(b))
+		}
 	}
 	return nil
 }


### PR DESCRIPTION
### Summary

When kuma-cp is run in Kubernetes mode, all the changes should happen through `kubectl`. Send an explanation in the response body, so clients (i.e. `kumactl` or the HTTP API) can show it to the user.

### Full changelog

* feat(kuma-cp) friendly response in K8s mode
* feat(kumactl) do not show error code 405 on apply/delete

### Issues resolved

Fix #165
