### PR TITLE
fix: fault injection regex

### DIFF
--- a/pkg/xds/envoy/listeners/fault_injection_configurer_test.go
+++ b/pkg/xds/envoy/listeners/fault_injection_configurer_test.go
@@ -68,7 +68,7 @@ var _ = Describe("FaultInjectionConfigurer", func() {
                       safeRegexMatch:
                         googleRe2: 
                           maxProgramSize: 500
-                        regex: '&tag1=[^&]*value1[,&].*&tag2=[^&]*value2[,&].*'
+                        regex: '.*&tag1=[^&]*value1[,&].*&tag2=[^&]*value2[,&].*'
                 - name: envoy.router
                 statPrefix: stats`,
 		}),
@@ -114,7 +114,7 @@ var _ = Describe("FaultInjectionConfigurer", func() {
                       safeRegexMatch:
                         googleRe2: 
                           maxProgramSize: 500
-                        regex: '(&tag1=[^&]*value1m1[,&].*&tag2=[^&]*value2m1[,&].*|&tag1=[^&]*value1m2[,&].*&tag2=[^&]*value2m2[,&].*)'
+                        regex: '(.*&tag1=[^&]*value1m1[,&].*&tag2=[^&]*value2m1[,&].*|.*&tag1=[^&]*value1m2[,&].*&tag2=[^&]*value2m2[,&].*)'
                 - name: envoy.router
                 statPrefix: stats`,
 		}),

--- a/pkg/xds/envoy/tags/match.go
+++ b/pkg/xds/envoy/tags/match.go
@@ -18,7 +18,7 @@ func MatchingRegex(tags mesh_proto.SingleValueTagSet) (re string) {
 			value = fmt.Sprintf(`[^&]*%s[,&]`, tags[key])
 		}
 		value = strings.ReplaceAll(value, ".", `\.`)
-		expr := keyIsEqual + value + `.*`
+		expr := `.*` + keyIsEqual + value + `.*`
 		re += expr
 	}
 	return

--- a/pkg/xds/envoy/tags/match.go
+++ b/pkg/xds/envoy/tags/match.go
@@ -18,9 +18,10 @@ func MatchingRegex(tags mesh_proto.SingleValueTagSet) (re string) {
 			value = fmt.Sprintf(`[^&]*%s[,&]`, tags[key])
 		}
 		value = strings.ReplaceAll(value, ".", `\.`)
-		expr := `.*` + keyIsEqual + value + `.*`
+		expr := keyIsEqual + value + `.*`
 		re += expr
 	}
+	re = `.*` + re
 	return
 }
 

--- a/pkg/xds/generator/testdata/inbound-proxy/3-envoy-config.golden.yaml
+++ b/pkg/xds/generator/testdata/inbound-proxy/3-envoy-config.golden.yaml
@@ -53,7 +53,7 @@ resources:
                           safeRegexMatch:
                             googleRe2:
                               maxProgramSize: 500
-                            regex: '&service=[^&]*frontend[,&].*'
+                            regex: '.*&service=[^&]*frontend[,&].*'
                   - name: envoy.router
                 routeConfig:
                   name: inbound:backend1

--- a/pkg/xds/generator/testdata/inbound-proxy/4-envoy-config.golden.yaml
+++ b/pkg/xds/generator/testdata/inbound-proxy/4-envoy-config.golden.yaml
@@ -55,7 +55,7 @@ resources:
                           safeRegexMatch:
                             googleRe2:
                               maxProgramSize: 500
-                            regex: '&service=[^&]*frontend[,&].*'
+                            regex: '.*&service=[^&]*frontend[,&].*'
                   - name: envoy.router
                 routeConfig:
                   name: inbound:backend1


### PR DESCRIPTION
### Summary

I thought the problem in envoy escaping of dot in regex. But escaping happens only for showing config_dump. The real problem was in the way safe_regex works. It checks that the whole header matches regex (not just its part).
So I updated regex and tests.
