### PR TITLE
feat(kuma-cp): Ingress Reconcile

### DIFF
--- a/pkg/xds/server/components_test.go
+++ b/pkg/xds/server/components_test.go
@@ -61,7 +61,7 @@ var _ = Describe("Components", func() {
 			reconciler := eventSnapshotReconciler{}
 			reconciler.events = make(chan event)
 			// and
-			tracker, err := DefaultDataplaneSyncTracker(runtime, &reconciler, NewDataplaneMetadataTracker())
+			tracker, err := DefaultDataplaneSyncTracker(runtime, &reconciler, NewIngressReconciler(runtime.ResourceManager()), NewDataplaneMetadataTracker())
 			Expect(err).ToNot(HaveOccurred())
 
 			// given

--- a/pkg/xds/server/ingress_reconcile.go
+++ b/pkg/xds/server/ingress_reconcile.go
@@ -1,0 +1,122 @@
+package server
+
+import (
+	"context"
+	"reflect"
+
+	"github.com/pkg/errors"
+
+	mesh_proto "github.com/Kong/kuma/api/mesh/v1alpha1"
+	"github.com/Kong/kuma/pkg/core"
+	core_mesh "github.com/Kong/kuma/pkg/core/resources/apis/mesh"
+	"github.com/Kong/kuma/pkg/core/resources/manager"
+	core_model "github.com/Kong/kuma/pkg/core/resources/model"
+	"github.com/Kong/kuma/pkg/core/resources/store"
+)
+
+var (
+	ingressLog = core.Log.WithName("ingress-reconcile")
+)
+
+func NewIngressReconciler(resourceManager manager.ResourceManager) *IngressReconciler {
+	return &IngressReconciler{
+		resourceManager: resourceManager,
+		lastUsedPort:    10000,
+	}
+}
+
+type IngressReconciler struct {
+	resourceManager manager.ResourceManager
+	lastUsedPort    uint32
+}
+
+func (r *IngressReconciler) Reconcile(dataplaneId core_model.ResourceKey) error {
+	ctx := context.Background()
+	var dp core_mesh.DataplaneResource
+	if err := r.resourceManager.Get(ctx, &dp, store.GetBy(dataplaneId)); err != nil {
+		if store.IsResourceNotFound(err) {
+			ingressLog.V(1).Info("Dataplane not found.", "dataplaneId", dataplaneId)
+			return nil
+		}
+		return err
+	}
+
+	if dp.Spec.GetNetworking().GetIngress() == nil {
+		return errors.Errorf("reconciliation loop works only for Ingress Dataplane")
+	}
+
+	meshes, err := r.getMeshes(ctx)
+	if err != nil {
+		return err
+	}
+	others, err := r.getDataplanes(ctx, meshes)
+	if err != nil {
+		return err
+	}
+
+	dp.Spec.Networking.Inbound = r.generateInbounds(others, dp.Spec.Networking.Inbound)
+	if err := r.resourceManager.Update(ctx, &dp); err != nil {
+		return err
+	}
+	return nil
+}
+
+type inboundSet []*mesh_proto.Dataplane_Networking_Inbound
+
+func (set inboundSet) getBy(tags map[string]string) *mesh_proto.Dataplane_Networking_Inbound {
+	for _, in := range set {
+		if reflect.DeepEqual(in.Tags, tags) {
+			return in
+		}
+	}
+	return nil
+}
+
+func (r *IngressReconciler) generatePort() uint32 {
+	r.lastUsedPort++
+	return r.lastUsedPort
+}
+
+func (r *IngressReconciler) generateInbounds(others []*core_mesh.DataplaneResource, old []*mesh_proto.Dataplane_Networking_Inbound) []*mesh_proto.Dataplane_Networking_Inbound {
+	inbounds := make([]*mesh_proto.Dataplane_Networking_Inbound, 0, len(others))
+	for _, dp := range others {
+		for _, dpInbound := range dp.Spec.GetNetworking().GetInbound() {
+			if dup := inboundSet(inbounds).getBy(dpInbound.GetTags()); dup != nil {
+				continue
+			}
+			var port uint32
+			if prev := inboundSet(old).getBy(dpInbound.GetTags()); prev != nil {
+				port = prev.Port
+			} else {
+				port = r.generatePort()
+			}
+
+			inbounds = append(inbounds, &mesh_proto.Dataplane_Networking_Inbound{
+				Port: port, //  picked automatically
+				Tags: dpInbound.GetTags(),
+			})
+		}
+	}
+	return inbounds
+}
+
+func (r *IngressReconciler) getMeshes(ctx context.Context) ([]*core_mesh.MeshResource, error) {
+	meshList := &core_mesh.MeshResourceList{}
+	if err := r.resourceManager.List(ctx, meshList); err != nil {
+		return nil, err
+	}
+
+	return meshList.Items, nil
+}
+
+func (r *IngressReconciler) getDataplanes(ctx context.Context, meshes []*core_mesh.MeshResource) ([]*core_mesh.DataplaneResource, error) {
+	dataplanes := make([]*core_mesh.DataplaneResource, 0)
+	for _, mesh := range meshes {
+		dataplaneList := &core_mesh.DataplaneResourceList{}
+		if err := r.resourceManager.List(ctx, dataplaneList, store.ListByMesh(mesh.Meta.GetName())); err != nil {
+			return nil, err
+		}
+		dataplanes = append(dataplanes, dataplaneList.Items...)
+	}
+	return dataplanes, nil
+}

--- a/pkg/xds/server/ingress_reconcile.go
+++ b/pkg/xds/server/ingress_reconcile.go
@@ -80,6 +80,9 @@ func (r *IngressReconciler) generatePort() uint32 {
 func (r *IngressReconciler) generateInbounds(others []*core_mesh.DataplaneResource, old []*mesh_proto.Dataplane_Networking_Inbound) []*mesh_proto.Dataplane_Networking_Inbound {
 	inbounds := make([]*mesh_proto.Dataplane_Networking_Inbound, 0, len(others))
 	for _, dp := range others {
+		if dp.Spec.GetNetworking().GetIngress() != nil {
+			continue
+		}
 		for _, dpInbound := range dp.Spec.GetNetworking().GetInbound() {
 			if dup := inboundSet(inbounds).getBy(dpInbound.GetTags()); dup != nil {
 				continue

--- a/pkg/xds/server/ingress_reconcile_test.go
+++ b/pkg/xds/server/ingress_reconcile_test.go
@@ -1,0 +1,215 @@
+package server_test
+
+import (
+	"context"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	mesh_proto "github.com/Kong/kuma/api/mesh/v1alpha1"
+	core_mesh "github.com/Kong/kuma/pkg/core/resources/apis/mesh"
+	core_manager "github.com/Kong/kuma/pkg/core/resources/manager"
+	"github.com/Kong/kuma/pkg/core/resources/model"
+	"github.com/Kong/kuma/pkg/core/resources/store"
+	"github.com/Kong/kuma/pkg/plugins/resources/memory"
+	util_proto "github.com/Kong/kuma/pkg/util/proto"
+	"github.com/Kong/kuma/pkg/xds/server"
+)
+
+var _ = Describe("Ingress Reconciler", func() {
+
+	dataplane1 := mesh_proto.Dataplane{
+		Networking: &mesh_proto.Dataplane_Networking{
+			Address: "1.1.1.2",
+			Inbound: []*mesh_proto.Dataplane_Networking_Inbound{
+				{
+					Port: 8080,
+					Tags: map[string]string{
+						"service": "payment",
+					},
+				},
+			},
+		},
+	}
+	dataplane2 := mesh_proto.Dataplane{
+		Networking: &mesh_proto.Dataplane_Networking{
+			Address: "1.1.1.2",
+			Inbound: []*mesh_proto.Dataplane_Networking_Inbound{
+				{
+					Port: 8080,
+					Tags: map[string]string{
+						"service": "payment",
+					},
+				},
+			},
+		},
+	}
+	dataplane3 := mesh_proto.Dataplane{
+		Networking: &mesh_proto.Dataplane_Networking{
+			Address: "1.1.1.4",
+			Inbound: []*mesh_proto.Dataplane_Networking_Inbound{
+				{
+					Port: 8080,
+					Tags: map[string]string{
+						"service": "payment",
+						"version": "0.1",
+					},
+				},
+			},
+		},
+	}
+	dataplane4 := mesh_proto.Dataplane{
+		Networking: &mesh_proto.Dataplane_Networking{
+			Address: "1.1.1.1",
+			Inbound: []*mesh_proto.Dataplane_Networking_Inbound{
+				{
+					Port: 8080,
+					Tags: map[string]string{
+						"service": "web",
+						"region":  "eu",
+						"version": "0.1",
+					},
+				},
+				{
+					Port: 8081,
+					Tags: map[string]string{
+						"service": "web-api",
+						"region":  "eu",
+						"version": "0.8",
+					},
+				},
+			},
+		},
+	}
+	ingress := mesh_proto.Dataplane{
+		Networking: &mesh_proto.Dataplane_Networking{
+			Ingress: &mesh_proto.Dataplane_Networking_Ingress{},
+			Inbound: nil,
+		},
+	}
+
+	Context("initially", func() {
+
+		manager := core_manager.NewResourceManager(memory.NewStore())
+		reconciler := server.NewIngressReconciler(manager)
+
+		BeforeEach(func() {
+			err := manager.Create(context.Background(), &core_mesh.MeshResource{}, store.CreateByKey("demo", "demo"))
+			Expect(err).ToNot(HaveOccurred())
+
+			err = manager.Create(context.Background(), &core_mesh.DataplaneResource{Spec: ingress}, store.CreateByKey("dp-ingress", "demo"))
+			Expect(err).ToNot(HaveOccurred())
+		})
+
+		Context("when new dataplanes added", func() {
+
+			BeforeEach(func() {
+				err := manager.Create(context.Background(), &core_mesh.DataplaneResource{Spec: dataplane1}, store.CreateByKey("dp1", "demo"))
+				Expect(err).ToNot(HaveOccurred())
+
+				err = manager.Create(context.Background(), &core_mesh.DataplaneResource{Spec: dataplane2}, store.CreateByKey("dp2", "demo"))
+				Expect(err).ToNot(HaveOccurred())
+
+				err = manager.Create(context.Background(), &core_mesh.DataplaneResource{Spec: dataplane3}, store.CreateByKey("dp3", "demo"))
+				Expect(err).ToNot(HaveOccurred())
+			})
+
+			It("should create inbound in ingress for every unique tag set", func() {
+
+				err := reconciler.Reconcile(model.ResourceKey{Name: "dp-ingress", Mesh: "demo"})
+				Expect(err).ToNot(HaveOccurred())
+
+				expected := `
+                    networking:
+                      inbound:
+                        - port: 10001
+                          tags:
+                            service: payment
+                        - port: 10002
+                          tags:
+                            service: payment
+                            version: "0.1"
+                      ingress: {}
+`
+
+				var actual core_mesh.DataplaneResource
+				err = manager.Get(context.Background(), &actual, store.GetByKey("dp-ingress", "demo"))
+				Expect(err).ToNot(HaveOccurred())
+
+				actualYAML, err := util_proto.ToYAML(&actual.Spec)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(actualYAML).To(MatchYAML(expected))
+			})
+		})
+	})
+
+	Context("has existing dataplanes", func() {
+
+		manager := core_manager.NewResourceManager(memory.NewStore())
+		reconciler := server.NewIngressReconciler(manager)
+
+		BeforeEach(func() {
+			err := manager.Create(context.Background(), &core_mesh.MeshResource{}, store.CreateByKey("demo", "demo"))
+			Expect(err).ToNot(HaveOccurred())
+
+			err = manager.Create(context.Background(), &core_mesh.DataplaneResource{Spec: ingress}, store.CreateByKey("dp-ingress", "demo"))
+			Expect(err).ToNot(HaveOccurred())
+
+			err = manager.Create(context.Background(), &core_mesh.DataplaneResource{Spec: dataplane1}, store.CreateByKey("dp1", "demo"))
+			Expect(err).ToNot(HaveOccurred())
+
+			err = manager.Create(context.Background(), &core_mesh.DataplaneResource{Spec: dataplane2}, store.CreateByKey("dp2", "demo"))
+			Expect(err).ToNot(HaveOccurred())
+
+			err = manager.Create(context.Background(), &core_mesh.DataplaneResource{Spec: dataplane3}, store.CreateByKey("dp3", "demo"))
+			Expect(err).ToNot(HaveOccurred())
+
+			err = reconciler.Reconcile(model.ResourceKey{Name: "dp-ingress", Mesh: "demo"})
+			Expect(err).ToNot(HaveOccurred())
+		})
+
+		Context("when new dataplanes added", func() {
+
+			BeforeEach(func() {
+				err := manager.Create(context.Background(), &core_mesh.DataplaneResource{Spec: dataplane4}, store.CreateByKey("dp4", "demo"))
+				Expect(err).ToNot(HaveOccurred())
+			})
+
+			It("should leave the same ports for existing dataplanes", func() {
+
+				err := reconciler.Reconcile(model.ResourceKey{Name: "dp-ingress", Mesh: "demo"})
+				Expect(err).ToNot(HaveOccurred())
+
+				expected := `
+                    networking:
+                      inbound:
+                      - port: 10001
+                        tags:
+                          service: payment
+                      - port: 10002
+                        tags:
+                          service: payment
+                          version: "0.1"
+                      - port: 10003
+                        tags:
+                          region: eu
+                          service: web
+                          version: "0.1"
+                      - port: 10004
+                        tags:
+                          region: eu
+                          service: web-api
+                          version: "0.8"
+                      ingress: {}
+`
+				var actual core_mesh.DataplaneResource
+				err = manager.Get(context.Background(), &actual, store.GetByKey("dp-ingress", "demo"))
+				Expect(err).ToNot(HaveOccurred())
+
+				actualYAML, err := util_proto.ToYAML(&actual.Spec)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(actualYAML).To(MatchYAML(expected))
+			})
+		})
+	})
+})


### PR DESCRIPTION
### Summary

This PR adds a reconciliation loop for Ingress. It collects all Dataplanes from all meshes and generates inbound interfaces in Ingress. 

### Issues resolved

Fix https://github.com/Kong/kuma/issues/775
