### PR TITLE
feat(kuma-cp) provide `total` field when listing resources in the HTTP API

### DIFF
--- a/app/kumactl/cmd/get/testdata/get-dataplanes.golden.json
+++ b/app/kumactl/cmd/get/testdata/get-dataplanes.golden.json
@@ -1,4 +1,5 @@
 {
+    "total": 2,
     "items": [
       {
         "mesh": "default",
@@ -49,6 +50,5 @@
         "type": "Dataplane"
       }
     ],
-    "total": 2,
     "next": null
 }

--- a/app/kumactl/cmd/get/testdata/get-dataplanes.golden.json
+++ b/app/kumactl/cmd/get/testdata/get-dataplanes.golden.json
@@ -49,5 +49,6 @@
         "type": "Dataplane"
       }
     ],
+    "total": 2,
     "next": null
 }

--- a/app/kumactl/cmd/get/testdata/get-dataplanes.golden.yaml
+++ b/app/kumactl/cmd/get/testdata/get-dataplanes.golden.yaml
@@ -31,3 +31,4 @@ items:
         version: v2
   type: Dataplane
 next: null
+total: 2

--- a/app/kumactl/cmd/get/testdata/get-dataplanes.golden.yaml
+++ b/app/kumactl/cmd/get/testdata/get-dataplanes.golden.yaml
@@ -1,3 +1,4 @@
+total: 2
 items:
 - creationTime: 0001-01-01T00:00:00Z
   mesh: default
@@ -31,4 +32,3 @@ items:
         version: v2
   type: Dataplane
 next: null
-total: 2

--- a/app/kumactl/cmd/get/testdata/get-fault-injections.golden.json
+++ b/app/kumactl/cmd/get/testdata/get-fault-injections.golden.json
@@ -1,4 +1,5 @@
 {
+  "total": 2,
   "items": [
     {
       "type": "FaultInjection",
@@ -73,6 +74,5 @@
       }
     }
   ],
-  "total": 2,
   "next": null
 }

--- a/app/kumactl/cmd/get/testdata/get-fault-injections.golden.json
+++ b/app/kumactl/cmd/get/testdata/get-fault-injections.golden.json
@@ -73,5 +73,6 @@
       }
     }
   ],
+  "total": 2,
   "next": null
 }

--- a/app/kumactl/cmd/get/testdata/get-fault-injections.golden.yaml
+++ b/app/kumactl/cmd/get/testdata/get-fault-injections.golden.yaml
@@ -1,3 +1,4 @@
+total: 2
 items:
   - conf:
       abort:
@@ -44,4 +45,3 @@ items:
           version: "0.1"
     type: FaultInjection
 next: null
-total: 2

--- a/app/kumactl/cmd/get/testdata/get-fault-injections.golden.yaml
+++ b/app/kumactl/cmd/get/testdata/get-fault-injections.golden.yaml
@@ -44,3 +44,4 @@ items:
           version: "0.1"
     type: FaultInjection
 next: null
+total: 2

--- a/app/kumactl/cmd/get/testdata/get-healthchecks.golden.json
+++ b/app/kumactl/cmd/get/testdata/get-healthchecks.golden.json
@@ -1,4 +1,5 @@
 {
+  "total": 2,
   "items": [
     {
       "mesh": "default",
@@ -15,6 +16,5 @@
       "modificationTime": "0001-01-01T00:00:00Z"
     }
   ],
-  "total": 2,
   "next": null
 }

--- a/app/kumactl/cmd/get/testdata/get-healthchecks.golden.json
+++ b/app/kumactl/cmd/get/testdata/get-healthchecks.golden.json
@@ -15,5 +15,6 @@
       "modificationTime": "0001-01-01T00:00:00Z"
     }
   ],
+  "total": 2,
   "next": null
 }

--- a/app/kumactl/cmd/get/testdata/get-healthchecks.golden.yaml
+++ b/app/kumactl/cmd/get/testdata/get-healthchecks.golden.yaml
@@ -1,3 +1,4 @@
+total: 2
 items:
 - creationTime: 0001-01-01T00:00:00Z
   mesh: default
@@ -10,4 +11,3 @@ items:
   name: backend-to-db
   type: HealthCheck
 next: null
-total: 2

--- a/app/kumactl/cmd/get/testdata/get-healthchecks.golden.yaml
+++ b/app/kumactl/cmd/get/testdata/get-healthchecks.golden.yaml
@@ -10,3 +10,4 @@ items:
   name: backend-to-db
   type: HealthCheck
 next: null
+total: 2

--- a/app/kumactl/cmd/get/testdata/get-meshes.golden.json
+++ b/app/kumactl/cmd/get/testdata/get-meshes.golden.json
@@ -1,4 +1,5 @@
 {
+  "total": 2,
   "items": [
     {
       "metrics": {
@@ -92,6 +93,5 @@
       "modificationTime": "0001-01-01T00:00:00Z"
     }
   ],
-  "total": 2,
   "next": null
 }

--- a/app/kumactl/cmd/get/testdata/get-meshes.golden.json
+++ b/app/kumactl/cmd/get/testdata/get-meshes.golden.json
@@ -92,5 +92,6 @@
       "modificationTime": "0001-01-01T00:00:00Z"
     }
   ],
+  "total": 2,
   "next": null
 }

--- a/app/kumactl/cmd/get/testdata/get-meshes.golden.yaml
+++ b/app/kumactl/cmd/get/testdata/get-meshes.golden.yaml
@@ -1,3 +1,4 @@
+total: 2
 items:
 - creationTime: "0001-01-01T00:00:00Z"
   logging:
@@ -54,4 +55,3 @@ items:
     backends: []
   type: Mesh
 next: null
-total: 2

--- a/app/kumactl/cmd/get/testdata/get-meshes.golden.yaml
+++ b/app/kumactl/cmd/get/testdata/get-meshes.golden.yaml
@@ -54,3 +54,4 @@ items:
     backends: []
   type: Mesh
 next: null
+total: 2

--- a/app/kumactl/cmd/get/testdata/get-proxytemplates.golden.json
+++ b/app/kumactl/cmd/get/testdata/get-proxytemplates.golden.json
@@ -1,4 +1,5 @@
 {
+  "total": 2,
   "items": [
     {
       "mesh": "default",
@@ -15,6 +16,5 @@
       "modificationTime": "0001-01-01T00:00:00Z"
     }
   ],
-  "total": 2,
   "next": null
 }

--- a/app/kumactl/cmd/get/testdata/get-proxytemplates.golden.json
+++ b/app/kumactl/cmd/get/testdata/get-proxytemplates.golden.json
@@ -15,5 +15,6 @@
       "modificationTime": "0001-01-01T00:00:00Z"
     }
   ],
+  "total": 2,
   "next": null
 }

--- a/app/kumactl/cmd/get/testdata/get-proxytemplates.golden.yaml
+++ b/app/kumactl/cmd/get/testdata/get-proxytemplates.golden.yaml
@@ -1,3 +1,4 @@
+total: 2
 items:
   - creationTime: 0001-01-01T00:00:00Z
     mesh: default
@@ -10,4 +11,3 @@ items:
     name: another-template
     type: ProxyTemplate
 next: null
-total: 2

--- a/app/kumactl/cmd/get/testdata/get-proxytemplates.golden.yaml
+++ b/app/kumactl/cmd/get/testdata/get-proxytemplates.golden.yaml
@@ -10,3 +10,4 @@ items:
     name: another-template
     type: ProxyTemplate
 next: null
+total: 2

--- a/app/kumactl/cmd/get/testdata/get-secrets.golden.json
+++ b/app/kumactl/cmd/get/testdata/get-secrets.golden.json
@@ -1,4 +1,5 @@
 {
+  "total": 2,
   "items": [
     {
       "type": "Secret",
@@ -17,6 +18,5 @@
       "data": "dGVzdDI="
     }
   ],
-  "total": 2,
   "next": null
 }

--- a/app/kumactl/cmd/get/testdata/get-secrets.golden.json
+++ b/app/kumactl/cmd/get/testdata/get-secrets.golden.json
@@ -17,5 +17,6 @@
       "data": "dGVzdDI="
     }
   ],
+  "total": 2,
   "next": null
 }

--- a/app/kumactl/cmd/get/testdata/get-secrets.golden.yaml
+++ b/app/kumactl/cmd/get/testdata/get-secrets.golden.yaml
@@ -12,3 +12,4 @@ items:
     modificationTime: "0001-01-01T00:00:00Z"
     data: dGVzdDI=
 next: null
+total: 2

--- a/app/kumactl/cmd/get/testdata/get-secrets.golden.yaml
+++ b/app/kumactl/cmd/get/testdata/get-secrets.golden.yaml
@@ -1,3 +1,4 @@
+total: 2
 items:
   - type: Secret
     mesh: default
@@ -12,4 +13,3 @@ items:
     modificationTime: "0001-01-01T00:00:00Z"
     data: dGVzdDI=
 next: null
-total: 2

--- a/app/kumactl/cmd/get/testdata/get-traffic-logs.golden.json
+++ b/app/kumactl/cmd/get/testdata/get-traffic-logs.golden.json
@@ -53,5 +53,6 @@
       "type": "TrafficLog"
     }
   ],
+  "total": 2,
   "next": null
 }

--- a/app/kumactl/cmd/get/testdata/get-traffic-logs.golden.json
+++ b/app/kumactl/cmd/get/testdata/get-traffic-logs.golden.json
@@ -1,4 +1,5 @@
 {
+  "total": 2,
   "items": [
     {
       "mesh": "default",
@@ -53,6 +54,5 @@
       "type": "TrafficLog"
     }
   ],
-  "total": 2,
   "next": null
 }

--- a/app/kumactl/cmd/get/testdata/get-traffic-logs.golden.yaml
+++ b/app/kumactl/cmd/get/testdata/get-traffic-logs.golden.yaml
@@ -30,3 +30,4 @@ items:
       backend: logstash
     type: TrafficLog
 next: null
+total: 2

--- a/app/kumactl/cmd/get/testdata/get-traffic-logs.golden.yaml
+++ b/app/kumactl/cmd/get/testdata/get-traffic-logs.golden.yaml
@@ -1,3 +1,4 @@
+total: 2
 items:
   - creationTime: 0001-01-01T00:00:00Z
     mesh: default
@@ -30,4 +31,3 @@ items:
       backend: logstash
     type: TrafficLog
 next: null
-total: 2

--- a/app/kumactl/cmd/get/testdata/get-traffic-permissions.golden.json
+++ b/app/kumactl/cmd/get/testdata/get-traffic-permissions.golden.json
@@ -47,5 +47,6 @@
       "type": "TrafficPermission"
     }
   ],
+  "total": 2,
   "next": null
 }

--- a/app/kumactl/cmd/get/testdata/get-traffic-permissions.golden.json
+++ b/app/kumactl/cmd/get/testdata/get-traffic-permissions.golden.json
@@ -1,4 +1,5 @@
 {
+  "total": 2,
   "items": [
     {
       "mesh": "default",
@@ -47,6 +48,5 @@
       "type": "TrafficPermission"
     }
   ],
-  "total": 2,
   "next": null
 }

--- a/app/kumactl/cmd/get/testdata/get-traffic-permissions.golden.yaml
+++ b/app/kumactl/cmd/get/testdata/get-traffic-permissions.golden.yaml
@@ -26,3 +26,4 @@ items:
         version: "1.0"
     type: TrafficPermission
 next: null
+total: 2

--- a/app/kumactl/cmd/get/testdata/get-traffic-permissions.golden.yaml
+++ b/app/kumactl/cmd/get/testdata/get-traffic-permissions.golden.yaml
@@ -1,3 +1,4 @@
+total: 2
 items:
   - creationTime: 0001-01-01T00:00:00Z
     mesh: default
@@ -26,4 +27,3 @@ items:
         version: "1.0"
     type: TrafficPermission
 next: null
-total: 2

--- a/app/kumactl/cmd/get/testdata/get-traffic-routes.golden.json
+++ b/app/kumactl/cmd/get/testdata/get-traffic-routes.golden.json
@@ -1,4 +1,5 @@
 {
+  "total": 2,
   "items": [
     {
       "mesh": "default",
@@ -15,6 +16,5 @@
       "modificationTime": "0001-01-01T00:00:00Z"
     }
   ],
-  "total": 2,
   "next": null
 }

--- a/app/kumactl/cmd/get/testdata/get-traffic-routes.golden.json
+++ b/app/kumactl/cmd/get/testdata/get-traffic-routes.golden.json
@@ -15,5 +15,6 @@
       "modificationTime": "0001-01-01T00:00:00Z"
     }
   ],
+  "total": 2,
   "next": null
 }

--- a/app/kumactl/cmd/get/testdata/get-traffic-routes.golden.yaml
+++ b/app/kumactl/cmd/get/testdata/get-traffic-routes.golden.yaml
@@ -10,3 +10,4 @@ items:
   name: backend-to-db
   type: TrafficRoute
 next: null
+total: 2

--- a/app/kumactl/cmd/get/testdata/get-traffic-routes.golden.yaml
+++ b/app/kumactl/cmd/get/testdata/get-traffic-routes.golden.yaml
@@ -1,3 +1,4 @@
+total: 2
 items:
 - creationTime: 0001-01-01T00:00:00Z
   mesh: default
@@ -10,4 +11,3 @@ items:
   name: backend-to-db
   type: TrafficRoute
 next: null
-total: 2

--- a/app/kumactl/cmd/get/testdata/get-traffic-traces.golden.json
+++ b/app/kumactl/cmd/get/testdata/get-traffic-traces.golden.json
@@ -37,5 +37,6 @@
       "type": "TrafficTrace"
     }
   ],
+  "total": 2,
   "next": null
 }

--- a/app/kumactl/cmd/get/testdata/get-traffic-traces.golden.json
+++ b/app/kumactl/cmd/get/testdata/get-traffic-traces.golden.json
@@ -1,4 +1,5 @@
 {
+  "total": 2,
   "items": [
     {
       "mesh": "default",
@@ -37,6 +38,5 @@
       "type": "TrafficTrace"
     }
   ],
-  "total": 2,
   "next": null
 }

--- a/app/kumactl/cmd/get/testdata/get-traffic-traces.golden.yaml
+++ b/app/kumactl/cmd/get/testdata/get-traffic-traces.golden.yaml
@@ -1,3 +1,4 @@
+total: 2
 items:
   - mesh: default
     modificationTime: 0001-01-01T00:00:00Z
@@ -22,4 +23,3 @@ items:
     creationTime: 0001-01-01T00:00:00Z
     type: TrafficTrace
 next: null
-total: 2

--- a/app/kumactl/cmd/get/testdata/get-traffic-traces.golden.yaml
+++ b/app/kumactl/cmd/get/testdata/get-traffic-traces.golden.yaml
@@ -22,3 +22,4 @@ items:
     creationTime: 0001-01-01T00:00:00Z
     type: TrafficTrace
 next: null
+total: 2

--- a/app/kumactl/cmd/inspect/inspect_dataplanes_test.go
+++ b/app/kumactl/cmd/inspect/inspect_dataplanes_test.go
@@ -29,7 +29,7 @@ import (
 type testDataplaneOverviewClient struct {
 	receivedTags    map[string]string
 	receivedGateway bool
-	total           uint64
+	total           uint32
 	overviews       []*mesh_core.DataplaneOverviewResource
 }
 
@@ -168,7 +168,7 @@ var _ = Describe("kumactl inspect dataplanes", func() {
 		BeforeEach(func() {
 			// setup
 			testClient = &testDataplaneOverviewClient{
-				total:     uint64(len(sampleDataplaneOverview)),
+				total:     uint32(len(sampleDataplaneOverview)),
 				overviews: sampleDataplaneOverview,
 			}
 

--- a/app/kumactl/cmd/inspect/inspect_dataplanes_test.go
+++ b/app/kumactl/cmd/inspect/inspect_dataplanes_test.go
@@ -30,6 +30,7 @@ type testDataplaneOverviewClient struct {
 	receivedTags    map[string]string
 	receivedGateway bool
 	overviews       []*mesh_core.DataplaneOverviewResource
+	total           uint64
 }
 
 func (c *testDataplaneOverviewClient) List(_ context.Context, _ string, tags map[string]string, gateway bool) (*mesh_core.DataplaneOverviewResourceList, error) {
@@ -37,6 +38,7 @@ func (c *testDataplaneOverviewClient) List(_ context.Context, _ string, tags map
 	c.receivedGateway = gateway
 	return &mesh_core.DataplaneOverviewResourceList{
 		Items: c.overviews,
+		Total: c.total,
 	}, nil
 }
 
@@ -167,6 +169,7 @@ var _ = Describe("kumactl inspect dataplanes", func() {
 			// setup
 			testClient = &testDataplaneOverviewClient{
 				overviews: sampleDataplaneOverview,
+				total:     uint64(len(sampleDataplaneOverview)),
 			}
 
 			rootCtx = &kumactl_cmd.RootContext{

--- a/app/kumactl/cmd/inspect/inspect_dataplanes_test.go
+++ b/app/kumactl/cmd/inspect/inspect_dataplanes_test.go
@@ -8,6 +8,8 @@ import (
 	"strings"
 	"time"
 
+	"github.com/Kong/kuma/pkg/core/resources/model"
+
 	"github.com/Kong/kuma/app/kumactl/cmd"
 	"github.com/Kong/kuma/app/kumactl/pkg/resources"
 
@@ -37,8 +39,10 @@ func (c *testDataplaneOverviewClient) List(_ context.Context, _ string, tags map
 	c.receivedTags = tags
 	c.receivedGateway = gateway
 	return &mesh_core.DataplaneOverviewResourceList{
-		Total: c.total,
 		Items: c.overviews,
+		Pagination: model.Pagination{
+			Total: c.total,
+		},
 	}, nil
 }
 

--- a/app/kumactl/cmd/inspect/inspect_dataplanes_test.go
+++ b/app/kumactl/cmd/inspect/inspect_dataplanes_test.go
@@ -29,16 +29,16 @@ import (
 type testDataplaneOverviewClient struct {
 	receivedTags    map[string]string
 	receivedGateway bool
-	overviews       []*mesh_core.DataplaneOverviewResource
 	total           uint64
+	overviews       []*mesh_core.DataplaneOverviewResource
 }
 
 func (c *testDataplaneOverviewClient) List(_ context.Context, _ string, tags map[string]string, gateway bool) (*mesh_core.DataplaneOverviewResourceList, error) {
 	c.receivedTags = tags
 	c.receivedGateway = gateway
 	return &mesh_core.DataplaneOverviewResourceList{
-		Items: c.overviews,
 		Total: c.total,
+		Items: c.overviews,
 	}, nil
 }
 
@@ -168,8 +168,8 @@ var _ = Describe("kumactl inspect dataplanes", func() {
 		BeforeEach(func() {
 			// setup
 			testClient = &testDataplaneOverviewClient{
-				overviews: sampleDataplaneOverview,
 				total:     uint64(len(sampleDataplaneOverview)),
+				overviews: sampleDataplaneOverview,
 			}
 
 			rootCtx = &kumactl_cmd.RootContext{

--- a/app/kumactl/cmd/inspect/testdata/inspect-dataplanes.golden.json
+++ b/app/kumactl/cmd/inspect/testdata/inspect-dataplanes.golden.json
@@ -94,5 +94,6 @@
       "type": "DataplaneOverview"
     }
   ],
+  "total": 2,
   "next": null
 }

--- a/app/kumactl/cmd/inspect/testdata/inspect-dataplanes.golden.json
+++ b/app/kumactl/cmd/inspect/testdata/inspect-dataplanes.golden.json
@@ -1,4 +1,5 @@
 {
+  "total": 2,
   "items": [
     {
       "dataplane": {
@@ -94,6 +95,5 @@
       "type": "DataplaneOverview"
     }
   ],
-  "total": 2,
   "next": null
 }

--- a/app/kumactl/cmd/inspect/testdata/inspect-dataplanes.golden.yaml
+++ b/app/kumactl/cmd/inspect/testdata/inspect-dataplanes.golden.yaml
@@ -56,3 +56,4 @@ items:
     name: example
     type: DataplaneOverview
 next: null
+total: 2

--- a/app/kumactl/cmd/inspect/testdata/inspect-dataplanes.golden.yaml
+++ b/app/kumactl/cmd/inspect/testdata/inspect-dataplanes.golden.yaml
@@ -1,3 +1,4 @@
+total: 2
 items:
   - creationTime: 2018-07-17T16:05:36.995Z
     dataplane:
@@ -56,4 +57,3 @@ items:
     name: example
     type: DataplaneOverview
 next: null
-total: 2

--- a/pkg/api-server/dataplane_overview_endpoints_test.go
+++ b/pkg/api-server/dataplane_overview_endpoints_test.go
@@ -173,27 +173,27 @@ var _ = Describe("Dataplane Overview Endpoints", func() {
 			},
 			Entry("should list all when no tag is provided", testCase{
 				url:          "/meshes/mesh1/dataplanes+insights",
-				expectedJson: fmt.Sprintf(`{"items": [%s], "next": null}`, sampleJson),
+				expectedJson: fmt.Sprintf(`{"items": [%s], "total": 1, "next": null}`, sampleJson),
 			}),
 			Entry("should list all when no tag is provided", testCase{
 				url:          "/dataplanes+insights",
-				expectedJson: fmt.Sprintf(`{"items": [%s], "next": null}`, sampleJson),
+				expectedJson: fmt.Sprintf(`{"items": [%s], "total": 1, "next": null}`, sampleJson),
 			}),
 			Entry("should list with only one matching tag", testCase{
 				url:          "/meshes/mesh1/dataplanes+insights?tag=service:sample",
-				expectedJson: fmt.Sprintf(`{"items": [%s], "next": null}`, sampleJson),
+				expectedJson: fmt.Sprintf(`{"items": [%s], "total": 1, "next": null}`, sampleJson),
 			}),
 			Entry("should list all with all matching tags", testCase{
 				url:          "/meshes/mesh1/dataplanes+insights?tag=service:sample&tag=version:v1",
-				expectedJson: fmt.Sprintf(`{"items": [%s], "next": null}`, sampleJson),
+				expectedJson: fmt.Sprintf(`{"items": [%s], "total": 1, "next": null}`, sampleJson),
 			}),
 			Entry("should not list when any tag is not matching", testCase{
 				url:          "/meshes/mesh1/dataplanes+insights?tag=service:sample&tag=version:v2",
-				expectedJson: `{"items": [], "next": null}`,
+				expectedJson: `{"items": [], "total": 1, "next": null}`,
 			}),
 			Entry("should list only gateway dataplanes", testCase{
 				url:          "/meshes/mesh1/dataplanes+insights?gateway=true",
-				expectedJson: fmt.Sprintf(`{"items": [%s], "next": null}`, sampleJson),
+				expectedJson: fmt.Sprintf(`{"items": [%s], "total": 1, "next": null}`, sampleJson),
 			}),
 		)
 	})

--- a/pkg/api-server/dataplane_overview_endpoints_test.go
+++ b/pkg/api-server/dataplane_overview_endpoints_test.go
@@ -173,27 +173,27 @@ var _ = Describe("Dataplane Overview Endpoints", func() {
 			},
 			Entry("should list all when no tag is provided", testCase{
 				url:          "/meshes/mesh1/dataplanes+insights",
-				expectedJson: fmt.Sprintf(`{"items": [%s], "total": 1, "next": null}`, sampleJson),
+				expectedJson: fmt.Sprintf(`{"total": 1, "items": [%s], "next": null}`, sampleJson),
 			}),
 			Entry("should list all when no tag is provided", testCase{
 				url:          "/dataplanes+insights",
-				expectedJson: fmt.Sprintf(`{"items": [%s], "total": 1, "next": null}`, sampleJson),
+				expectedJson: fmt.Sprintf(`{"total": 1, "items": [%s], "next": null}`, sampleJson),
 			}),
 			Entry("should list with only one matching tag", testCase{
 				url:          "/meshes/mesh1/dataplanes+insights?tag=service:sample",
-				expectedJson: fmt.Sprintf(`{"items": [%s], "total": 1, "next": null}`, sampleJson),
+				expectedJson: fmt.Sprintf(`{"total": 1, "items": [%s], "next": null}`, sampleJson),
 			}),
 			Entry("should list all with all matching tags", testCase{
 				url:          "/meshes/mesh1/dataplanes+insights?tag=service:sample&tag=version:v1",
-				expectedJson: fmt.Sprintf(`{"items": [%s], "total": 1, "next": null}`, sampleJson),
+				expectedJson: fmt.Sprintf(`{"total": 1, "items": [%s], "next": null}`, sampleJson),
 			}),
 			Entry("should not list when any tag is not matching", testCase{
 				url:          "/meshes/mesh1/dataplanes+insights?tag=service:sample&tag=version:v2",
-				expectedJson: `{"items": [], "total": 1, "next": null}`,
+				expectedJson: `{"total": 1, "items": [], "next": null}`,
 			}),
 			Entry("should list only gateway dataplanes", testCase{
 				url:          "/meshes/mesh1/dataplanes+insights?gateway=true",
-				expectedJson: fmt.Sprintf(`{"items": [%s], "total": 1, "next": null}`, sampleJson),
+				expectedJson: fmt.Sprintf(`{"total": 1, "items": [%s], "next": null}`, sampleJson),
 			}),
 		)
 	})

--- a/pkg/api-server/mesh_endpoints_test.go
+++ b/pkg/api-server/mesh_endpoints_test.go
@@ -103,8 +103,8 @@ var _ = Describe("Resource Endpoints", func() {
 			Expect(err).ToNot(HaveOccurred())
 
 			Expect(string(body)).To(Or(
-				MatchJSON(fmt.Sprintf(`{"items": [%s,%s], "total": %d, "next": null}`, json1, json2, 2)),
-				MatchJSON(fmt.Sprintf(`{"items": [%s,%s], "total": %d, "next": null}`, json2, json1, 2)),
+				MatchJSON(fmt.Sprintf(`{"total": %d, "items": [%s,%s], "next": null}`, 2, json1, json2)),
+				MatchJSON(fmt.Sprintf(`{"total": %d, "items": [%s,%s], "next": null}`, 2, json2, json1)),
 			))
 		})
 	})

--- a/pkg/api-server/mesh_endpoints_test.go
+++ b/pkg/api-server/mesh_endpoints_test.go
@@ -103,8 +103,8 @@ var _ = Describe("Resource Endpoints", func() {
 			Expect(err).ToNot(HaveOccurred())
 
 			Expect(string(body)).To(Or(
-				MatchJSON(fmt.Sprintf(`{"items": [%s,%s], "next": null}`, json1, json2)),
-				MatchJSON(fmt.Sprintf(`{"items": [%s,%s], "next": null}`, json2, json1)),
+				MatchJSON(fmt.Sprintf(`{"items": [%s,%s], "total": %d, "next": null}`, json1, json2, 2)),
+				MatchJSON(fmt.Sprintf(`{"items": [%s,%s], "total": %d, "next": null}`, json2, json1, 2)),
 			))
 		})
 	})

--- a/pkg/api-server/resource_endpoints_test.go
+++ b/pkg/api-server/resource_endpoints_test.go
@@ -131,8 +131,8 @@ var _ = Describe("Resource Endpoints", func() {
 			body, err := ioutil.ReadAll(response.Body)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(body).To(Or(
-				MatchJSON(fmt.Sprintf(`{"items": [%s,%s], "total": %d, "next": null}`, json1, json2, 2)),
-				MatchJSON(fmt.Sprintf(`{"items": [%s,%s], "total": %d, "next": null}`, json2, json1, 2)),
+				MatchJSON(fmt.Sprintf(`{"total": %d, "items": [%s,%s], "next": null}`, 2, json1, json2)),
+				MatchJSON(fmt.Sprintf(`{"total": %d, "items": [%s,%s], "next": null}`, 2, json2, json1)),
 			))
 		})
 
@@ -171,8 +171,8 @@ var _ = Describe("Resource Endpoints", func() {
 			body, err := ioutil.ReadAll(response.Body)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(body).To(Or(
-				MatchJSON(fmt.Sprintf(`{"items": [%s,%s], "total": %d, "next": null}`, json1, json2, 2)),
-				MatchJSON(fmt.Sprintf(`{"items": [%s,%s], "total": %d, "next": null}`, json2, json1, 2)),
+				MatchJSON(fmt.Sprintf(`{"total": %d, "items": [%s,%s], "next": null}`, 2, json1, json2)),
+				MatchJSON(fmt.Sprintf(`{"total": %d, "items": [%s,%s], "next": null}`, 2, json2, json1)),
 			))
 		})
 
@@ -193,6 +193,7 @@ var _ = Describe("Resource Endpoints", func() {
 			Expect(response.StatusCode).To(Equal(200))
 			json := fmt.Sprintf(`
 			{
+				"total": 3,
 				"items": [
 					{
 						"type": "SampleTrafficRoute",
@@ -211,7 +212,6 @@ var _ = Describe("Resource Endpoints", func() {
 						"path": "/sample-path"
 					}
 				],
-				"total": 3,
 				"next": "%s/sample-traffic-routes?offset=2&size=2"
 			}`, publicApiServerUrl)
 			body, err := ioutil.ReadAll(response.Body)
@@ -229,6 +229,7 @@ var _ = Describe("Resource Endpoints", func() {
 			Expect(response.StatusCode).To(Equal(200))
 			json = `
 			{
+				"total": 3,
 				"items": [
 					{
 						"type": "SampleTrafficRoute",
@@ -239,7 +240,6 @@ var _ = Describe("Resource Endpoints", func() {
 						"path": "/sample-path"
 					}
 				],
-				"total": 3,
 				"next": null
 			}`
 			body, err = ioutil.ReadAll(response.Body)

--- a/pkg/api-server/resource_endpoints_test.go
+++ b/pkg/api-server/resource_endpoints_test.go
@@ -131,8 +131,8 @@ var _ = Describe("Resource Endpoints", func() {
 			body, err := ioutil.ReadAll(response.Body)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(body).To(Or(
-				MatchJSON(fmt.Sprintf(`{"items": [%s,%s], "next": null}`, json1, json2)),
-				MatchJSON(fmt.Sprintf(`{"items": [%s,%s]}, "next": null`, json2, json1)),
+				MatchJSON(fmt.Sprintf(`{"items": [%s,%s], "total": %d, "next": null}`, json1, json2, 2)),
+				MatchJSON(fmt.Sprintf(`{"items": [%s,%s], "total": %d, "next": null}`, json2, json1, 2)),
 			))
 		})
 
@@ -171,8 +171,8 @@ var _ = Describe("Resource Endpoints", func() {
 			body, err := ioutil.ReadAll(response.Body)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(body).To(Or(
-				MatchJSON(fmt.Sprintf(`{"items": [%s,%s], "next": null}`, json1, json2)),
-				MatchJSON(fmt.Sprintf(`{"items": [%s,%s], "next": null}`, json2, json1)),
+				MatchJSON(fmt.Sprintf(`{"items": [%s,%s], "total": %d, "next": null}`, json1, json2, 2)),
+				MatchJSON(fmt.Sprintf(`{"items": [%s,%s], "total": %d, "next": null}`, json2, json1, 2)),
 			))
 		})
 
@@ -211,6 +211,7 @@ var _ = Describe("Resource Endpoints", func() {
 						"path": "/sample-path"
 					}
 				],
+				"total": 3,
 				"next": "%s/sample-traffic-routes?offset=2&size=2"
 			}`, publicApiServerUrl)
 			body, err := ioutil.ReadAll(response.Body)
@@ -238,6 +239,7 @@ var _ = Describe("Resource Endpoints", func() {
 						"path": "/sample-path"
 					}
 				],
+				"total": 3,
 				"next": null
 			}`
 			body, err = ioutil.ReadAll(response.Body)

--- a/pkg/core/resources/apis/mesh/dataplane.go
+++ b/pkg/core/resources/apis/mesh/dataplane.go
@@ -70,8 +70,8 @@ func (l *DataplaneResourceList) AddItem(r model.Resource) error {
 		return model.ErrorInvalidItemType((*DataplaneResource)(nil), r)
 	}
 }
-func (l *DataplaneResourceList) GetPagination() model.Pagination {
-	return l.Pagination
+func (l *DataplaneResourceList) GetPagination() *model.Pagination {
+	return &l.Pagination
 }
 func (l *DataplaneResourceList) SetPagination(pagination model.Pagination) {
 	l.Pagination = pagination

--- a/pkg/core/resources/apis/mesh/dataplane.go
+++ b/pkg/core/resources/apis/mesh/dataplane.go
@@ -45,6 +45,7 @@ var _ model.ResourceList = &DataplaneResourceList{}
 
 type DataplaneResourceList struct {
 	Items      []*DataplaneResource
+	Total      uint64
 	Pagination model.Pagination
 }
 
@@ -55,7 +56,12 @@ func (l *DataplaneResourceList) GetItems() []model.Resource {
 	}
 	return res
 }
-
+func (l *DataplaneResourceList) GetTotal() uint64 {
+	return l.Total
+}
+func (l *DataplaneResourceList) SetTotal(total uint64) {
+	l.Total = total
+}
 func (l *DataplaneResourceList) GetItemType() model.ResourceType {
 	return DataplaneType
 }

--- a/pkg/core/resources/apis/mesh/dataplane.go
+++ b/pkg/core/resources/apis/mesh/dataplane.go
@@ -44,16 +44,16 @@ func (t *DataplaneResource) SetSpec(spec model.ResourceSpec) error {
 var _ model.ResourceList = &DataplaneResourceList{}
 
 type DataplaneResourceList struct {
-	Total      uint64
+	Total      uint32
 	Items      []*DataplaneResource
 	Pagination model.Pagination
 }
 
-func (l *DataplaneResourceList) GetTotal() uint64 {
+func (l *DataplaneResourceList) GetTotal() uint32 {
 	return l.Total
 }
 
-func (l *DataplaneResourceList) SetTotal(total uint64) {
+func (l *DataplaneResourceList) SetTotal(total uint32) {
 	l.Total = total
 }
 

--- a/pkg/core/resources/apis/mesh/dataplane.go
+++ b/pkg/core/resources/apis/mesh/dataplane.go
@@ -44,17 +44,8 @@ func (t *DataplaneResource) SetSpec(spec model.ResourceSpec) error {
 var _ model.ResourceList = &DataplaneResourceList{}
 
 type DataplaneResourceList struct {
-	Total      uint32
 	Items      []*DataplaneResource
 	Pagination model.Pagination
-}
-
-func (l *DataplaneResourceList) GetTotal() uint32 {
-	return l.Total
-}
-
-func (l *DataplaneResourceList) SetTotal(total uint32) {
-	l.Total = total
 }
 
 func (l *DataplaneResourceList) GetItems() []model.Resource {

--- a/pkg/core/resources/apis/mesh/dataplane.go
+++ b/pkg/core/resources/apis/mesh/dataplane.go
@@ -44,9 +44,17 @@ func (t *DataplaneResource) SetSpec(spec model.ResourceSpec) error {
 var _ model.ResourceList = &DataplaneResourceList{}
 
 type DataplaneResourceList struct {
-	Items      []*DataplaneResource
 	Total      uint64
+	Items      []*DataplaneResource
 	Pagination model.Pagination
+}
+
+func (l *DataplaneResourceList) GetTotal() uint64 {
+	return l.Total
+}
+
+func (l *DataplaneResourceList) SetTotal(total uint64) {
+	l.Total = total
 }
 
 func (l *DataplaneResourceList) GetItems() []model.Resource {
@@ -56,12 +64,7 @@ func (l *DataplaneResourceList) GetItems() []model.Resource {
 	}
 	return res
 }
-func (l *DataplaneResourceList) GetTotal() uint64 {
-	return l.Total
-}
-func (l *DataplaneResourceList) SetTotal(total uint64) {
-	l.Total = total
-}
+
 func (l *DataplaneResourceList) GetItemType() model.ResourceType {
 	return DataplaneType
 }

--- a/pkg/core/resources/apis/mesh/dataplane.go
+++ b/pkg/core/resources/apis/mesh/dataplane.go
@@ -73,9 +73,6 @@ func (l *DataplaneResourceList) AddItem(r model.Resource) error {
 func (l *DataplaneResourceList) GetPagination() *model.Pagination {
 	return &l.Pagination
 }
-func (l *DataplaneResourceList) SetPagination(pagination model.Pagination) {
-	l.Pagination = pagination
-}
 
 func init() {
 	registry.RegisterType(&DataplaneResource{})

--- a/pkg/core/resources/apis/mesh/dataplane_insight.go
+++ b/pkg/core/resources/apis/mesh/dataplane_insight.go
@@ -74,8 +74,8 @@ func (l *DataplaneInsightResourceList) AddItem(r model.Resource) error {
 	}
 }
 
-func (l *DataplaneInsightResourceList) GetPagination() model.Pagination {
-	return l.Pagination
+func (l *DataplaneInsightResourceList) GetPagination() *model.Pagination {
+	return &l.Pagination
 }
 
 func (l *DataplaneInsightResourceList) SetPagination(pagination model.Pagination) {

--- a/pkg/core/resources/apis/mesh/dataplane_insight.go
+++ b/pkg/core/resources/apis/mesh/dataplane_insight.go
@@ -49,6 +49,7 @@ var _ model.ResourceList = &DataplaneInsightResourceList{}
 
 type DataplaneInsightResourceList struct {
 	Items      []*DataplaneInsightResource
+	Total      uint64
 	Pagination model.Pagination
 }
 
@@ -58,6 +59,12 @@ func (l *DataplaneInsightResourceList) GetItems() []model.Resource {
 		res[i] = elem
 	}
 	return res
+}
+func (l *DataplaneInsightResourceList) GetTotal() uint64 {
+	return l.Total
+}
+func (l *DataplaneInsightResourceList) SetTotal(total uint64) {
+	l.Total = total
 }
 func (l *DataplaneInsightResourceList) GetItemType() model.ResourceType {
 	return DataplaneInsightType

--- a/pkg/core/resources/apis/mesh/dataplane_insight.go
+++ b/pkg/core/resources/apis/mesh/dataplane_insight.go
@@ -48,17 +48,10 @@ func (t *DataplaneInsightResource) Validate() error {
 var _ model.ResourceList = &DataplaneInsightResourceList{}
 
 type DataplaneInsightResourceList struct {
-	Total      uint32
 	Items      []*DataplaneInsightResource
 	Pagination model.Pagination
 }
 
-func (l *DataplaneInsightResourceList) GetTotal() uint32 {
-	return l.Total
-}
-func (l *DataplaneInsightResourceList) SetTotal(total uint32) {
-	l.Total = total
-}
 func (l *DataplaneInsightResourceList) GetItems() []model.Resource {
 	res := make([]model.Resource, len(l.Items))
 	for i, elem := range l.Items {

--- a/pkg/core/resources/apis/mesh/dataplane_insight.go
+++ b/pkg/core/resources/apis/mesh/dataplane_insight.go
@@ -48,23 +48,23 @@ func (t *DataplaneInsightResource) Validate() error {
 var _ model.ResourceList = &DataplaneInsightResourceList{}
 
 type DataplaneInsightResourceList struct {
-	Items      []*DataplaneInsightResource
 	Total      uint64
+	Items      []*DataplaneInsightResource
 	Pagination model.Pagination
 }
 
+func (l *DataplaneInsightResourceList) GetTotal() uint64 {
+	return l.Total
+}
+func (l *DataplaneInsightResourceList) SetTotal(total uint64) {
+	l.Total = total
+}
 func (l *DataplaneInsightResourceList) GetItems() []model.Resource {
 	res := make([]model.Resource, len(l.Items))
 	for i, elem := range l.Items {
 		res[i] = elem
 	}
 	return res
-}
-func (l *DataplaneInsightResourceList) GetTotal() uint64 {
-	return l.Total
-}
-func (l *DataplaneInsightResourceList) SetTotal(total uint64) {
-	l.Total = total
 }
 func (l *DataplaneInsightResourceList) GetItemType() model.ResourceType {
 	return DataplaneInsightType

--- a/pkg/core/resources/apis/mesh/dataplane_insight.go
+++ b/pkg/core/resources/apis/mesh/dataplane_insight.go
@@ -78,10 +78,6 @@ func (l *DataplaneInsightResourceList) GetPagination() *model.Pagination {
 	return &l.Pagination
 }
 
-func (l *DataplaneInsightResourceList) SetPagination(pagination model.Pagination) {
-	l.Pagination = pagination
-}
-
 func init() {
 	registry.RegisterType(&DataplaneInsightResource{})
 	registry.RegistryListType(&DataplaneInsightResourceList{})

--- a/pkg/core/resources/apis/mesh/dataplane_insight.go
+++ b/pkg/core/resources/apis/mesh/dataplane_insight.go
@@ -48,15 +48,15 @@ func (t *DataplaneInsightResource) Validate() error {
 var _ model.ResourceList = &DataplaneInsightResourceList{}
 
 type DataplaneInsightResourceList struct {
-	Total      uint64
+	Total      uint32
 	Items      []*DataplaneInsightResource
 	Pagination model.Pagination
 }
 
-func (l *DataplaneInsightResourceList) GetTotal() uint64 {
+func (l *DataplaneInsightResourceList) GetTotal() uint32 {
 	return l.Total
 }
-func (l *DataplaneInsightResourceList) SetTotal(total uint64) {
+func (l *DataplaneInsightResourceList) SetTotal(total uint32) {
 	l.Total = total
 }
 func (l *DataplaneInsightResourceList) GetItems() []model.Resource {

--- a/pkg/core/resources/apis/mesh/dataplane_overview.go
+++ b/pkg/core/resources/apis/mesh/dataplane_overview.go
@@ -80,8 +80,8 @@ func (l *DataplaneOverviewResourceList) AddItem(r model.Resource) error {
 	}
 }
 
-func (l *DataplaneOverviewResourceList) GetPagination() model.Pagination {
-	return l.Pagination
+func (l *DataplaneOverviewResourceList) GetPagination() *model.Pagination {
+	return &l.Pagination
 }
 
 func (l *DataplaneOverviewResourceList) SetPagination(pagination model.Pagination) {

--- a/pkg/core/resources/apis/mesh/dataplane_overview.go
+++ b/pkg/core/resources/apis/mesh/dataplane_overview.go
@@ -54,6 +54,7 @@ var _ model.ResourceList = &DataplaneOverviewResourceList{}
 
 type DataplaneOverviewResourceList struct {
 	Items      []*DataplaneOverviewResource
+	Total      uint64
 	Pagination model.Pagination
 }
 
@@ -63,6 +64,14 @@ func (l *DataplaneOverviewResourceList) GetItems() []model.Resource {
 		res[i] = elem
 	}
 	return res
+}
+
+func (l *DataplaneOverviewResourceList) GetTotal() uint64 {
+	return l.Total
+}
+
+func (l *DataplaneOverviewResourceList) SetTotal(total uint64) {
+	l.Total = total
 }
 
 func (l *DataplaneOverviewResourceList) GetItemType() model.ResourceType {
@@ -112,6 +121,7 @@ func NewDataplaneOverviews(dataplanes DataplaneResourceList, insights DataplaneI
 	return DataplaneOverviewResourceList{
 		Pagination: dataplanes.Pagination,
 		Items:      items,
+		Total:      dataplanes.Total,
 	}
 }
 

--- a/pkg/core/resources/apis/mesh/dataplane_overview.go
+++ b/pkg/core/resources/apis/mesh/dataplane_overview.go
@@ -53,17 +53,9 @@ func (t *DataplaneOverviewResource) Validate() error {
 var _ model.ResourceList = &DataplaneOverviewResourceList{}
 
 type DataplaneOverviewResourceList struct {
-	Items      []*DataplaneOverviewResource
 	Total      uint64
+	Items      []*DataplaneOverviewResource
 	Pagination model.Pagination
-}
-
-func (l *DataplaneOverviewResourceList) GetItems() []model.Resource {
-	res := make([]model.Resource, len(l.Items))
-	for i, elem := range l.Items {
-		res[i] = elem
-	}
-	return res
 }
 
 func (l *DataplaneOverviewResourceList) GetTotal() uint64 {
@@ -72,6 +64,14 @@ func (l *DataplaneOverviewResourceList) GetTotal() uint64 {
 
 func (l *DataplaneOverviewResourceList) SetTotal(total uint64) {
 	l.Total = total
+}
+
+func (l *DataplaneOverviewResourceList) GetItems() []model.Resource {
+	res := make([]model.Resource, len(l.Items))
+	for i, elem := range l.Items {
+		res[i] = elem
+	}
+	return res
 }
 
 func (l *DataplaneOverviewResourceList) GetItemType() model.ResourceType {
@@ -119,9 +119,9 @@ func NewDataplaneOverviews(dataplanes DataplaneResourceList, insights DataplaneI
 		items = append(items, &overview)
 	}
 	return DataplaneOverviewResourceList{
+		Total:      dataplanes.Total,
 		Pagination: dataplanes.Pagination,
 		Items:      items,
-		Total:      dataplanes.Total,
 	}
 }
 

--- a/pkg/core/resources/apis/mesh/dataplane_overview.go
+++ b/pkg/core/resources/apis/mesh/dataplane_overview.go
@@ -53,16 +53,16 @@ func (t *DataplaneOverviewResource) Validate() error {
 var _ model.ResourceList = &DataplaneOverviewResourceList{}
 
 type DataplaneOverviewResourceList struct {
-	Total      uint64
+	Total      uint32
 	Items      []*DataplaneOverviewResource
 	Pagination model.Pagination
 }
 
-func (l *DataplaneOverviewResourceList) GetTotal() uint64 {
+func (l *DataplaneOverviewResourceList) GetTotal() uint32 {
 	return l.Total
 }
 
-func (l *DataplaneOverviewResourceList) SetTotal(total uint64) {
+func (l *DataplaneOverviewResourceList) SetTotal(total uint32) {
 	l.Total = total
 }
 

--- a/pkg/core/resources/apis/mesh/dataplane_overview.go
+++ b/pkg/core/resources/apis/mesh/dataplane_overview.go
@@ -53,17 +53,8 @@ func (t *DataplaneOverviewResource) Validate() error {
 var _ model.ResourceList = &DataplaneOverviewResourceList{}
 
 type DataplaneOverviewResourceList struct {
-	Total      uint32
 	Items      []*DataplaneOverviewResource
 	Pagination model.Pagination
-}
-
-func (l *DataplaneOverviewResourceList) GetTotal() uint32 {
-	return l.Total
-}
-
-func (l *DataplaneOverviewResourceList) SetTotal(total uint32) {
-	l.Total = total
 }
 
 func (l *DataplaneOverviewResourceList) GetItems() []model.Resource {
@@ -119,7 +110,6 @@ func NewDataplaneOverviews(dataplanes DataplaneResourceList, insights DataplaneI
 		items = append(items, &overview)
 	}
 	return DataplaneOverviewResourceList{
-		Total:      dataplanes.Total,
 		Pagination: dataplanes.Pagination,
 		Items:      items,
 	}

--- a/pkg/core/resources/apis/mesh/dataplane_overview.go
+++ b/pkg/core/resources/apis/mesh/dataplane_overview.go
@@ -84,10 +84,6 @@ func (l *DataplaneOverviewResourceList) GetPagination() *model.Pagination {
 	return &l.Pagination
 }
 
-func (l *DataplaneOverviewResourceList) SetPagination(pagination model.Pagination) {
-	l.Pagination = pagination
-}
-
 func NewDataplaneOverviews(dataplanes DataplaneResourceList, insights DataplaneInsightResourceList) DataplaneOverviewResourceList {
 	insightsByKey := map[model.ResourceKey]*DataplaneInsightResource{}
 	for _, insight := range insights.Items {

--- a/pkg/core/resources/apis/mesh/fault_injection.go
+++ b/pkg/core/resources/apis/mesh/fault_injection.go
@@ -78,8 +78,8 @@ func (l *FaultInjectionResourceList) AddItem(r model.Resource) error {
 	}
 }
 
-func (l *FaultInjectionResourceList) GetPagination() model.Pagination {
-	return l.Pagination
+func (l *FaultInjectionResourceList) GetPagination() *model.Pagination {
+	return &l.Pagination
 }
 
 func (l *FaultInjectionResourceList) SetPagination(pagination model.Pagination) {

--- a/pkg/core/resources/apis/mesh/fault_injection.go
+++ b/pkg/core/resources/apis/mesh/fault_injection.go
@@ -49,9 +49,17 @@ func (f *FaultInjectionResource) SetSpec(spec model.ResourceSpec) error {
 var _ model.ResourceList = &FaultInjectionResourceList{}
 
 type FaultInjectionResourceList struct {
-	Items      []*FaultInjectionResource
 	Total      uint64
+	Items      []*FaultInjectionResource
 	Pagination model.Pagination
+}
+
+func (l *FaultInjectionResourceList) GetTotal() uint64 {
+	return l.Total
+}
+
+func (l *FaultInjectionResourceList) SetTotal(total uint64) {
+	l.Total = total
 }
 
 func (l *FaultInjectionResourceList) GetItems() []model.Resource {
@@ -60,13 +68,6 @@ func (l *FaultInjectionResourceList) GetItems() []model.Resource {
 		res[i] = elem
 	}
 	return res
-}
-func (l *FaultInjectionResourceList) GetTotal() uint64 {
-	return l.Total
-}
-
-func (l *FaultInjectionResourceList) SetTotal(total uint64) {
-	l.Total = total
 }
 
 func (l *FaultInjectionResourceList) GetItemType() model.ResourceType {

--- a/pkg/core/resources/apis/mesh/fault_injection.go
+++ b/pkg/core/resources/apis/mesh/fault_injection.go
@@ -82,10 +82,6 @@ func (l *FaultInjectionResourceList) GetPagination() *model.Pagination {
 	return &l.Pagination
 }
 
-func (l *FaultInjectionResourceList) SetPagination(pagination model.Pagination) {
-	l.Pagination = pagination
-}
-
 func init() {
 	registry.RegisterType(&FaultInjectionResource{})
 	registry.RegistryListType(&FaultInjectionResourceList{})

--- a/pkg/core/resources/apis/mesh/fault_injection.go
+++ b/pkg/core/resources/apis/mesh/fault_injection.go
@@ -49,16 +49,16 @@ func (f *FaultInjectionResource) SetSpec(spec model.ResourceSpec) error {
 var _ model.ResourceList = &FaultInjectionResourceList{}
 
 type FaultInjectionResourceList struct {
-	Total      uint64
+	Total      uint32
 	Items      []*FaultInjectionResource
 	Pagination model.Pagination
 }
 
-func (l *FaultInjectionResourceList) GetTotal() uint64 {
+func (l *FaultInjectionResourceList) GetTotal() uint32 {
 	return l.Total
 }
 
-func (l *FaultInjectionResourceList) SetTotal(total uint64) {
+func (l *FaultInjectionResourceList) SetTotal(total uint32) {
 	l.Total = total
 }
 

--- a/pkg/core/resources/apis/mesh/fault_injection.go
+++ b/pkg/core/resources/apis/mesh/fault_injection.go
@@ -49,17 +49,8 @@ func (f *FaultInjectionResource) SetSpec(spec model.ResourceSpec) error {
 var _ model.ResourceList = &FaultInjectionResourceList{}
 
 type FaultInjectionResourceList struct {
-	Total      uint32
 	Items      []*FaultInjectionResource
 	Pagination model.Pagination
-}
-
-func (l *FaultInjectionResourceList) GetTotal() uint32 {
-	return l.Total
-}
-
-func (l *FaultInjectionResourceList) SetTotal(total uint32) {
-	l.Total = total
 }
 
 func (l *FaultInjectionResourceList) GetItems() []model.Resource {

--- a/pkg/core/resources/apis/mesh/fault_injection.go
+++ b/pkg/core/resources/apis/mesh/fault_injection.go
@@ -50,6 +50,7 @@ var _ model.ResourceList = &FaultInjectionResourceList{}
 
 type FaultInjectionResourceList struct {
 	Items      []*FaultInjectionResource
+	Total      uint64
 	Pagination model.Pagination
 }
 
@@ -59,6 +60,13 @@ func (l *FaultInjectionResourceList) GetItems() []model.Resource {
 		res[i] = elem
 	}
 	return res
+}
+func (l *FaultInjectionResourceList) GetTotal() uint64 {
+	return l.Total
+}
+
+func (l *FaultInjectionResourceList) SetTotal(total uint64) {
+	l.Total = total
 }
 
 func (l *FaultInjectionResourceList) GetItemType() model.ResourceType {

--- a/pkg/core/resources/apis/mesh/health_check.go
+++ b/pkg/core/resources/apis/mesh/health_check.go
@@ -50,23 +50,23 @@ func (t *HealthCheckResource) Destinations() []*mesh_proto.Selector {
 var _ model.ResourceList = &HealthCheckResourceList{}
 
 type HealthCheckResourceList struct {
-	Items      []*HealthCheckResource
 	Total      uint64
+	Items      []*HealthCheckResource
 	Pagination model.Pagination
 }
 
+func (l *HealthCheckResourceList) GetTotal() uint64 {
+	return l.Total
+}
+func (l *HealthCheckResourceList) SetTotal(total uint64) {
+	l.Total = total
+}
 func (l *HealthCheckResourceList) GetItems() []model.Resource {
 	res := make([]model.Resource, len(l.Items))
 	for i, elem := range l.Items {
 		res[i] = elem
 	}
 	return res
-}
-func (l *HealthCheckResourceList) GetTotal() uint64 {
-	return l.Total
-}
-func (l *HealthCheckResourceList) SetTotal(total uint64) {
-	l.Total = total
 }
 func (l *HealthCheckResourceList) GetItemType() model.ResourceType {
 	return HealthCheckType

--- a/pkg/core/resources/apis/mesh/health_check.go
+++ b/pkg/core/resources/apis/mesh/health_check.go
@@ -50,15 +50,15 @@ func (t *HealthCheckResource) Destinations() []*mesh_proto.Selector {
 var _ model.ResourceList = &HealthCheckResourceList{}
 
 type HealthCheckResourceList struct {
-	Total      uint64
+	Total      uint32
 	Items      []*HealthCheckResource
 	Pagination model.Pagination
 }
 
-func (l *HealthCheckResourceList) GetTotal() uint64 {
+func (l *HealthCheckResourceList) GetTotal() uint32 {
 	return l.Total
 }
-func (l *HealthCheckResourceList) SetTotal(total uint64) {
+func (l *HealthCheckResourceList) SetTotal(total uint32) {
 	l.Total = total
 }
 func (l *HealthCheckResourceList) GetItems() []model.Resource {

--- a/pkg/core/resources/apis/mesh/health_check.go
+++ b/pkg/core/resources/apis/mesh/health_check.go
@@ -50,17 +50,10 @@ func (t *HealthCheckResource) Destinations() []*mesh_proto.Selector {
 var _ model.ResourceList = &HealthCheckResourceList{}
 
 type HealthCheckResourceList struct {
-	Total      uint32
 	Items      []*HealthCheckResource
 	Pagination model.Pagination
 }
 
-func (l *HealthCheckResourceList) GetTotal() uint32 {
-	return l.Total
-}
-func (l *HealthCheckResourceList) SetTotal(total uint32) {
-	l.Total = total
-}
 func (l *HealthCheckResourceList) GetItems() []model.Resource {
 	res := make([]model.Resource, len(l.Items))
 	for i, elem := range l.Items {

--- a/pkg/core/resources/apis/mesh/health_check.go
+++ b/pkg/core/resources/apis/mesh/health_check.go
@@ -51,6 +51,7 @@ var _ model.ResourceList = &HealthCheckResourceList{}
 
 type HealthCheckResourceList struct {
 	Items      []*HealthCheckResource
+	Total      uint64
 	Pagination model.Pagination
 }
 
@@ -60,6 +61,12 @@ func (l *HealthCheckResourceList) GetItems() []model.Resource {
 		res[i] = elem
 	}
 	return res
+}
+func (l *HealthCheckResourceList) GetTotal() uint64 {
+	return l.Total
+}
+func (l *HealthCheckResourceList) SetTotal(total uint64) {
+	l.Total = total
 }
 func (l *HealthCheckResourceList) GetItemType() model.ResourceType {
 	return HealthCheckType

--- a/pkg/core/resources/apis/mesh/health_check.go
+++ b/pkg/core/resources/apis/mesh/health_check.go
@@ -75,8 +75,8 @@ func (l *HealthCheckResourceList) AddItem(r model.Resource) error {
 		return model.ErrorInvalidItemType((*HealthCheckResource)(nil), r)
 	}
 }
-func (l *HealthCheckResourceList) GetPagination() model.Pagination {
-	return l.Pagination
+func (l *HealthCheckResourceList) GetPagination() *model.Pagination {
+	return &l.Pagination
 }
 func (l *HealthCheckResourceList) SetPagination(pagination model.Pagination) {
 	l.Pagination = pagination

--- a/pkg/core/resources/apis/mesh/health_check.go
+++ b/pkg/core/resources/apis/mesh/health_check.go
@@ -78,9 +78,6 @@ func (l *HealthCheckResourceList) AddItem(r model.Resource) error {
 func (l *HealthCheckResourceList) GetPagination() *model.Pagination {
 	return &l.Pagination
 }
-func (l *HealthCheckResourceList) SetPagination(pagination model.Pagination) {
-	l.Pagination = pagination
-}
 
 func init() {
 	registry.RegisterType(&HealthCheckResource{})

--- a/pkg/core/resources/apis/mesh/mesh.go
+++ b/pkg/core/resources/apis/mesh/mesh.go
@@ -45,6 +45,7 @@ var _ model.ResourceList = &MeshResourceList{}
 
 type MeshResourceList struct {
 	Items      []*MeshResource
+	Total      uint64
 	Pagination model.Pagination
 }
 
@@ -54,6 +55,12 @@ func (l *MeshResourceList) GetItems() []model.Resource {
 		res[i] = elem
 	}
 	return res
+}
+func (l *MeshResourceList) GetTotal() uint64 {
+	return l.Total
+}
+func (l *MeshResourceList) SetTotal(total uint64) {
+	l.Total = total
 }
 func (l *MeshResourceList) GetItemType() model.ResourceType {
 	return MeshType

--- a/pkg/core/resources/apis/mesh/mesh.go
+++ b/pkg/core/resources/apis/mesh/mesh.go
@@ -69,8 +69,8 @@ func (l *MeshResourceList) AddItem(r model.Resource) error {
 		return model.ErrorInvalidItemType((*MeshResource)(nil), r)
 	}
 }
-func (l *MeshResourceList) GetPagination() model.Pagination {
-	return l.Pagination
+func (l *MeshResourceList) GetPagination() *model.Pagination {
+	return &l.Pagination
 }
 func (l *MeshResourceList) SetPagination(pagination model.Pagination) {
 	l.Pagination = pagination

--- a/pkg/core/resources/apis/mesh/mesh.go
+++ b/pkg/core/resources/apis/mesh/mesh.go
@@ -44,23 +44,23 @@ func (t *MeshResource) SetSpec(spec model.ResourceSpec) error {
 var _ model.ResourceList = &MeshResourceList{}
 
 type MeshResourceList struct {
-	Items      []*MeshResource
 	Total      uint64
+	Items      []*MeshResource
 	Pagination model.Pagination
 }
 
+func (l *MeshResourceList) GetTotal() uint64 {
+	return l.Total
+}
+func (l *MeshResourceList) SetTotal(total uint64) {
+	l.Total = total
+}
 func (l *MeshResourceList) GetItems() []model.Resource {
 	res := make([]model.Resource, len(l.Items))
 	for i, elem := range l.Items {
 		res[i] = elem
 	}
 	return res
-}
-func (l *MeshResourceList) GetTotal() uint64 {
-	return l.Total
-}
-func (l *MeshResourceList) SetTotal(total uint64) {
-	l.Total = total
 }
 func (l *MeshResourceList) GetItemType() model.ResourceType {
 	return MeshType

--- a/pkg/core/resources/apis/mesh/mesh.go
+++ b/pkg/core/resources/apis/mesh/mesh.go
@@ -44,17 +44,10 @@ func (t *MeshResource) SetSpec(spec model.ResourceSpec) error {
 var _ model.ResourceList = &MeshResourceList{}
 
 type MeshResourceList struct {
-	Total      uint32
 	Items      []*MeshResource
 	Pagination model.Pagination
 }
 
-func (l *MeshResourceList) GetTotal() uint32 {
-	return l.Total
-}
-func (l *MeshResourceList) SetTotal(total uint32) {
-	l.Total = total
-}
 func (l *MeshResourceList) GetItems() []model.Resource {
 	res := make([]model.Resource, len(l.Items))
 	for i, elem := range l.Items {

--- a/pkg/core/resources/apis/mesh/mesh.go
+++ b/pkg/core/resources/apis/mesh/mesh.go
@@ -72,9 +72,6 @@ func (l *MeshResourceList) AddItem(r model.Resource) error {
 func (l *MeshResourceList) GetPagination() *model.Pagination {
 	return &l.Pagination
 }
-func (l *MeshResourceList) SetPagination(pagination model.Pagination) {
-	l.Pagination = pagination
-}
 
 func init() {
 	registry.RegisterType(&MeshResource{})

--- a/pkg/core/resources/apis/mesh/mesh.go
+++ b/pkg/core/resources/apis/mesh/mesh.go
@@ -44,15 +44,15 @@ func (t *MeshResource) SetSpec(spec model.ResourceSpec) error {
 var _ model.ResourceList = &MeshResourceList{}
 
 type MeshResourceList struct {
-	Total      uint64
+	Total      uint32
 	Items      []*MeshResource
 	Pagination model.Pagination
 }
 
-func (l *MeshResourceList) GetTotal() uint64 {
+func (l *MeshResourceList) GetTotal() uint32 {
 	return l.Total
 }
-func (l *MeshResourceList) SetTotal(total uint64) {
+func (l *MeshResourceList) SetTotal(total uint32) {
 	l.Total = total
 }
 func (l *MeshResourceList) GetItems() []model.Resource {

--- a/pkg/core/resources/apis/mesh/proxytemplate.go
+++ b/pkg/core/resources/apis/mesh/proxytemplate.go
@@ -69,8 +69,8 @@ func (l *ProxyTemplateResourceList) AddItem(r model.Resource) error {
 		return model.ErrorInvalidItemType((*ProxyTemplateResource)(nil), r)
 	}
 }
-func (l *ProxyTemplateResourceList) GetPagination() model.Pagination {
-	return l.Pagination
+func (l *ProxyTemplateResourceList) GetPagination() *model.Pagination {
+	return &l.Pagination
 }
 func (l *ProxyTemplateResourceList) SetPagination(pagination model.Pagination) {
 	l.Pagination = pagination

--- a/pkg/core/resources/apis/mesh/proxytemplate.go
+++ b/pkg/core/resources/apis/mesh/proxytemplate.go
@@ -44,17 +44,10 @@ func (t *ProxyTemplateResource) SetSpec(spec model.ResourceSpec) error {
 var _ model.ResourceList = &ProxyTemplateResourceList{}
 
 type ProxyTemplateResourceList struct {
-	Total      uint32
 	Items      []*ProxyTemplateResource
 	Pagination model.Pagination
 }
 
-func (l *ProxyTemplateResourceList) GetTotal() uint32 {
-	return l.Total
-}
-func (l *ProxyTemplateResourceList) SetTotal(total uint32) {
-	l.Total = total
-}
 func (l *ProxyTemplateResourceList) GetItems() []model.Resource {
 	res := make([]model.Resource, len(l.Items))
 	for i, elem := range l.Items {

--- a/pkg/core/resources/apis/mesh/proxytemplate.go
+++ b/pkg/core/resources/apis/mesh/proxytemplate.go
@@ -44,23 +44,23 @@ func (t *ProxyTemplateResource) SetSpec(spec model.ResourceSpec) error {
 var _ model.ResourceList = &ProxyTemplateResourceList{}
 
 type ProxyTemplateResourceList struct {
-	Total      uint64
+	Total      uint32
 	Items      []*ProxyTemplateResource
 	Pagination model.Pagination
 }
 
+func (l *ProxyTemplateResourceList) GetTotal() uint32 {
+	return l.Total
+}
+func (l *ProxyTemplateResourceList) SetTotal(total uint32) {
+	l.Total = total
+}
 func (l *ProxyTemplateResourceList) GetItems() []model.Resource {
 	res := make([]model.Resource, len(l.Items))
 	for i, elem := range l.Items {
 		res[i] = elem
 	}
 	return res
-}
-func (l *ProxyTemplateResourceList) GetTotal() uint64 {
-	return l.Total
-}
-func (l *ProxyTemplateResourceList) SetTotal(total uint64) {
-	l.Total = total
 }
 func (l *ProxyTemplateResourceList) GetItemType() model.ResourceType {
 	return ProxyTemplateType

--- a/pkg/core/resources/apis/mesh/proxytemplate.go
+++ b/pkg/core/resources/apis/mesh/proxytemplate.go
@@ -72,9 +72,6 @@ func (l *ProxyTemplateResourceList) AddItem(r model.Resource) error {
 func (l *ProxyTemplateResourceList) GetPagination() *model.Pagination {
 	return &l.Pagination
 }
-func (l *ProxyTemplateResourceList) SetPagination(pagination model.Pagination) {
-	l.Pagination = pagination
-}
 
 func init() {
 	registry.RegisterType(&ProxyTemplateResource{})

--- a/pkg/core/resources/apis/mesh/proxytemplate.go
+++ b/pkg/core/resources/apis/mesh/proxytemplate.go
@@ -44,8 +44,8 @@ func (t *ProxyTemplateResource) SetSpec(spec model.ResourceSpec) error {
 var _ model.ResourceList = &ProxyTemplateResourceList{}
 
 type ProxyTemplateResourceList struct {
-	Items      []*ProxyTemplateResource
 	Total      uint64
+	Items      []*ProxyTemplateResource
 	Pagination model.Pagination
 }
 

--- a/pkg/core/resources/apis/mesh/proxytemplate.go
+++ b/pkg/core/resources/apis/mesh/proxytemplate.go
@@ -45,6 +45,7 @@ var _ model.ResourceList = &ProxyTemplateResourceList{}
 
 type ProxyTemplateResourceList struct {
 	Items      []*ProxyTemplateResource
+	Total      uint64
 	Pagination model.Pagination
 }
 
@@ -54,6 +55,12 @@ func (l *ProxyTemplateResourceList) GetItems() []model.Resource {
 		res[i] = elem
 	}
 	return res
+}
+func (l *ProxyTemplateResourceList) GetTotal() uint64 {
+	return l.Total
+}
+func (l *ProxyTemplateResourceList) SetTotal(total uint64) {
+	l.Total = total
 }
 func (l *ProxyTemplateResourceList) GetItemType() model.ResourceType {
 	return ProxyTemplateType

--- a/pkg/core/resources/apis/mesh/traffic_log.go
+++ b/pkg/core/resources/apis/mesh/traffic_log.go
@@ -72,9 +72,6 @@ func (l *TrafficLogResourceList) AddItem(r model.Resource) error {
 func (l *TrafficLogResourceList) GetPagination() *model.Pagination {
 	return &l.Pagination
 }
-func (l *TrafficLogResourceList) SetPagination(pagination model.Pagination) {
-	l.Pagination = pagination
-}
 
 func init() {
 	registry.RegisterType(&TrafficLogResource{})

--- a/pkg/core/resources/apis/mesh/traffic_log.go
+++ b/pkg/core/resources/apis/mesh/traffic_log.go
@@ -44,15 +44,15 @@ func (t *TrafficLogResource) SetSpec(spec model.ResourceSpec) error {
 var _ model.ResourceList = &TrafficLogResourceList{}
 
 type TrafficLogResourceList struct {
-	Total      uint64
+	Total      uint32
 	Items      []*TrafficLogResource
 	Pagination model.Pagination
 }
 
-func (l *TrafficLogResourceList) GetTotal() uint64 {
+func (l *TrafficLogResourceList) GetTotal() uint32 {
 	return l.Total
 }
-func (l *TrafficLogResourceList) SetTotal(total uint64) {
+func (l *TrafficLogResourceList) SetTotal(total uint32) {
 	l.Total = total
 }
 func (l *TrafficLogResourceList) GetItems() []model.Resource {

--- a/pkg/core/resources/apis/mesh/traffic_log.go
+++ b/pkg/core/resources/apis/mesh/traffic_log.go
@@ -44,17 +44,10 @@ func (t *TrafficLogResource) SetSpec(spec model.ResourceSpec) error {
 var _ model.ResourceList = &TrafficLogResourceList{}
 
 type TrafficLogResourceList struct {
-	Total      uint32
 	Items      []*TrafficLogResource
 	Pagination model.Pagination
 }
 
-func (l *TrafficLogResourceList) GetTotal() uint32 {
-	return l.Total
-}
-func (l *TrafficLogResourceList) SetTotal(total uint32) {
-	l.Total = total
-}
 func (l *TrafficLogResourceList) GetItems() []model.Resource {
 	res := make([]model.Resource, len(l.Items))
 	for i, elem := range l.Items {

--- a/pkg/core/resources/apis/mesh/traffic_log.go
+++ b/pkg/core/resources/apis/mesh/traffic_log.go
@@ -45,6 +45,7 @@ var _ model.ResourceList = &TrafficLogResourceList{}
 
 type TrafficLogResourceList struct {
 	Items      []*TrafficLogResource
+	Total      uint64
 	Pagination model.Pagination
 }
 
@@ -54,6 +55,12 @@ func (l *TrafficLogResourceList) GetItems() []model.Resource {
 		res[i] = elem
 	}
 	return res
+}
+func (l *TrafficLogResourceList) GetTotal() uint64 {
+	return l.Total
+}
+func (l *TrafficLogResourceList) SetTotal(total uint64) {
+	l.Total = total
 }
 func (l *TrafficLogResourceList) GetItemType() model.ResourceType {
 	return TrafficLogType

--- a/pkg/core/resources/apis/mesh/traffic_log.go
+++ b/pkg/core/resources/apis/mesh/traffic_log.go
@@ -69,8 +69,8 @@ func (l *TrafficLogResourceList) AddItem(r model.Resource) error {
 		return model.ErrorInvalidItemType((*TrafficLogResource)(nil), r)
 	}
 }
-func (l *TrafficLogResourceList) GetPagination() model.Pagination {
-	return l.Pagination
+func (l *TrafficLogResourceList) GetPagination() *model.Pagination {
+	return &l.Pagination
 }
 func (l *TrafficLogResourceList) SetPagination(pagination model.Pagination) {
 	l.Pagination = pagination

--- a/pkg/core/resources/apis/mesh/traffic_log.go
+++ b/pkg/core/resources/apis/mesh/traffic_log.go
@@ -44,23 +44,23 @@ func (t *TrafficLogResource) SetSpec(spec model.ResourceSpec) error {
 var _ model.ResourceList = &TrafficLogResourceList{}
 
 type TrafficLogResourceList struct {
-	Items      []*TrafficLogResource
 	Total      uint64
+	Items      []*TrafficLogResource
 	Pagination model.Pagination
 }
 
+func (l *TrafficLogResourceList) GetTotal() uint64 {
+	return l.Total
+}
+func (l *TrafficLogResourceList) SetTotal(total uint64) {
+	l.Total = total
+}
 func (l *TrafficLogResourceList) GetItems() []model.Resource {
 	res := make([]model.Resource, len(l.Items))
 	for i, elem := range l.Items {
 		res[i] = elem
 	}
 	return res
-}
-func (l *TrafficLogResourceList) GetTotal() uint64 {
-	return l.Total
-}
-func (l *TrafficLogResourceList) SetTotal(total uint64) {
-	l.Total = total
 }
 func (l *TrafficLogResourceList) GetItemType() model.ResourceType {
 	return TrafficLogType

--- a/pkg/core/resources/apis/mesh/traffic_permission.go
+++ b/pkg/core/resources/apis/mesh/traffic_permission.go
@@ -45,6 +45,7 @@ var _ model.ResourceList = &TrafficPermissionResourceList{}
 
 type TrafficPermissionResourceList struct {
 	Items      []*TrafficPermissionResource
+	Total      uint64
 	Pagination model.Pagination
 }
 
@@ -54,6 +55,12 @@ func (l *TrafficPermissionResourceList) GetItems() []model.Resource {
 		res[i] = elem
 	}
 	return res
+}
+func (l *TrafficPermissionResourceList) GetTotal() uint64 {
+	return l.Total
+}
+func (l *TrafficPermissionResourceList) SetTotal(total uint64) {
+	l.Total = total
 }
 func (l *TrafficPermissionResourceList) GetItemType() model.ResourceType {
 	return TrafficPermissionType

--- a/pkg/core/resources/apis/mesh/traffic_permission.go
+++ b/pkg/core/resources/apis/mesh/traffic_permission.go
@@ -72,9 +72,6 @@ func (l *TrafficPermissionResourceList) AddItem(r model.Resource) error {
 func (l *TrafficPermissionResourceList) GetPagination() *model.Pagination {
 	return &l.Pagination
 }
-func (l *TrafficPermissionResourceList) SetPagination(pagination model.Pagination) {
-	l.Pagination = pagination
-}
 
 func (t *TrafficPermissionResource) Sources() []*mesh_proto.Selector {
 	return t.Spec.GetSources()

--- a/pkg/core/resources/apis/mesh/traffic_permission.go
+++ b/pkg/core/resources/apis/mesh/traffic_permission.go
@@ -44,15 +44,15 @@ func (t *TrafficPermissionResource) SetSpec(spec model.ResourceSpec) error {
 var _ model.ResourceList = &TrafficPermissionResourceList{}
 
 type TrafficPermissionResourceList struct {
-	Total      uint64
+	Total      uint32
 	Items      []*TrafficPermissionResource
 	Pagination model.Pagination
 }
 
-func (l *TrafficPermissionResourceList) GetTotal() uint64 {
+func (l *TrafficPermissionResourceList) GetTotal() uint32 {
 	return l.Total
 }
-func (l *TrafficPermissionResourceList) SetTotal(total uint64) {
+func (l *TrafficPermissionResourceList) SetTotal(total uint32) {
 	l.Total = total
 }
 func (l *TrafficPermissionResourceList) GetItems() []model.Resource {

--- a/pkg/core/resources/apis/mesh/traffic_permission.go
+++ b/pkg/core/resources/apis/mesh/traffic_permission.go
@@ -44,17 +44,10 @@ func (t *TrafficPermissionResource) SetSpec(spec model.ResourceSpec) error {
 var _ model.ResourceList = &TrafficPermissionResourceList{}
 
 type TrafficPermissionResourceList struct {
-	Total      uint32
 	Items      []*TrafficPermissionResource
 	Pagination model.Pagination
 }
 
-func (l *TrafficPermissionResourceList) GetTotal() uint32 {
-	return l.Total
-}
-func (l *TrafficPermissionResourceList) SetTotal(total uint32) {
-	l.Total = total
-}
 func (l *TrafficPermissionResourceList) GetItems() []model.Resource {
 	res := make([]model.Resource, len(l.Items))
 	for i, elem := range l.Items {

--- a/pkg/core/resources/apis/mesh/traffic_permission.go
+++ b/pkg/core/resources/apis/mesh/traffic_permission.go
@@ -69,8 +69,8 @@ func (l *TrafficPermissionResourceList) AddItem(r model.Resource) error {
 		return model.ErrorInvalidItemType((*TrafficPermissionResource)(nil), r)
 	}
 }
-func (l *TrafficPermissionResourceList) GetPagination() model.Pagination {
-	return l.Pagination
+func (l *TrafficPermissionResourceList) GetPagination() *model.Pagination {
+	return &l.Pagination
 }
 func (l *TrafficPermissionResourceList) SetPagination(pagination model.Pagination) {
 	l.Pagination = pagination

--- a/pkg/core/resources/apis/mesh/traffic_permission.go
+++ b/pkg/core/resources/apis/mesh/traffic_permission.go
@@ -44,23 +44,23 @@ func (t *TrafficPermissionResource) SetSpec(spec model.ResourceSpec) error {
 var _ model.ResourceList = &TrafficPermissionResourceList{}
 
 type TrafficPermissionResourceList struct {
-	Items      []*TrafficPermissionResource
 	Total      uint64
+	Items      []*TrafficPermissionResource
 	Pagination model.Pagination
 }
 
+func (l *TrafficPermissionResourceList) GetTotal() uint64 {
+	return l.Total
+}
+func (l *TrafficPermissionResourceList) SetTotal(total uint64) {
+	l.Total = total
+}
 func (l *TrafficPermissionResourceList) GetItems() []model.Resource {
 	res := make([]model.Resource, len(l.Items))
 	for i, elem := range l.Items {
 		res[i] = elem
 	}
 	return res
-}
-func (l *TrafficPermissionResourceList) GetTotal() uint64 {
-	return l.Total
-}
-func (l *TrafficPermissionResourceList) SetTotal(total uint64) {
-	l.Total = total
 }
 func (l *TrafficPermissionResourceList) GetItemType() model.ResourceType {
 	return TrafficPermissionType

--- a/pkg/core/resources/apis/mesh/traffic_route.go
+++ b/pkg/core/resources/apis/mesh/traffic_route.go
@@ -69,8 +69,8 @@ func (l *TrafficRouteResourceList) AddItem(r model.Resource) error {
 		return model.ErrorInvalidItemType((*TrafficRouteResource)(nil), r)
 	}
 }
-func (l *TrafficRouteResourceList) GetPagination() model.Pagination {
-	return l.Pagination
+func (l *TrafficRouteResourceList) GetPagination() *model.Pagination {
+	return &l.Pagination
 }
 func (l *TrafficRouteResourceList) SetPagination(pagination model.Pagination) {
 	l.Pagination = pagination

--- a/pkg/core/resources/apis/mesh/traffic_route.go
+++ b/pkg/core/resources/apis/mesh/traffic_route.go
@@ -45,6 +45,7 @@ var _ model.ResourceList = &TrafficRouteResourceList{}
 
 type TrafficRouteResourceList struct {
 	Items      []*TrafficRouteResource
+	Total      uint64
 	Pagination model.Pagination
 }
 
@@ -54,6 +55,12 @@ func (l *TrafficRouteResourceList) GetItems() []model.Resource {
 		res[i] = elem
 	}
 	return res
+}
+func (l *TrafficRouteResourceList) GetTotal() uint64 {
+	return l.Total
+}
+func (l *TrafficRouteResourceList) SetTotal(total uint64) {
+	l.Total = total
 }
 func (l *TrafficRouteResourceList) GetItemType() model.ResourceType {
 	return TrafficRouteType

--- a/pkg/core/resources/apis/mesh/traffic_route.go
+++ b/pkg/core/resources/apis/mesh/traffic_route.go
@@ -44,23 +44,23 @@ func (t *TrafficRouteResource) SetSpec(spec model.ResourceSpec) error {
 var _ model.ResourceList = &TrafficRouteResourceList{}
 
 type TrafficRouteResourceList struct {
-	Items      []*TrafficRouteResource
 	Total      uint64
+	Items      []*TrafficRouteResource
 	Pagination model.Pagination
 }
 
+func (l *TrafficRouteResourceList) GetTotal() uint64 {
+	return l.Total
+}
+func (l *TrafficRouteResourceList) SetTotal(total uint64) {
+	l.Total = total
+}
 func (l *TrafficRouteResourceList) GetItems() []model.Resource {
 	res := make([]model.Resource, len(l.Items))
 	for i, elem := range l.Items {
 		res[i] = elem
 	}
 	return res
-}
-func (l *TrafficRouteResourceList) GetTotal() uint64 {
-	return l.Total
-}
-func (l *TrafficRouteResourceList) SetTotal(total uint64) {
-	l.Total = total
 }
 func (l *TrafficRouteResourceList) GetItemType() model.ResourceType {
 	return TrafficRouteType

--- a/pkg/core/resources/apis/mesh/traffic_route.go
+++ b/pkg/core/resources/apis/mesh/traffic_route.go
@@ -44,15 +44,15 @@ func (t *TrafficRouteResource) SetSpec(spec model.ResourceSpec) error {
 var _ model.ResourceList = &TrafficRouteResourceList{}
 
 type TrafficRouteResourceList struct {
-	Total      uint64
+	Total      uint32
 	Items      []*TrafficRouteResource
 	Pagination model.Pagination
 }
 
-func (l *TrafficRouteResourceList) GetTotal() uint64 {
+func (l *TrafficRouteResourceList) GetTotal() uint32 {
 	return l.Total
 }
-func (l *TrafficRouteResourceList) SetTotal(total uint64) {
+func (l *TrafficRouteResourceList) SetTotal(total uint32) {
 	l.Total = total
 }
 func (l *TrafficRouteResourceList) GetItems() []model.Resource {

--- a/pkg/core/resources/apis/mesh/traffic_route.go
+++ b/pkg/core/resources/apis/mesh/traffic_route.go
@@ -44,17 +44,10 @@ func (t *TrafficRouteResource) SetSpec(spec model.ResourceSpec) error {
 var _ model.ResourceList = &TrafficRouteResourceList{}
 
 type TrafficRouteResourceList struct {
-	Total      uint32
 	Items      []*TrafficRouteResource
 	Pagination model.Pagination
 }
 
-func (l *TrafficRouteResourceList) GetTotal() uint32 {
-	return l.Total
-}
-func (l *TrafficRouteResourceList) SetTotal(total uint32) {
-	l.Total = total
-}
 func (l *TrafficRouteResourceList) GetItems() []model.Resource {
 	res := make([]model.Resource, len(l.Items))
 	for i, elem := range l.Items {

--- a/pkg/core/resources/apis/mesh/traffic_route.go
+++ b/pkg/core/resources/apis/mesh/traffic_route.go
@@ -72,9 +72,6 @@ func (l *TrafficRouteResourceList) AddItem(r model.Resource) error {
 func (l *TrafficRouteResourceList) GetPagination() *model.Pagination {
 	return &l.Pagination
 }
-func (l *TrafficRouteResourceList) SetPagination(pagination model.Pagination) {
-	l.Pagination = pagination
-}
 
 func init() {
 	registry.RegisterType(&TrafficRouteResource{})

--- a/pkg/core/resources/apis/mesh/traffic_trace.go
+++ b/pkg/core/resources/apis/mesh/traffic_trace.go
@@ -69,8 +69,8 @@ func (l *TrafficTraceResourceList) AddItem(r model.Resource) error {
 		return model.ErrorInvalidItemType((*TrafficTraceResource)(nil), r)
 	}
 }
-func (l *TrafficTraceResourceList) GetPagination() model.Pagination {
-	return l.Pagination
+func (l *TrafficTraceResourceList) GetPagination() *model.Pagination {
+	return &l.Pagination
 }
 func (l *TrafficTraceResourceList) SetPagination(pagination model.Pagination) {
 	l.Pagination = pagination

--- a/pkg/core/resources/apis/mesh/traffic_trace.go
+++ b/pkg/core/resources/apis/mesh/traffic_trace.go
@@ -44,15 +44,15 @@ func (t *TrafficTraceResource) SetSpec(spec model.ResourceSpec) error {
 var _ model.ResourceList = &TrafficTraceResourceList{}
 
 type TrafficTraceResourceList struct {
-	Total      uint64
+	Total      uint32
 	Items      []*TrafficTraceResource
 	Pagination model.Pagination
 }
 
-func (l *TrafficTraceResourceList) GetTotal() uint64 {
+func (l *TrafficTraceResourceList) GetTotal() uint32 {
 	return l.Total
 }
-func (l *TrafficTraceResourceList) SetTotal(total uint64) {
+func (l *TrafficTraceResourceList) SetTotal(total uint32) {
 	l.Total = total
 }
 func (l *TrafficTraceResourceList) GetItems() []model.Resource {

--- a/pkg/core/resources/apis/mesh/traffic_trace.go
+++ b/pkg/core/resources/apis/mesh/traffic_trace.go
@@ -44,17 +44,10 @@ func (t *TrafficTraceResource) SetSpec(spec model.ResourceSpec) error {
 var _ model.ResourceList = &TrafficTraceResourceList{}
 
 type TrafficTraceResourceList struct {
-	Total      uint32
 	Items      []*TrafficTraceResource
 	Pagination model.Pagination
 }
 
-func (l *TrafficTraceResourceList) GetTotal() uint32 {
-	return l.Total
-}
-func (l *TrafficTraceResourceList) SetTotal(total uint32) {
-	l.Total = total
-}
 func (l *TrafficTraceResourceList) GetItems() []model.Resource {
 	res := make([]model.Resource, len(l.Items))
 	for i, elem := range l.Items {

--- a/pkg/core/resources/apis/mesh/traffic_trace.go
+++ b/pkg/core/resources/apis/mesh/traffic_trace.go
@@ -72,9 +72,6 @@ func (l *TrafficTraceResourceList) AddItem(r model.Resource) error {
 func (l *TrafficTraceResourceList) GetPagination() *model.Pagination {
 	return &l.Pagination
 }
-func (l *TrafficTraceResourceList) SetPagination(pagination model.Pagination) {
-	l.Pagination = pagination
-}
 
 func init() {
 	registry.RegisterType(&TrafficTraceResource{})

--- a/pkg/core/resources/apis/mesh/traffic_trace.go
+++ b/pkg/core/resources/apis/mesh/traffic_trace.go
@@ -44,23 +44,23 @@ func (t *TrafficTraceResource) SetSpec(spec model.ResourceSpec) error {
 var _ model.ResourceList = &TrafficTraceResourceList{}
 
 type TrafficTraceResourceList struct {
-	Items      []*TrafficTraceResource
 	Total      uint64
+	Items      []*TrafficTraceResource
 	Pagination model.Pagination
 }
 
+func (l *TrafficTraceResourceList) GetTotal() uint64 {
+	return l.Total
+}
+func (l *TrafficTraceResourceList) SetTotal(total uint64) {
+	l.Total = total
+}
 func (l *TrafficTraceResourceList) GetItems() []model.Resource {
 	res := make([]model.Resource, len(l.Items))
 	for i, elem := range l.Items {
 		res[i] = elem
 	}
 	return res
-}
-func (l *TrafficTraceResourceList) GetTotal() uint64 {
-	return l.Total
-}
-func (l *TrafficTraceResourceList) SetTotal(total uint64) {
-	l.Total = total
 }
 func (l *TrafficTraceResourceList) GetItemType() model.ResourceType {
 	return TrafficTraceType

--- a/pkg/core/resources/apis/mesh/traffic_trace.go
+++ b/pkg/core/resources/apis/mesh/traffic_trace.go
@@ -45,6 +45,7 @@ var _ model.ResourceList = &TrafficTraceResourceList{}
 
 type TrafficTraceResourceList struct {
 	Items      []*TrafficTraceResource
+	Total      uint64
 	Pagination model.Pagination
 }
 
@@ -54,6 +55,12 @@ func (l *TrafficTraceResourceList) GetItems() []model.Resource {
 		res[i] = elem
 	}
 	return res
+}
+func (l *TrafficTraceResourceList) GetTotal() uint64 {
+	return l.Total
+}
+func (l *TrafficTraceResourceList) SetTotal(total uint64) {
+	l.Total = total
 }
 func (l *TrafficTraceResourceList) GetItemType() model.ResourceType {
 	return TrafficTraceType

--- a/pkg/core/resources/apis/system/secret.go
+++ b/pkg/core/resources/apis/system/secret.go
@@ -47,17 +47,10 @@ func (t *SecretResource) Validate() error {
 var _ model.ResourceList = &SecretResourceList{}
 
 type SecretResourceList struct {
-	Total      uint32
 	Items      []*SecretResource
 	Pagination model.Pagination
 }
 
-func (l *SecretResourceList) GetTotal() uint32 {
-	return l.Total
-}
-func (l *SecretResourceList) SetTotal(total uint32) {
-	l.Total = total
-}
 func (l *SecretResourceList) GetItems() []model.Resource {
 	res := make([]model.Resource, len(l.Items))
 	for i, elem := range l.Items {

--- a/pkg/core/resources/apis/system/secret.go
+++ b/pkg/core/resources/apis/system/secret.go
@@ -72,8 +72,8 @@ func (l *SecretResourceList) AddItem(r model.Resource) error {
 		return model.ErrorInvalidItemType((*SecretResource)(nil), r)
 	}
 }
-func (l *SecretResourceList) GetPagination() model.Pagination {
-	return l.Pagination
+func (l *SecretResourceList) GetPagination() *model.Pagination {
+	return &l.Pagination
 }
 func (l *SecretResourceList) SetPagination(pagination model.Pagination) {
 	l.Pagination = pagination

--- a/pkg/core/resources/apis/system/secret.go
+++ b/pkg/core/resources/apis/system/secret.go
@@ -47,23 +47,23 @@ func (t *SecretResource) Validate() error {
 var _ model.ResourceList = &SecretResourceList{}
 
 type SecretResourceList struct {
-	Items      []*SecretResource
 	Total      uint64
+	Items      []*SecretResource
 	Pagination model.Pagination
 }
 
+func (l *SecretResourceList) GetTotal() uint64 {
+	return l.Total
+}
+func (l *SecretResourceList) SetTotal(total uint64) {
+	l.Total = total
+}
 func (l *SecretResourceList) GetItems() []model.Resource {
 	res := make([]model.Resource, len(l.Items))
 	for i, elem := range l.Items {
 		res[i] = elem
 	}
 	return res
-}
-func (l *SecretResourceList) GetTotal() uint64 {
-	return l.Total
-}
-func (l *SecretResourceList) SetTotal(total uint64) {
-	l.Total = total
 }
 func (l *SecretResourceList) GetItemType() model.ResourceType {
 	return SecretType

--- a/pkg/core/resources/apis/system/secret.go
+++ b/pkg/core/resources/apis/system/secret.go
@@ -75,9 +75,6 @@ func (l *SecretResourceList) AddItem(r model.Resource) error {
 func (l *SecretResourceList) GetPagination() *model.Pagination {
 	return &l.Pagination
 }
-func (l *SecretResourceList) SetPagination(pagination model.Pagination) {
-	l.Pagination = pagination
-}
 
 func init() {
 	registry.RegisterType(&SecretResource{})

--- a/pkg/core/resources/apis/system/secret.go
+++ b/pkg/core/resources/apis/system/secret.go
@@ -47,15 +47,15 @@ func (t *SecretResource) Validate() error {
 var _ model.ResourceList = &SecretResourceList{}
 
 type SecretResourceList struct {
-	Total      uint64
+	Total      uint32
 	Items      []*SecretResource
 	Pagination model.Pagination
 }
 
-func (l *SecretResourceList) GetTotal() uint64 {
+func (l *SecretResourceList) GetTotal() uint32 {
 	return l.Total
 }
-func (l *SecretResourceList) SetTotal(total uint64) {
+func (l *SecretResourceList) SetTotal(total uint32) {
 	l.Total = total
 }
 func (l *SecretResourceList) GetItems() []model.Resource {

--- a/pkg/core/resources/apis/system/secret.go
+++ b/pkg/core/resources/apis/system/secret.go
@@ -48,6 +48,7 @@ var _ model.ResourceList = &SecretResourceList{}
 
 type SecretResourceList struct {
 	Items      []*SecretResource
+	Total      uint64
 	Pagination model.Pagination
 }
 
@@ -57,6 +58,12 @@ func (l *SecretResourceList) GetItems() []model.Resource {
 		res[i] = elem
 	}
 	return res
+}
+func (l *SecretResourceList) GetTotal() uint64 {
+	return l.Total
+}
+func (l *SecretResourceList) SetTotal(total uint64) {
+	l.Total = total
 }
 func (l *SecretResourceList) GetItemType() model.ResourceType {
 	return SecretType

--- a/pkg/core/resources/model/resource.go
+++ b/pkg/core/resources/model/resource.go
@@ -82,6 +82,8 @@ type ResourceSpec interface {
 type ResourceList interface {
 	GetItemType() ResourceType
 	GetItems() []Resource
+	GetTotal() uint64
+	SetTotal(uint64)
 	NewItem() Resource
 	AddItem(Resource) error
 	GetPagination() Pagination

--- a/pkg/core/resources/model/resource.go
+++ b/pkg/core/resources/model/resource.go
@@ -85,7 +85,6 @@ type ResourceList interface {
 	NewItem() Resource
 	AddItem(Resource) error
 	GetPagination() *Pagination
-	SetPagination(Pagination)
 }
 
 type Pagination struct {
@@ -99,6 +98,14 @@ func (p *Pagination) GetTotal() uint32 {
 
 func (p *Pagination) SetTotal(total uint32) {
 	p.Total = total
+}
+
+func (p *Pagination) GetNextOffset() string {
+	return p.NextOffset
+}
+
+func (p *Pagination) SetNextOffset(nextOffset string) {
+	p.NextOffset = nextOffset
 }
 
 func ErrorInvalidItemType(expected, actual interface{}) error {

--- a/pkg/core/resources/model/resource.go
+++ b/pkg/core/resources/model/resource.go
@@ -80,10 +80,10 @@ type ResourceSpec interface {
 }
 
 type ResourceList interface {
-	GetItemType() ResourceType
-	GetItems() []Resource
 	GetTotal() uint64
 	SetTotal(uint64)
+	GetItemType() ResourceType
+	GetItems() []Resource
 	NewItem() Resource
 	AddItem(Resource) error
 	GetPagination() Pagination

--- a/pkg/core/resources/model/resource.go
+++ b/pkg/core/resources/model/resource.go
@@ -80,8 +80,6 @@ type ResourceSpec interface {
 }
 
 type ResourceList interface {
-	GetTotal() uint32
-	SetTotal(uint32)
 	GetItemType() ResourceType
 	GetItems() []Resource
 	NewItem() Resource
@@ -91,7 +89,16 @@ type ResourceList interface {
 }
 
 type Pagination struct {
+	Total      uint32
 	NextOffset string
+}
+
+func (p Pagination) GetTotal() uint32 {
+	return p.Total
+}
+
+func (p Pagination) SetTotal(total uint32) {
+	p.Total = total
 }
 
 func ErrorInvalidItemType(expected, actual interface{}) error {

--- a/pkg/core/resources/model/resource.go
+++ b/pkg/core/resources/model/resource.go
@@ -80,8 +80,8 @@ type ResourceSpec interface {
 }
 
 type ResourceList interface {
-	GetTotal() uint64
-	SetTotal(uint64)
+	GetTotal() uint32
+	SetTotal(uint32)
 	GetItemType() ResourceType
 	GetItems() []Resource
 	NewItem() Resource

--- a/pkg/core/resources/model/resource.go
+++ b/pkg/core/resources/model/resource.go
@@ -84,7 +84,7 @@ type ResourceList interface {
 	GetItems() []Resource
 	NewItem() Resource
 	AddItem(Resource) error
-	GetPagination() Pagination
+	GetPagination() *Pagination
 	SetPagination(Pagination)
 }
 
@@ -93,11 +93,11 @@ type Pagination struct {
 	NextOffset string
 }
 
-func (p Pagination) GetTotal() uint32 {
+func (p *Pagination) GetTotal() uint32 {
 	return p.Total
 }
 
-func (p Pagination) SetTotal(total uint32) {
+func (p *Pagination) SetTotal(total uint32) {
 	p.Total = total
 }
 

--- a/pkg/core/resources/model/rest/converter.go
+++ b/pkg/core/resources/model/rest/converter.go
@@ -33,5 +33,6 @@ func (c *from) ResourceList(rs model.ResourceList) *ResourceList {
 	}
 	return &ResourceList{
 		Items: items,
+		Total: rs.GetTotal(),
 	}
 }

--- a/pkg/core/resources/model/rest/converter.go
+++ b/pkg/core/resources/model/rest/converter.go
@@ -32,7 +32,7 @@ func (c *from) ResourceList(rs model.ResourceList) *ResourceList {
 		items[i] = c.Resource(r)
 	}
 	return &ResourceList{
-		Items: items,
 		Total: rs.GetTotal(),
+		Items: items,
 	}
 }

--- a/pkg/core/resources/model/rest/converter.go
+++ b/pkg/core/resources/model/rest/converter.go
@@ -32,7 +32,7 @@ func (c *from) ResourceList(rs model.ResourceList) *ResourceList {
 		items[i] = c.Resource(r)
 	}
 	return &ResourceList{
-		Total: rs.GetTotal(),
+		Total: rs.GetPagination().Total,
 		Items: items,
 	}
 }

--- a/pkg/core/resources/model/rest/resource.go
+++ b/pkg/core/resources/model/rest/resource.go
@@ -25,8 +25,8 @@ type Resource struct {
 }
 
 type ResourceList struct {
-	Items []*Resource `json:"items"`
 	Total uint64      `json:"total"`
+	Items []*Resource `json:"items"`
 	Next  *string     `json:"next"`
 }
 
@@ -81,14 +81,15 @@ func (rec *ResourceListReceiver) UnmarshalJSON(data []byte) error {
 		return errors.Errorf("NewResource must not be nil")
 	}
 	type List struct {
-		Items []*json.RawMessage `json:"items"`
 		Total uint64             `json:"total"`
+		Items []*json.RawMessage `json:"items"`
 		Next  *string            `json:"next"`
 	}
 	list := List{}
 	if err := json.Unmarshal(data, &list); err != nil {
 		return err
 	}
+	rec.ResourceList.Total = list.Total
 	rec.ResourceList.Items = make([]*Resource, len(list.Items))
 	for i, li := range list.Items {
 		b, err := json.Marshal(li)
@@ -105,7 +106,6 @@ func (rec *ResourceListReceiver) UnmarshalJSON(data []byte) error {
 		}
 		rec.ResourceList.Items[i] = r
 	}
-	rec.ResourceList.Total = list.Total
 	rec.ResourceList.Next = list.Next
 	return nil
 }

--- a/pkg/core/resources/model/rest/resource.go
+++ b/pkg/core/resources/model/rest/resource.go
@@ -25,7 +25,7 @@ type Resource struct {
 }
 
 type ResourceList struct {
-	Total uint64      `json:"total"`
+	Total uint32      `json:"total"`
 	Items []*Resource `json:"items"`
 	Next  *string     `json:"next"`
 }
@@ -81,7 +81,7 @@ func (rec *ResourceListReceiver) UnmarshalJSON(data []byte) error {
 		return errors.Errorf("NewResource must not be nil")
 	}
 	type List struct {
-		Total uint64             `json:"total"`
+		Total uint32             `json:"total"`
 		Items []*json.RawMessage `json:"items"`
 		Next  *string            `json:"next"`
 	}

--- a/pkg/core/resources/model/rest/resource.go
+++ b/pkg/core/resources/model/rest/resource.go
@@ -26,6 +26,7 @@ type Resource struct {
 
 type ResourceList struct {
 	Items []*Resource `json:"items"`
+	Total uint64      `json:"total"`
 	Next  *string     `json:"next"`
 }
 
@@ -81,6 +82,7 @@ func (rec *ResourceListReceiver) UnmarshalJSON(data []byte) error {
 	}
 	type List struct {
 		Items []*json.RawMessage `json:"items"`
+		Total uint64             `json:"total"`
 		Next  *string            `json:"next"`
 	}
 	list := List{}
@@ -103,6 +105,7 @@ func (rec *ResourceListReceiver) UnmarshalJSON(data []byte) error {
 		}
 		rec.ResourceList.Items[i] = r
 	}
+	rec.ResourceList.Total = list.Total
 	rec.ResourceList.Next = list.Next
 	return nil
 }

--- a/pkg/plugins/resources/k8s/store.go
+++ b/pkg/plugins/resources/k8s/store.go
@@ -137,12 +137,6 @@ func (s *KubernetesStore) List(ctx context.Context, rs core_model.ResourceList, 
 		return errors.Wrapf(err, "failed to convert core list model of type %s into k8s counterpart", rs.GetItemType())
 	}
 
-	total, err := s.countK8sResources(ctx, rs)
-	if err != nil {
-		return err
-	}
-	rs.SetTotal(uint32(total))
-
 	var kubeOpts kube_client.ListOptions
 	if opts.PageSize > 0 {
 		kubeOpts = kube_client.ListOptions{
@@ -166,6 +160,13 @@ func (s *KubernetesStore) List(ctx context.Context, rs core_model.ResourceList, 
 	if err := s.Converter.ToCoreList(obj, rs, predicate); err != nil {
 		return errors.Wrap(err, "failed to convert k8s model into core counterpart")
 	}
+
+	total, err := s.countK8sResources(ctx, rs)
+	if err != nil {
+		return err
+	}
+	rs.GetPagination().SetTotal(uint32(total))
+
 	return nil
 }
 

--- a/pkg/plugins/resources/k8s/store.go
+++ b/pkg/plugins/resources/k8s/store.go
@@ -310,8 +310,6 @@ func (c *SimpleConverter) ToCoreList(in k8s_model.KubernetesList, out core_model
 			_ = out.AddItem(r)
 		}
 	}
-	out.SetPagination(core_model.Pagination{
-		NextOffset: in.GetContinue(),
-	})
+	out.GetPagination().SetNextOffset(in.GetContinue())
 	return nil
 }

--- a/pkg/plugins/resources/k8s/store_test.go
+++ b/pkg/plugins/resources/k8s/store_test.go
@@ -557,6 +557,15 @@ var _ = Describe("KubernetesStore", func() {
 
 		It("should return a list of matching resource", func() {
 			// setup
+			demoMesh := backend.ParseYAML(fmt.Sprintf(`
+            apiVersion: kuma.io/v1alpha1
+            kind: Mesh
+            metadata:
+              name: %s
+`, "demo"))
+			backend.Create(demoMesh)
+
+			// and
 			one := backend.ParseYAML(fmt.Sprintf(`
             apiVersion: sample.test.kuma.io/v1alpha1
             kind: SampleTrafficRoute
@@ -580,6 +589,18 @@ var _ = Describe("KubernetesStore", func() {
               path: /another
 `, ns, "two"))
 			backend.Create(two)
+			// and
+			three := backend.ParseYAML(fmt.Sprintf(`
+            apiVersion: sample.test.kuma.io/v1alpha1
+            kind: SampleTrafficRoute
+            mesh: demo
+            metadata:
+              namespace: %s
+              name: %s
+            spec:
+              path: /third
+`, ns, "three"))
+			backend.Create(three)
 
 			// given
 			trl := &sample_core.TrafficRouteResourceList{}
@@ -589,6 +610,8 @@ var _ = Describe("KubernetesStore", func() {
 
 			// then
 			Expect(err).ToNot(HaveOccurred())
+			// and
+			Expect(trl.Pagination.Total).To(Equal(uint32(2)))
 			// and
 			Expect(trl.Items).To(HaveLen(2))
 
@@ -612,6 +635,40 @@ var _ = Describe("KubernetesStore", func() {
 				"k8s.kuma.io/namespace": ns,
 				"k8s.kuma.io/name":      "two",
 			}))
+
+			// given
+			trl = &sample_core.TrafficRouteResourceList{}
+
+			// when
+			err = s.List(context.Background(), trl, store.ListByMesh(name))
+
+			// then
+			Expect(err).ToNot(HaveOccurred())
+			// and
+			Expect(trl.Pagination.Total).To(Equal(uint32(1)))
+			// and
+			Expect(trl.Items).To(HaveLen(1))
+
+			// when
+			actualResources = map[string]*sample_core.TrafficRouteResource{
+				trl.Items[0].Meta.GetName(): trl.Items[0],
+			}
+			// then
+			actualResourceThree := actualResources[fmt.Sprintf("three.%s", ns)]
+			Expect(actualResourceThree.Spec.Path).To(Equal("/third"))
+			Expect(actualResourceThree.Meta.GetNameExtensions()).To(Equal(core_model.ResourceNameExtensions{
+				"k8s.kuma.io/namespace": ns,
+				"k8s.kuma.io/name":      "three",
+			}))
+
+			// when
+			err = s.Delete(context.Background(), &core_mesh.MeshResource{}, store.DeleteByKey("demo", "demo"))
+
+			// then
+			Expect(err).ToNot(HaveOccurred())
+			// and
+			backend.AssertNotExists(&mesh_k8s.Mesh{}, ns, "demo")
+
 		})
 
 		It("should return a list of matching Meshes", func() {

--- a/pkg/plugins/resources/k8s/store_test.go
+++ b/pkg/plugins/resources/k8s/store_test.go
@@ -602,6 +602,7 @@ var _ = Describe("KubernetesStore", func() {
 `, ns, "three"))
 			backend.Create(three)
 
+			By("listing resources from default mesh")
 			// given
 			trl := &sample_core.TrafficRouteResourceList{}
 
@@ -635,6 +636,8 @@ var _ = Describe("KubernetesStore", func() {
 				"k8s.kuma.io/namespace": ns,
 				"k8s.kuma.io/name":      "two",
 			}))
+
+			By("listing resources from demo mesh")
 
 			// given
 			trl = &sample_core.TrafficRouteResourceList{}

--- a/pkg/plugins/resources/memory/store.go
+++ b/pkg/plugins/resources/memory/store.go
@@ -210,6 +210,8 @@ func (c *memoryStore) List(_ context.Context, rs model.ResourceList, fs ...store
 		}
 	}
 
+	rs.SetTotal(uint64(len(records)))
+
 	i := offset
 	for ; i < offset+pageSize && i < len(records); i++ {
 		r := rs.NewItem()
@@ -218,8 +220,6 @@ func (c *memoryStore) List(_ context.Context, rs model.ResourceList, fs ...store
 		}
 		_ = rs.AddItem(r)
 	}
-
-	rs.SetTotal(uint64(len(records)))
 
 	if paginateResults {
 		nextOffset := ""

--- a/pkg/plugins/resources/memory/store.go
+++ b/pkg/plugins/resources/memory/store.go
@@ -210,7 +210,7 @@ func (c *memoryStore) List(_ context.Context, rs model.ResourceList, fs ...store
 		}
 	}
 
-	rs.SetTotal(uint64(len(records)))
+	rs.SetTotal(uint32(len(records)))
 
 	i := offset
 	for ; i < offset+pageSize && i < len(records); i++ {

--- a/pkg/plugins/resources/memory/store.go
+++ b/pkg/plugins/resources/memory/store.go
@@ -224,9 +224,7 @@ func (c *memoryStore) List(_ context.Context, rs model.ResourceList, fs ...store
 		if offset+pageSize < len(records) { // set new offset only if we did not reach the end of the collection
 			nextOffset = strconv.Itoa(offset + opts.PageSize)
 		}
-		rs.SetPagination(model.Pagination{
-			NextOffset: nextOffset,
-		})
+		rs.GetPagination().SetNextOffset(nextOffset)
 	}
 
 	rs.GetPagination().SetTotal(uint32(len(records)))

--- a/pkg/plugins/resources/memory/store.go
+++ b/pkg/plugins/resources/memory/store.go
@@ -210,8 +210,6 @@ func (c *memoryStore) List(_ context.Context, rs model.ResourceList, fs ...store
 		}
 	}
 
-	rs.SetTotal(uint32(len(records)))
-
 	i := offset
 	for ; i < offset+pageSize && i < len(records); i++ {
 		r := rs.NewItem()
@@ -230,6 +228,9 @@ func (c *memoryStore) List(_ context.Context, rs model.ResourceList, fs ...store
 			NextOffset: nextOffset,
 		})
 	}
+
+	rs.GetPagination().SetTotal(uint32(len(records)))
+
 	return nil
 }
 

--- a/pkg/plugins/resources/memory/store.go
+++ b/pkg/plugins/resources/memory/store.go
@@ -210,13 +210,16 @@ func (c *memoryStore) List(_ context.Context, rs model.ResourceList, fs ...store
 		}
 	}
 
-	for i := offset; i < offset+pageSize && i < len(records); i++ {
+	i := offset
+	for ; i < offset+pageSize && i < len(records); i++ {
 		r := rs.NewItem()
 		if err := c.unmarshalRecord(records[i], r); err != nil {
 			return err
 		}
 		_ = rs.AddItem(r)
 	}
+
+	rs.SetTotal(uint64(len(records)))
 
 	if paginateResults {
 		nextOffset := ""

--- a/pkg/plugins/resources/memory/store.go
+++ b/pkg/plugins/resources/memory/store.go
@@ -210,8 +210,7 @@ func (c *memoryStore) List(_ context.Context, rs model.ResourceList, fs ...store
 		}
 	}
 
-	i := offset
-	for ; i < offset+pageSize && i < len(records); i++ {
+	for i := offset; i < offset+pageSize && i < len(records); i++ {
 		r := rs.NewItem()
 		if err := c.unmarshalRecord(records[i], r); err != nil {
 			return err

--- a/pkg/plugins/resources/postgres/store.go
+++ b/pkg/plugins/resources/postgres/store.go
@@ -221,6 +221,12 @@ func (r *postgresResourceStore) List(_ context.Context, resources model.Resource
 		statement += fmt.Sprintf(" LIMIT %d OFFSET %d", opts.PageSize+1, offset) // ask for +1 to check if there are any elements left
 	}
 
+	total, err := r.countRows(string(resources.GetItemType()))
+	if err != nil {
+		return err
+	}
+	resources.SetTotal(uint64(total))
+
 	rows, err := r.db.Query(statement, statementArgs...)
 	if err != nil {
 		return errors.Wrapf(err, "failed to execute query: %s", statement)
@@ -239,13 +245,6 @@ func (r *postgresResourceStore) List(_ context.Context, resources model.Resource
 		}
 		items++
 	}
-
-	var total int
-	total, err = r.countRows(string(resources.GetItemType()))
-	if err != nil {
-		return err
-	}
-	resources.SetTotal(uint64(total))
 
 	if paginateResults {
 		nextOffset := ""

--- a/pkg/plugins/resources/postgres/store.go
+++ b/pkg/plugins/resources/postgres/store.go
@@ -225,7 +225,7 @@ func (r *postgresResourceStore) List(_ context.Context, resources model.Resource
 	if err != nil {
 		return err
 	}
-	resources.SetTotal(uint64(total))
+	resources.SetTotal(uint32(total))
 
 	rows, err := r.db.Query(statement, statementArgs...)
 	if err != nil {

--- a/pkg/plugins/resources/postgres/store.go
+++ b/pkg/plugins/resources/postgres/store.go
@@ -292,7 +292,6 @@ func (r *postgresResourceStore) countRows(resource, mesh string) (int, error) {
 		statement += fmt.Sprintf(" AND mesh=$%d", argsIndex)
 		statementArgs = append(statementArgs, mesh)
 	}
-	statement += " GROUP BY name,mesh ORDER BY name, mesh"
 
 	var count int
 	err := r.db.QueryRow(statement, statementArgs...).Scan(&count)

--- a/pkg/plugins/resources/postgres/store.go
+++ b/pkg/plugins/resources/postgres/store.go
@@ -221,12 +221,6 @@ func (r *postgresResourceStore) List(_ context.Context, resources model.Resource
 		statement += fmt.Sprintf(" LIMIT %d OFFSET %d", opts.PageSize+1, offset) // ask for +1 to check if there are any elements left
 	}
 
-	total, err := r.countRows(string(resources.GetItemType()), opts.Mesh)
-	if err != nil {
-		return err
-	}
-	resources.SetTotal(uint32(total))
-
 	rows, err := r.db.Query(statement, statementArgs...)
 	if err != nil {
 		return errors.Wrapf(err, "failed to execute query: %s", statement)
@@ -255,6 +249,13 @@ func (r *postgresResourceStore) List(_ context.Context, resources model.Resource
 			NextOffset: nextOffset,
 		})
 	}
+
+	total, err := r.countRows(string(resources.GetItemType()), opts.Mesh)
+	if err != nil {
+		return err
+	}
+	resources.GetPagination().SetTotal(uint32(total))
+
 	return nil
 }
 

--- a/pkg/plugins/resources/postgres/store.go
+++ b/pkg/plugins/resources/postgres/store.go
@@ -245,9 +245,7 @@ func (r *postgresResourceStore) List(_ context.Context, resources model.Resource
 		if items > opts.PageSize { // set new offset only if there is next page
 			nextOffset = strconv.Itoa(offset + opts.PageSize)
 		}
-		resources.SetPagination(model.Pagination{
-			NextOffset: nextOffset,
-		})
+		resources.GetPagination().SetNextOffset(nextOffset)
 	}
 
 	total, err := r.countRows(string(resources.GetItemType()), opts.Mesh)

--- a/pkg/plugins/resources/remote/testdata/list.json
+++ b/pkg/plugins/resources/remote/testdata/list.json
@@ -1,4 +1,5 @@
 {
+    "total": 2,
     "items": [
         {
             "type": "TrafficRoute",
@@ -17,6 +18,5 @@
             "modificationTime": "2019-07-17T16:05:36.995Z"
         }
     ],
-    "total": 2,
     "next": null
 }

--- a/pkg/plugins/resources/remote/testdata/list.json
+++ b/pkg/plugins/resources/remote/testdata/list.json
@@ -17,5 +17,6 @@
             "modificationTime": "2019-07-17T16:05:36.995Z"
         }
     ],
+    "total": 2,
     "next": null
 }

--- a/pkg/plugins/resources/remote/unmarshalling.go
+++ b/pkg/plugins/resources/remote/unmarshalling.go
@@ -76,6 +76,7 @@ func UnmarshalList(b []byte, rs model.ResourceList) error {
 		})
 		_ = rs.AddItem(r)
 	}
+	rs.SetTotal(rsr.ResourceList.Total)
 	if rsr.Next != nil {
 		uri, err := url.ParseRequestURI(*rsr.Next)
 		if err != nil {

--- a/pkg/plugins/resources/remote/unmarshalling.go
+++ b/pkg/plugins/resources/remote/unmarshalling.go
@@ -62,7 +62,6 @@ func UnmarshalList(b []byte, rs model.ResourceList) error {
 	if err := json.Unmarshal(b, rsr); err != nil {
 		return err
 	}
-	rs.GetPagination().SetTotal(rsr.ResourceList.Total)
 	for _, ri := range rsr.ResourceList.Items {
 		r := rs.NewItem()
 		if err := r.SetSpec(ri.Spec); err != nil {
@@ -91,5 +90,6 @@ func UnmarshalList(b []byte, rs model.ResourceList) error {
 			})
 		}
 	}
+	rs.GetPagination().SetTotal(rsr.ResourceList.Total)
 	return nil
 }

--- a/pkg/plugins/resources/remote/unmarshalling.go
+++ b/pkg/plugins/resources/remote/unmarshalling.go
@@ -85,9 +85,7 @@ func UnmarshalList(b []byte, rs model.ResourceList) error {
 		// we do not preserve here the size of the page, but since it is used in kumactl
 		// user will rerun command with the page size of his choice
 		if offset != "" {
-			rs.SetPagination(model.Pagination{
-				NextOffset: offset,
-			})
+			rs.GetPagination().SetNextOffset(offset)
 		}
 	}
 	rs.GetPagination().SetTotal(rsr.ResourceList.Total)

--- a/pkg/plugins/resources/remote/unmarshalling.go
+++ b/pkg/plugins/resources/remote/unmarshalling.go
@@ -62,6 +62,7 @@ func UnmarshalList(b []byte, rs model.ResourceList) error {
 	if err := json.Unmarshal(b, rsr); err != nil {
 		return err
 	}
+	rs.SetTotal(rsr.ResourceList.Total)
 	for _, ri := range rsr.ResourceList.Items {
 		r := rs.NewItem()
 		if err := r.SetSpec(ri.Spec); err != nil {
@@ -76,7 +77,6 @@ func UnmarshalList(b []byte, rs model.ResourceList) error {
 		})
 		_ = rs.AddItem(r)
 	}
-	rs.SetTotal(rsr.ResourceList.Total)
 	if rsr.Next != nil {
 		uri, err := url.ParseRequestURI(*rsr.Next)
 		if err != nil {

--- a/pkg/plugins/resources/remote/unmarshalling.go
+++ b/pkg/plugins/resources/remote/unmarshalling.go
@@ -62,7 +62,7 @@ func UnmarshalList(b []byte, rs model.ResourceList) error {
 	if err := json.Unmarshal(b, rsr); err != nil {
 		return err
 	}
-	rs.SetTotal(rsr.ResourceList.Total)
+	rs.GetPagination().SetTotal(rsr.ResourceList.Total)
 	for _, ri := range rsr.ResourceList.Items {
 		r := rs.NewItem()
 		if err := r.SetSpec(ri.Spec); err != nil {

--- a/pkg/test/resources/apis/sample/sample_types.go
+++ b/pkg/test/resources/apis/sample/sample_types.go
@@ -52,17 +52,9 @@ func (t *TrafficRouteResource) Validate() error {
 var _ model.ResourceList = &TrafficRouteResourceList{}
 
 type TrafficRouteResourceList struct {
-	Items      []*TrafficRouteResource
 	Total      uint64
+	Items      []*TrafficRouteResource
 	Pagination model.Pagination
-}
-
-func (l *TrafficRouteResourceList) GetItems() []model.Resource {
-	res := make([]model.Resource, len(l.Items))
-	for i, elem := range l.Items {
-		res[i] = elem
-	}
-	return res
 }
 
 func (l *TrafficRouteResourceList) GetTotal() uint64 {
@@ -71,6 +63,14 @@ func (l *TrafficRouteResourceList) GetTotal() uint64 {
 
 func (l *TrafficRouteResourceList) SetTotal(total uint64) {
 	l.Total = total
+}
+
+func (l *TrafficRouteResourceList) GetItems() []model.Resource {
+	res := make([]model.Resource, len(l.Items))
+	for i, elem := range l.Items {
+		res[i] = elem
+	}
+	return res
 }
 
 func (l *TrafficRouteResourceList) GetItemType() model.ResourceType {

--- a/pkg/test/resources/apis/sample/sample_types.go
+++ b/pkg/test/resources/apis/sample/sample_types.go
@@ -82,9 +82,6 @@ func (l *TrafficRouteResourceList) AddItem(r model.Resource) error {
 func (l *TrafficRouteResourceList) GetPagination() *model.Pagination {
 	return &l.Pagination
 }
-func (l *TrafficRouteResourceList) SetPagination(pagination model.Pagination) {
-	l.Pagination = pagination
-}
 
 func init() {
 	registry.RegisterType(&TrafficRouteResource{})

--- a/pkg/test/resources/apis/sample/sample_types.go
+++ b/pkg/test/resources/apis/sample/sample_types.go
@@ -53,6 +53,7 @@ var _ model.ResourceList = &TrafficRouteResourceList{}
 
 type TrafficRouteResourceList struct {
 	Items      []*TrafficRouteResource
+	Total      uint64
 	Pagination model.Pagination
 }
 
@@ -62,6 +63,14 @@ func (l *TrafficRouteResourceList) GetItems() []model.Resource {
 		res[i] = elem
 	}
 	return res
+}
+
+func (l *TrafficRouteResourceList) GetTotal() uint64 {
+	return l.Total
+}
+
+func (l *TrafficRouteResourceList) SetTotal(total uint64) {
+	l.Total = total
 }
 
 func (l *TrafficRouteResourceList) GetItemType() model.ResourceType {

--- a/pkg/test/resources/apis/sample/sample_types.go
+++ b/pkg/test/resources/apis/sample/sample_types.go
@@ -88,8 +88,8 @@ func (l *TrafficRouteResourceList) AddItem(r model.Resource) error {
 		return model.ErrorInvalidItemType((*TrafficRouteResource)(nil), r)
 	}
 }
-func (l *TrafficRouteResourceList) GetPagination() model.Pagination {
-	return l.Pagination
+func (l *TrafficRouteResourceList) GetPagination() *model.Pagination {
+	return &l.Pagination
 }
 func (l *TrafficRouteResourceList) SetPagination(pagination model.Pagination) {
 	l.Pagination = pagination

--- a/pkg/test/resources/apis/sample/sample_types.go
+++ b/pkg/test/resources/apis/sample/sample_types.go
@@ -52,17 +52,8 @@ func (t *TrafficRouteResource) Validate() error {
 var _ model.ResourceList = &TrafficRouteResourceList{}
 
 type TrafficRouteResourceList struct {
-	Total      uint32
 	Items      []*TrafficRouteResource
 	Pagination model.Pagination
-}
-
-func (l *TrafficRouteResourceList) GetTotal() uint32 {
-	return l.Total
-}
-
-func (l *TrafficRouteResourceList) SetTotal(total uint32) {
-	l.Total = total
 }
 
 func (l *TrafficRouteResourceList) GetItems() []model.Resource {

--- a/pkg/test/resources/apis/sample/sample_types.go
+++ b/pkg/test/resources/apis/sample/sample_types.go
@@ -52,16 +52,16 @@ func (t *TrafficRouteResource) Validate() error {
 var _ model.ResourceList = &TrafficRouteResourceList{}
 
 type TrafficRouteResourceList struct {
-	Total      uint64
+	Total      uint32
 	Items      []*TrafficRouteResource
 	Pagination model.Pagination
 }
 
-func (l *TrafficRouteResourceList) GetTotal() uint64 {
+func (l *TrafficRouteResourceList) GetTotal() uint32 {
 	return l.Total
 }
 
-func (l *TrafficRouteResourceList) SetTotal(total uint64) {
+func (l *TrafficRouteResourceList) SetTotal(total uint32) {
 	l.Total = total
 }
 

--- a/pkg/test/store/store_test_template.go
+++ b/pkg/test/store/store_test_template.go
@@ -286,6 +286,8 @@ func ExecuteStoreTests(
 			// then
 			Expect(err).ToNot(HaveOccurred())
 			// and
+			Expect(list.Pagination.Total).To(Equal(uint32(0)))
+			// and
 			Expect(list.Items).To(HaveLen(0))
 		})
 
@@ -301,6 +303,8 @@ func ExecuteStoreTests(
 
 			// then
 			Expect(err).ToNot(HaveOccurred())
+			// and
+			Expect(list.Pagination.Total).To(Equal(uint32(2)))
 			// and
 			Expect(list.Items).To(HaveLen(2))
 			// and
@@ -324,6 +328,8 @@ func ExecuteStoreTests(
 
 			// then
 			Expect(err).ToNot(HaveOccurred())
+			// and
+			Expect(list.Pagination.Total).To(Equal(uint32(0)))
 			// and
 			Expect(list.Items).To(HaveLen(0))
 		})
@@ -361,6 +367,7 @@ func ExecuteStoreTests(
 
 				// then
 				Expect(err).ToNot(HaveOccurred())
+				Expect(list.Pagination.Total).To(Equal(uint32(numOfResources)))
 				Expect(list.Pagination.NextOffset).To(BeEmpty())
 				Expect(list.Items).To(HaveLen(1))
 				resourceNames[list.Items[0].GetMeta().GetName()] = true
@@ -381,6 +388,7 @@ func ExecuteStoreTests(
 				err := s.List(context.Background(), &list, store.ListByMesh(mesh), store.ListByPage(5, ""))
 
 				// then
+				Expect(list.Pagination.Total).To(Equal(uint32(1)))
 				Expect(list.Items).To(HaveLen(1))
 				Expect(err).ToNot(HaveOccurred())
 				Expect(list.Pagination.NextOffset).To(BeEmpty())
@@ -395,6 +403,7 @@ func ExecuteStoreTests(
 				err := s.List(context.Background(), &list, store.ListByMesh(mesh), store.ListByPage(1, ""))
 
 				// then
+				Expect(list.Pagination.Total).To(Equal(uint32(1)))
 				Expect(list.Items).To(HaveLen(1))
 				Expect(err).ToNot(HaveOccurred())
 				Expect(list.Pagination.NextOffset).To(BeEmpty())
@@ -406,6 +415,7 @@ func ExecuteStoreTests(
 				err := s.List(context.Background(), &list, store.ListByMesh("unknown-mesh"), store.ListByPage(2, ""))
 
 				// then
+				Expect(list.Pagination.Total).To(Equal(uint32(0)))
 				Expect(list.Items).To(BeEmpty())
 				Expect(err).ToNot(HaveOccurred())
 				Expect(list.Pagination.NextOffset).To(BeEmpty())
@@ -417,6 +427,7 @@ func ExecuteStoreTests(
 				err := s.List(context.Background(), &list, store.ListByMesh("unknown-mesh"), store.ListByPage(2, "123invalidOffset"))
 
 				// then
+				Expect(list.Pagination.Total).To(Equal(uint32(0)))
 				Expect(err).To(Equal(store.ErrorInvalidOffset))
 			})
 		})


### PR DESCRIPTION
### Summary

When we fetch entities via the HTTP API (and therefore via the GUI and `kumactl`) we don't know what is the total number of sites for a particular resource stored in the Kuma control plane. Return a **total** count of items for each resource that works on both Universal and Kubernetes.

Adds a new `total` top-level property in the HTTP API responses, so they look like

```json
$ curl localhost:5681/meshes
{
 "total": 3,
 "items": [
  {
   "type": "Mesh",
   "name": "default",
   ...
  },
  {
   "type": "Mesh",
   "name": "default1",
   ...
  },
  {
   "type": "Mesh",
   "name": "default2",
   ...
  }
 ],
 "next": null
}

```

The implementation in all supported resource store mechanisms (memory, PostgreSQL and Kubernetes) is based on naive resource counting each time a List requests gets in. That can be optimized (cached?) for better scalability once Kuma has to handle huge amount of resources with multiple concurrent API requests happening. This optimisation is left for a follow-up PR.

### Full changelog

* feat(kuma-cp) add naive total implementation for k8s store
* fix(kuma-cp) 32 bits for Total should be enough
* chore(*) reorder to make Total on the top of the structure
* feat(kuma-cp) add support for total count in PostgreSQL store
* (http/feat/count_entities) fix(*) fix testing when totals introduced
* feat(kuma-cp) expand ResourceList interface


### Issues resolved

None
