### PR TITLE
feat: limit number subscription

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -31,7 +31,6 @@ require (
 	github.com/prometheus/common v0.9.1
 	github.com/prometheus/prometheus v0.0.0-00010101000000-000000000000
 	github.com/shurcooL/httpfs v0.0.0-20190707220628-8d4bc4ba7749
-	github.com/shurcooL/vfsgen v0.0.0-20181202132449-6a9ea43bcacd // indirect
 	github.com/spf13/cobra v1.0.0
 	github.com/spiffe/go-spiffe v0.0.0-20190820222348-6adcf1eecbcc
 	github.com/spiffe/spire v0.10.0

--- a/go.sum
+++ b/go.sum
@@ -472,8 +472,6 @@ github.com/shopspring/decimal v0.0.0-20180709203117-cd690d0c9e24/go.mod h1:M+9Nz
 github.com/shurcooL/httpfs v0.0.0-20190707220628-8d4bc4ba7749 h1:bUGsEnyNbVPw06Bs80sCeARAlK8lhwqGyi6UT8ymuGk=
 github.com/shurcooL/httpfs v0.0.0-20190707220628-8d4bc4ba7749/go.mod h1:ZY1cvUeJuFPAdZ/B6v7RHavJWZn2YPVFQ1OSXhCGOkg=
 github.com/shurcooL/sanitized_anchor_name v1.0.0/go.mod h1:1NzhyTcUVG4SuEtjjoZeVRXNmyL/1OwPU0+IJeTBvfc=
-github.com/shurcooL/vfsgen v0.0.0-20181202132449-6a9ea43bcacd h1:ug7PpSOB5RBPK1Kg6qskGBoP3Vnj/aNYFTznWvlkGo0=
-github.com/shurcooL/vfsgen v0.0.0-20181202132449-6a9ea43bcacd/go.mod h1:TrYk7fJVaAttu97ZZKrO9UbRa8izdowaMIZcxYMbVaw=
 github.com/sirupsen/logrus v1.2.0/go.mod h1:LxeOpSwHxABJmUn/MG1IvRgCAasNZTLOkJPxbbu5VWo=
 github.com/sirupsen/logrus v1.4.1/go.mod h1:ni0Sbl8bgC9z8RoU9G6nDWqqs/fq4eDPysMBDgk/93Q=
 github.com/sirupsen/logrus v1.4.2 h1:SPIRibHv4MatM3XXNO2BJeFLZwZ2LvZgfQ5+UNI2im4=

--- a/pkg/api-server/config_ws_test.go
+++ b/pkg/api-server/config_ws_test.go
@@ -120,6 +120,12 @@ var _ = Describe("Config WS", func() {
             "port": 5683,
             "apiServerUrl": ""
           },
+          "metrics": {
+            "dataplane": {
+              "enabled": true,
+              "subscriptionLimit": 10
+            }
+          },
           "monitoringAssignmentServer": {
             "assignmentRefreshInterval": "1s",
             "grpcPort": 5676

--- a/pkg/config/app/kuma-cp/kuma-cp.defaults.yaml
+++ b/pkg/config/app/kuma-cp/kuma-cp.defaults.yaml
@@ -220,6 +220,14 @@ defaults:
     type: Mesh
     name: default
 
+# Metrics configuration
+metrics:
+  dataplane:
+    # Enables collecting metrics from Dataplane
+    enabled: true
+    # How many latest subscriptions will be stored in DataplaneInsight object, if equals 0 then unlimited
+    subscriptionLimit: 10
+
 # Reports configuration
 reports:
   # If true then usage stats will be reported

--- a/pkg/core/bootstrap/bootstrap.go
+++ b/pkg/core/bootstrap/bootstrap.go
@@ -242,7 +242,7 @@ func initializeResourceManager(builder *core_runtime.Builder) {
 	meshManager := mesh_managers.NewMeshManager(builder.ResourceStore(), customizableManager, builder.SecretManager(), builder.CaManagers(), registry.Global(), validator)
 	customManagers[mesh.MeshType] = meshManager
 
-	dpInsightManager := dataplaneinsight.NewDataplaneInsightManager(builder.ResourceStore(), customizableManager)
+	dpInsightManager := dataplaneinsight.NewDataplaneInsightManager(builder.ResourceStore(), builder.Config().Metrics.Dataplane)
 	customManagers[mesh.DataplaneInsightType] = dpInsightManager
 
 	builder.WithResourceManager(customizableManager)

--- a/pkg/core/managers/apis/dataplaneinsight/dataplane_insight_manager.go
+++ b/pkg/core/managers/apis/dataplaneinsight/dataplane_insight_manager.go
@@ -2,6 +2,7 @@ package dataplaneinsight
 
 import (
 	"context"
+	kuma_cp "github.com/Kong/kuma/pkg/config/app/kuma-cp"
 
 	"github.com/Kong/kuma/pkg/core"
 
@@ -11,22 +12,18 @@ import (
 	core_store "github.com/Kong/kuma/pkg/core/resources/store"
 )
 
-func NewDataplaneInsightManager(
-	store core_store.ResourceStore,
-	otherManagers core_manager.ResourceManager,
-) core_manager.ResourceManager {
+func NewDataplaneInsightManager(store core_store.ResourceStore, config *kuma_cp.DataplaneMetrics) core_manager.ResourceManager {
 	return &dataplaneInsightManager{
 		ResourceManager: core_manager.NewResourceManager(store),
 		store:           store,
-		otherManagers:   otherManagers,
+		config:          config,
 	}
 }
 
 type dataplaneInsightManager struct {
 	core_manager.ResourceManager
-
-	store         core_store.ResourceStore
-	otherManagers core_manager.ResourceManager
+	store  core_store.ResourceStore
+	config *kuma_cp.DataplaneMetrics
 }
 
 func (m *dataplaneInsightManager) Create(ctx context.Context, resource core_model.Resource, fs ...core_store.CreateOptionsFunc) error {
@@ -35,9 +32,31 @@ func (m *dataplaneInsightManager) Create(ctx context.Context, resource core_mode
 	}
 	opts := core_store.NewCreateOptions(fs...)
 
+	m.limitSubscription(resource.(*core_mesh.DataplaneInsightResource))
+
 	dp := core_mesh.DataplaneResource{}
 	if err := m.store.Get(ctx, &dp, core_store.GetByKey(opts.Name, opts.Mesh)); err != nil {
 		return err
 	}
 	return m.store.Create(ctx, resource, append(fs, core_store.CreatedAt(core.Now()), core_store.CreateWithOwner(&dp))...)
+}
+
+func (m *dataplaneInsightManager) Update(ctx context.Context, resource core_model.Resource, fs ...core_store.UpdateOptionsFunc) error {
+	m.limitSubscription(resource.(*core_mesh.DataplaneInsightResource))
+	return m.ResourceManager.Update(ctx, resource, fs...)
+}
+
+func (m *dataplaneInsightManager) limitSubscription(dpInsight *core_mesh.DataplaneInsightResource) {
+	if !m.config.Enabled {
+		dpInsight.Spec.Subscriptions = nil
+		return
+	}
+	if m.config.SubscriptionLimit == 0 {
+		return
+	}
+	if len(dpInsight.Spec.Subscriptions) <= m.config.SubscriptionLimit {
+		return
+	}
+	s := dpInsight.Spec.Subscriptions
+	dpInsight.Spec.Subscriptions = s[len(s)-m.config.SubscriptionLimit:]
 }

--- a/pkg/core/managers/apis/dataplaneinsight/dataplane_insight_manager.go
+++ b/pkg/core/managers/apis/dataplaneinsight/dataplane_insight_manager.go
@@ -2,6 +2,7 @@ package dataplaneinsight
 
 import (
 	"context"
+
 	kuma_cp "github.com/Kong/kuma/pkg/config/app/kuma-cp"
 
 	"github.com/Kong/kuma/pkg/core"

--- a/pkg/core/managers/apis/dataplaneinsight/dataplane_insight_manager_suit_test.go
+++ b/pkg/core/managers/apis/dataplaneinsight/dataplane_insight_manager_suit_test.go
@@ -1,0 +1,12 @@
+package dataplaneinsight_test
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"testing"
+)
+
+func TestDataplainInsightManaget(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Mesh Manager Suite")
+}

--- a/pkg/core/managers/apis/dataplaneinsight/dataplane_insight_manager_suit_test.go
+++ b/pkg/core/managers/apis/dataplaneinsight/dataplane_insight_manager_suit_test.go
@@ -1,9 +1,10 @@
 package dataplaneinsight_test
 
 import (
+	"testing"
+
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
-	"testing"
 )
 
 func TestDataplainInsightManaget(t *testing.T) {

--- a/pkg/core/managers/apis/dataplaneinsight/dataplane_insight_manager_test.go
+++ b/pkg/core/managers/apis/dataplaneinsight/dataplane_insight_manager_test.go
@@ -3,14 +3,16 @@ package dataplaneinsight_test
 import (
 	"context"
 	"fmt"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
 	mesh_proto "github.com/Kong/kuma/api/mesh/v1alpha1"
 	kuma_cp "github.com/Kong/kuma/pkg/config/app/kuma-cp"
 	"github.com/Kong/kuma/pkg/core/managers/apis/dataplaneinsight"
 	mesh_core "github.com/Kong/kuma/pkg/core/resources/apis/mesh"
 	"github.com/Kong/kuma/pkg/core/resources/store"
 	"github.com/Kong/kuma/pkg/plugins/resources/memory"
-	. "github.com/onsi/ginkgo"
-	. "github.com/onsi/gomega"
 )
 
 var _ = Describe("DataplaneInsight Manager", func() {

--- a/pkg/core/managers/apis/dataplaneinsight/dataplane_insight_manager_test.go
+++ b/pkg/core/managers/apis/dataplaneinsight/dataplane_insight_manager_test.go
@@ -1,0 +1,82 @@
+package dataplaneinsight_test
+
+import (
+	"context"
+	"fmt"
+	mesh_proto "github.com/Kong/kuma/api/mesh/v1alpha1"
+	kuma_cp "github.com/Kong/kuma/pkg/config/app/kuma-cp"
+	"github.com/Kong/kuma/pkg/core/managers/apis/dataplaneinsight"
+	mesh_core "github.com/Kong/kuma/pkg/core/resources/apis/mesh"
+	"github.com/Kong/kuma/pkg/core/resources/store"
+	"github.com/Kong/kuma/pkg/plugins/resources/memory"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("DataplaneInsight Manager", func() {
+
+	It("should limit the number of subscription", func() {
+		// setup
+		s := memory.NewStore()
+		cfg := &kuma_cp.DataplaneMetrics{
+			Enabled:           true,
+			SubscriptionLimit: 3,
+		}
+		manager := dataplaneinsight.NewDataplaneInsightManager(s, cfg)
+
+		err := s.Create(context.Background(), &mesh_core.DataplaneResource{}, store.CreateByKey("di1", "default"))
+		Expect(err).ToNot(HaveOccurred())
+
+		input := mesh_core.DataplaneInsightResource{}
+		for i := 0; i < 10; i++ {
+			input.Spec.Subscriptions = append(input.Spec.Subscriptions, &mesh_proto.DiscoverySubscription{
+				Id: fmt.Sprintf("%d", i),
+			})
+		}
+
+		// when
+		err = manager.Create(context.Background(), &input, store.CreateByKey("di1", "default"))
+		Expect(err).ToNot(HaveOccurred())
+
+		actual := mesh_core.DataplaneInsightResource{}
+		err = s.Get(context.Background(), &actual, store.GetByKey("di1", "default"))
+		Expect(err).ToNot(HaveOccurred())
+
+		// then
+		Expect(actual.Spec.Subscriptions).To(HaveLen(3))
+		Expect(actual.Spec.Subscriptions[0].Id).To(Equal("7"))
+		Expect(actual.Spec.Subscriptions[1].Id).To(Equal("8"))
+		Expect(actual.Spec.Subscriptions[2].Id).To(Equal("9"))
+	})
+
+	It("should cleanup subscriptions if disabled", func() {
+		// setup
+		s := memory.NewStore()
+		cfg := &kuma_cp.DataplaneMetrics{
+			Enabled: false,
+		}
+		manager := dataplaneinsight.NewDataplaneInsightManager(s, cfg)
+
+		err := s.Create(context.Background(), &mesh_core.DataplaneResource{}, store.CreateByKey("di1", "default"))
+		Expect(err).ToNot(HaveOccurred())
+
+		input := mesh_core.DataplaneInsightResource{}
+		for i := 0; i < 10; i++ {
+			input.Spec.Subscriptions = append(input.Spec.Subscriptions, &mesh_proto.DiscoverySubscription{
+				Id: fmt.Sprintf("%d", i),
+			})
+		}
+
+		// when
+		err = manager.Create(context.Background(), &input, store.CreateByKey("di1", "default"))
+		Expect(err).ToNot(HaveOccurred())
+
+		actual := mesh_core.DataplaneInsightResource{}
+		err = s.Get(context.Background(), &actual, store.GetByKey("di1", "default"))
+		Expect(err).ToNot(HaveOccurred())
+
+		// then
+		Expect(actual.Spec.Subscriptions).To(HaveLen(0))
+		Expect(actual.Spec.Subscriptions).To(BeNil())
+	})
+})


### PR DESCRIPTION
### Summary

Today we don't limit the number of subscriptions that could be stored in DataplaneInsight and there is no way to disable it. 
This PR introduces the ability to configure that functionality. 
Here is new config section:

```json
"metrics": {
  "dataplane": {
     "enabled": true,
     "subscriptionLimit": 10
  }
}
```

Note: `Enable` flag works quite naive and straightforward - it doesn't prevent `dataplaneInsightSink` from Start, just cut off all subscriptions before adding them to storage. That was the simplest way to implement, but if needed I can provide full fair `Enable` support