### PR TITLE
feat(kuma-cp) block retrieving secrets from another mesh

### DIFF
--- a/pkg/plugins/secrets/k8s/store.go
+++ b/pkg/plugins/secrets/k8s/store.go
@@ -120,6 +120,9 @@ func (s *KubernetesStore) Get(ctx context.Context, r *secret_model.SecretResourc
 		return errors.Wrap(err, "failed to convert k8s Secret into core counterpart")
 	}
 	if r.GetMeta().GetMesh() != opts.Mesh {
+		if err := r.SetSpec(&system_proto.Secret{}); err != nil {
+			return err
+		}
 		return core_store.ErrorResourceNotFound(r.GetType(), opts.Name, opts.Mesh)
 	}
 	return nil

--- a/pkg/plugins/secrets/k8s/store.go
+++ b/pkg/plugins/secrets/k8s/store.go
@@ -119,6 +119,9 @@ func (s *KubernetesStore) Get(ctx context.Context, r *secret_model.SecretResourc
 	if err := s.converter.ToCoreResource(secret, r); err != nil {
 		return errors.Wrap(err, "failed to convert k8s Secret into core counterpart")
 	}
+	if r.GetMeta().GetMesh() != opts.Mesh {
+		return core_store.ErrorResourceNotFound(r.GetType(), opts.Name, opts.Mesh)
+	}
 	return nil
 }
 func (s *KubernetesStore) List(ctx context.Context, rs *secret_model.SecretResourceList, fs ...core_store.ListOptionsFunc) error {

--- a/pkg/plugins/secrets/k8s/store_test.go
+++ b/pkg/plugins/secrets/k8s/store_test.go
@@ -295,7 +295,7 @@ var _ = Describe("KubernetesStore", func() {
 			Expect(err).To(MatchError(store.ErrorResourceNotFound(core_system.SecretType, name, "demo")))
 		})
 
-		It("should return an existing resource", func() {
+		It("should return an existing resource with explicit mesh label", func() {
 			// setup
 			expected := backend.ParseYAML(fmt.Sprintf(`
             apiVersion: v1
@@ -324,6 +324,61 @@ var _ = Describe("KubernetesStore", func() {
 			Expect(actual.Meta.GetMesh()).To(Equal("demo"))
 			// and
 			Expect(actual.Spec.Data.Value).To(Equal([]byte("example")))
+		})
+
+		It("should return an existing resource with implicit default mesh", func() {
+			// setup
+			expected := backend.ParseYAML(fmt.Sprintf(`
+            apiVersion: v1
+            kind: Secret
+            type: system.kuma.io/secret
+            metadata:
+              namespace: %s
+              name: %s
+            data:
+              value: ZXhhbXBsZQ== # base64(example)
+`, ns, name))
+			backend.Create(expected)
+
+			// given
+			actual := &secret_model.SecretResource{}
+
+			// when
+			err := s.Get(context.Background(), actual, store.GetByKey(name, "default"))
+
+			// then
+			Expect(err).ToNot(HaveOccurred())
+			// and
+			Expect(actual.Meta.GetName()).To(Equal(name))
+			Expect(actual.Meta.GetMesh()).To(Equal("default"))
+			// and
+			Expect(actual.Spec.Data.Value).To(Equal([]byte("example")))
+		})
+
+		It("should return an error if resource is in another mesh", func() {
+			// setup
+			expected := backend.ParseYAML(fmt.Sprintf(`
+            apiVersion: v1
+            kind: Secret
+            type: system.kuma.io/secret
+            metadata:
+              namespace: %s
+              name: %s
+              labels:
+                kuma.io/mesh: demo
+            data:
+              value: ZXhhbXBsZQ== # base64(example)
+`, ns, name))
+			backend.Create(expected)
+
+			// given
+			actual := &secret_model.SecretResource{}
+
+			// when
+			err := s.Get(context.Background(), actual, store.GetByKey(name, "another-mesh"))
+
+			// then
+			Expect(err).To(MatchError(store.ErrorResourceNotFound(core_system.SecretType, name, "another-mesh")))
 		})
 	})
 

--- a/pkg/plugins/secrets/k8s/store_test.go
+++ b/pkg/plugins/secrets/k8s/store_test.go
@@ -379,6 +379,7 @@ var _ = Describe("KubernetesStore", func() {
 
 			// then
 			Expect(err).To(MatchError(store.ErrorResourceNotFound(core_system.SecretType, name, "another-mesh")))
+			Expect(actual.Spec.GetData().GetValue()).To(BeEmpty())
 		})
 	})
 


### PR DESCRIPTION
### Summary

When retrieving Secret from K8S we need to check if mesh matches manually, otherwise Secrets won't be Mesh scoped.

I also test case that Secret without explicit mesh label works (just in case)