### PR TITLE
fix(kuma-cp) turn off transparent proxy for prometheus scraping

### DIFF
--- a/pkg/xds/generator/prometheus_endpoint_generator.go
+++ b/pkg/xds/generator/prometheus_endpoint_generator.go
@@ -70,7 +70,6 @@ func (g PrometheusEndpointGenerator) Generate(ctx xds_context.Context, proxy *co
 		Configure(envoy_listeners.InboundListener(prometheusListenerName, prometheusEndpointAddress, prometheusEndpoint.Port)).
 		Configure(envoy_listeners.FilterChain(envoy_listeners.NewFilterChainBuilder().
 			Configure(envoy_listeners.PrometheusEndpoint(prometheusListenerName, prometheusEndpoint.Path, envoyAdminClusterName)))).
-		Configure(envoy_listeners.TransparentProxying(proxy.Dataplane.Spec.Networking.GetTransparentProxying())).
 		Build()
 	if err != nil {
 		return nil, err

--- a/pkg/xds/generator/testdata/profile-source/4-envoy-config.golden.yaml
+++ b/pkg/xds/generator/testdata/profile-source/4-envoy-config.golden.yaml
@@ -22,8 +22,6 @@ resources:
         socketAddress:
           address: 0.0.0.0
           portValue: 1234
-      deprecatedV1:
-        bindToPort: false
       filterChains:
         - filters:
             - name: envoy.http_connection_manager


### PR DESCRIPTION
### Summary

Kuma could not scrape metrics from Gateway dataplane on K8S. The problem was that we were generating listeners with transparent proxy mode (bindToPort: false) but we do not enable transparent proxying on inbound connections with Gateways. The solution is to generate listeners without transparent proxy mode.