### PR TITLE
fix(kuma-cp) allow slash validation so standard K8S tags are supported

### DIFF
--- a/pkg/core/resources/apis/mesh/dataplane_validator.go
+++ b/pkg/core/resources/apis/mesh/dataplane_validator.go
@@ -141,7 +141,7 @@ func validateTags(tags map[string]string) validators.ValidationError {
 			result.AddViolationAt(validators.RootedAt("tags").Key(name), `tag value cannot be empty`)
 		}
 		if !tagNameCharacterSet.MatchString(name) {
-			result.AddViolationAt(validators.RootedAt("tags").Key(name), `tag name must consist of alphanumeric characters, dots, dashes and underscores`)
+			result.AddViolationAt(validators.RootedAt("tags").Key(name), `tag name must consist of alphanumeric characters, dots, dashes, slashes and underscores`)
 		}
 		if !tagValueCharacterSet.MatchString(value) {
 			result.AddViolationAt(validators.RootedAt("tags").Key(name), `tag value must consist of alphanumeric characters, dots, dashes and underscores`)

--- a/pkg/core/resources/apis/mesh/dataplane_validator_test.go
+++ b/pkg/core/resources/apis/mesh/dataplane_validator_test.go
@@ -100,7 +100,7 @@ var _ = Describe("Dataplane", func() {
                 tags:
                   service: backend
                   version: "1"
-                  valid: abc.0123-789.under_score:90
+                  kuma.io/valid: abc.0123-789.under_score:90
               outbound:
                 - port: 3333
                   service: redis`,
@@ -589,7 +589,7 @@ var _ = Describe("Dataplane", func() {
 			expected: `
                 violations:
                 - field: networking.inbound[0].tags["inv@lidT/gN%me"]
-                  message: tag name must consist of alphanumeric characters, dots, dashes and underscores`,
+                  message: tag name must consist of alphanumeric characters, dots, dashes, slashes and underscores`,
 		}),
 		Entry("networking.inbound: tag value with invalid characters", testCase{
 			dataplane: `

--- a/pkg/core/resources/apis/mesh/fault_injection_validator_test.go
+++ b/pkg/core/resources/apis/mesh/fault_injection_validator_test.go
@@ -37,7 +37,7 @@ var _ = Describe("FaultInjection", func() {
                     service: backend
                     protocol: http
                     region: eu
-                    valid: abcd.123-456.under_score_.:80
+                    kuma.io/valid: abcd.123-456.under_score_.:80
                 conf:
                   delay:
                     percentage: 50
@@ -254,9 +254,9 @@ var _ = Describe("FaultInjection", func() {
 				expected: `
                violations:
                - field: sources[0].match["invalidTag"]
-                 message: tag value must consist of alphanumeric characters, dots, dashes and underscores or be "*"
+                 message: tag value must consist of alphanumeric characters, dots, dashes, slashes and underscores or be "*"
                - field: destinations[0].match["invalidTag"]
-                 message: tag value must consist of alphanumeric characters, dots, dashes and underscores or be "*"`}),
+                 message: tag value must consist of alphanumeric characters, dots, dashes, slashes and underscores or be "*"`}),
 			Entry("tag name: invalid character set", testCase{
 				faultInjection: `
                 sources:
@@ -276,9 +276,9 @@ var _ = Describe("FaultInjection", func() {
 				expected: `
                violations:
                - field: sources[0].match["inv@lidT@g#"]
-                 message: tag name must consist of alphanumeric characters, dots, dashes and underscores
+                 message: tag name must consist of alphanumeric characters, dots, dashes, slashes and underscores
                - field: destinations[0].match["inv@lidT@g#"]
-                 message: tag name must consist of alphanumeric characters, dots, dashes and underscores`}),
+                 message: tag name must consist of alphanumeric characters, dots, dashes, slashes and underscores`}),
 		)
 	})
 })

--- a/pkg/core/resources/apis/mesh/validators.go
+++ b/pkg/core/resources/apis/mesh/validators.go
@@ -30,9 +30,9 @@ type ValidateSelectorsOpts struct {
 	RequireAtLeastOneSelector bool
 }
 
-var tagNameCharacterSet = regexp.MustCompile(`^[a-zA-Z0-9\.\-_:]*$`)
+var tagNameCharacterSet = regexp.MustCompile(`^[a-zA-Z0-9\.\-_:/]*$`)
 var tagValueCharacterSet = regexp.MustCompile(`^[a-zA-Z0-9\.\-_:]*$`)
-var selectorCharacterSet = regexp.MustCompile(`^([a-zA-Z0-9\.\-_:]*|\*)$`)
+var selectorCharacterSet = regexp.MustCompile(`^([a-zA-Z0-9\.\-_:/]*|\*)$`)
 
 func ValidateSelectors(path validators.PathBuilder, sources []*mesh_proto.Selector, opts ValidateSelectorsOpts) (err validators.ValidationError) {
 	if opts.RequireAtLeastOneSelector && len(sources) == 0 {
@@ -56,7 +56,7 @@ func ValidateSelector(path validators.PathBuilder, selector map[string]string, o
 			err.AddViolationAt(path, "tag name must be non-empty")
 		}
 		if !tagNameCharacterSet.MatchString(key) {
-			err.AddViolationAt(path.Key(key), `tag name must consist of alphanumeric characters, dots, dashes and underscores`)
+			err.AddViolationAt(path.Key(key), `tag name must consist of alphanumeric characters, dots, dashes, slashes and underscores`)
 		}
 		for _, validate := range opts.ExtraTagKeyValidators {
 			err.Add(validate(path, key))
@@ -67,7 +67,7 @@ func ValidateSelector(path validators.PathBuilder, selector map[string]string, o
 			err.AddViolationAt(path.Key(key), "tag value must be non-empty")
 		}
 		if !selectorCharacterSet.MatchString(value) {
-			err.AddViolationAt(path.Key(key), `tag value must consist of alphanumeric characters, dots, dashes and underscores or be "*"`)
+			err.AddViolationAt(path.Key(key), `tag value must consist of alphanumeric characters, dots, dashes, slashes and underscores or be "*"`)
 		}
 		for _, validate := range opts.ExtraTagValueValidators {
 			err.Add(validate(path, key, value))


### PR DESCRIPTION
### Summary

Allow slash validation so standard K8S tags are supported

### Issues resolved

Fix #754
