### PR TITLE
feat(kuma-cp) dp sync tracker runs only one watchdog

### DIFF
--- a/pkg/core/xds/types.go
+++ b/pkg/core/xds/types.go
@@ -13,6 +13,9 @@ import (
 	envoy_core "github.com/envoyproxy/go-control-plane/envoy/api/v2/core"
 )
 
+// StreamID represents a stream opened by XDS
+type StreamID = int64
+
 type ProxyId struct {
 	Mesh string
 	Name string

--- a/pkg/xds/sync/dataplane_sync_tracker.go
+++ b/pkg/xds/sync/dataplane_sync_tracker.go
@@ -60,9 +60,9 @@ func (t *dataplaneSyncTracker) OnStreamClosed(streamID core_xds.StreamID) {
 	defer t.Unlock()
 
 	dp, hasAssociation := t.streamsAssociation[streamID]
-	delete(t.streamsAssociation, streamID)
-
 	if hasAssociation {
+		delete(t.streamsAssociation, streamID)
+
 		streams := t.dpStreams[dp]
 		delete(streams.activeStreams, streamID)
 		if len(streams.activeStreams) == 0 { // no stream is active, cancel watchdog

--- a/pkg/xds/sync/dataplane_sync_tracker_test.go
+++ b/pkg/xds/sync/dataplane_sync_tracker_test.go
@@ -3,7 +3,6 @@ package sync_test
 import (
 	"context"
 	"sync/atomic"
-	"time"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -165,22 +164,25 @@ var _ = Describe("Sync", func() {
 			Expect(err).ToNot(HaveOccurred())
 
 			// then only one watchdog is active
-			time.Sleep(50 * time.Millisecond) // wait for goroutines
-			Expect(atomic.LoadInt32(&activeWatchdogs)).To(Equal(int32(1)))
+			Eventually(func() int32 {
+				return atomic.LoadInt32(&activeWatchdogs)
+			}, "5s", "10ms").Should(Equal(int32(1)))
 
 			// when first stream is closed
 			tracker.OnStreamClosed(1)
 
 			// then watchdog is still active because other stream is opened
-			time.Sleep(50 * time.Millisecond) // wait for goroutines
-			Expect(atomic.LoadInt32(&activeWatchdogs)).To(Equal(int32(1)))
+			Eventually(func() int32 {
+				return atomic.LoadInt32(&activeWatchdogs)
+			}, "5s", "10ms").Should(Equal(int32(1)))
 
 			// when other stream is closed
 			tracker.OnStreamClosed(2)
 
 			// then no watchdog is stopped
-			time.Sleep(50 * time.Millisecond) // wait for goroutines
-			Expect(atomic.LoadInt32(&activeWatchdogs)).To(Equal(int32(0)))
+			Eventually(func() int32 {
+				return atomic.LoadInt32(&activeWatchdogs)
+			}, "5s", "10ms").Should(Equal(int32(0)))
 		})
 	})
 })


### PR DESCRIPTION
### Summary

With ADS the relation was 1 DP = 1 gRPC stream. With SDS that uses Dataplane Sync Tracker the relation is that 1 DP can open many streams. We want to start only one watchdog for DP so we need to which DP the stream belongs. When closing the stream we need to cancel watchdog only if DP has no streams left.