### PR TITLE
(fix ca):Updated Ca Certificate Expiration and Rotation by adding a c…

### DIFF
--- a/pkg/core/resources/apis/mesh/mesh_helpers.go
+++ b/pkg/core/resources/apis/mesh/mesh_helpers.go
@@ -109,5 +109,5 @@ func ParseDuration(durationStr string) (time.Duration, error) {
 	default:
 		return 0, fmt.Errorf("invalid time unit in duration string: %q", unit)
 	}
-	return time.Duration(dur), nil
+	return dur, nil
 }

--- a/pkg/core/resources/apis/mesh/mesh_helpers.go
+++ b/pkg/core/resources/apis/mesh/mesh_helpers.go
@@ -1,7 +1,11 @@
 package mesh
 
 import (
+	"fmt"
+	"regexp"
+	"strconv"
 	"strings"
+	"time"
 
 	mesh_proto "github.com/Kong/kuma/api/mesh/v1alpha1"
 )
@@ -69,4 +73,41 @@ func (m *MeshResource) GetCertificateAuthorityBackend(name string) *mesh_proto.C
 		}
 	}
 	return nil
+}
+
+var durationRE = regexp.MustCompile("^([0-9]+)(y|w|d|h|m|s|ms)$")
+
+// ParseDuration parses a string into a time.Duration
+func ParseDuration(durationStr string) (time.Duration, error) {
+	// Allow 0 without a unit.
+	if durationStr == "0" {
+		return 0, nil
+	}
+	matches := durationRE.FindStringSubmatch(durationStr)
+	if len(matches) != 3 {
+		return 0, fmt.Errorf("not a valid duration string: %q", durationStr)
+	}
+	var (
+		n, _ = strconv.Atoi(matches[1])
+		dur  = time.Duration(n) * time.Millisecond
+	)
+	switch unit := matches[2]; unit {
+	case "y":
+		dur *= 1000 * 60 * 60 * 24 * 365
+	case "w":
+		dur *= 1000 * 60 * 60 * 24 * 7
+	case "d":
+		dur *= 1000 * 60 * 60 * 24
+	case "h":
+		dur *= 1000 * 60 * 60
+	case "m":
+		dur *= 1000 * 60
+	case "s":
+		dur *= 1000
+	case "ms":
+		// Value already correct
+	default:
+		return 0, fmt.Errorf("invalid time unit in duration string: %q", unit)
+	}
+	return time.Duration(dur), nil
 }

--- a/pkg/core/resources/apis/mesh/mesh_helpers_test.go
+++ b/pkg/core/resources/apis/mesh/mesh_helpers_test.go
@@ -1,6 +1,8 @@
 package mesh_test
 
 import (
+	"time"
+
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/ginkgo/extensions/table"
 	. "github.com/onsi/gomega"
@@ -249,5 +251,35 @@ var _ = Describe("MeshResource", func() {
 			backends := mesh.GetTracingBackends()
 			Expect(backends).To(Equal(""))
 		})
+	})
+	Describe("ParseDuration", func() {
+
+		type testCase struct {
+			input  string
+			output time.Duration
+		}
+
+		DescribeTable("should return the correct duration",
+			func(given testCase) {
+				duration, _ := ParseDuration(given.input)
+				Expect(given.output).To(Equal(duration))
+			},
+			Entry("should return 0 if seconds is 0", testCase{
+				input:  "0s",
+				output: 0,
+			}),
+			Entry("should return minute", testCase{
+				input:  "5m",
+				output: 5 * time.Minute,
+			}),
+			Entry("should return day", testCase{
+				input:  "4d",
+				output: 4 * 24 * time.Hour,
+			}),
+			Entry("should return year", testCase{
+				input:  "5y",
+				output: 5 * 365 * 24 * time.Hour,
+			}),
+		)
 	})
 })

--- a/pkg/core/resources/apis/mesh/mesh_validator.go
+++ b/pkg/core/resources/apis/mesh/mesh_validator.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"net"
 	"net/url"
-	"time"
 
 	structpb "github.com/golang/protobuf/ptypes/struct"
 
@@ -40,7 +39,7 @@ func validateMtls(mtls *mesh_proto.Mesh_Mtls) validators.ValidationError {
 	}
 	for _, backend := range mtls.Backends {
 		if backend.GetDpCert() != nil {
-			_, err := time.ParseDuration(backend.GetDpCert().GetRotation().GetExpiration())
+			_, err := ParseDuration(backend.GetDpCert().GetRotation().GetExpiration())
 			if err != nil {
 				verr.AddViolation("dpcert.rotation.expiration", "has to be a valid format")
 			}

--- a/pkg/core/resources/apis/mesh/mesh_validator_test.go
+++ b/pkg/core/resources/apis/mesh/mesh_validator_test.go
@@ -23,6 +23,9 @@ var _ = Describe("Mesh", func() {
               backends:
               - name: builtin-1
                 type: builtin
+                dpCert:
+                  rotation:
+                    expiration: 2y
             logging:
               backends:
               - name: file-1

--- a/pkg/plugins/ca/builtin/manager.go
+++ b/pkg/plugins/ca/builtin/manager.go
@@ -3,7 +3,6 @@ package builtin
 import (
 	"context"
 	"fmt"
-	"time"
 
 	"github.com/golang/protobuf/ptypes/wrappers"
 	"github.com/pkg/errors"
@@ -12,6 +11,7 @@ import (
 	system_proto "github.com/Kong/kuma/api/system/v1alpha1"
 	core_ca "github.com/Kong/kuma/pkg/core/ca"
 	ca_issuer "github.com/Kong/kuma/pkg/core/ca/issuer"
+	mesh_helper "github.com/Kong/kuma/pkg/core/resources/apis/mesh"
 	core_system "github.com/Kong/kuma/pkg/core/resources/apis/system"
 	core_model "github.com/Kong/kuma/pkg/core/resources/model"
 	core_store "github.com/Kong/kuma/pkg/core/resources/store"
@@ -70,7 +70,7 @@ func (b *builtinCaManager) create(ctx context.Context, mesh string, backend mesh
 
 	var opts []certOptsFn
 	if cfg.GetCaCert().GetExpiration() != "" {
-		duration, err := time.ParseDuration(cfg.GetCaCert().GetExpiration())
+		duration, err := mesh_helper.ParseDuration(cfg.GetCaCert().GetExpiration())
 		if err != nil {
 			return err
 		}
@@ -135,7 +135,7 @@ func (b *builtinCaManager) GenerateDataplaneCert(ctx context.Context, mesh strin
 
 	var opts []ca_issuer.CertOptsFn
 	if backend.GetDpCert().GetRotation().GetExpiration() != "" {
-		duration, err := time.ParseDuration(backend.GetDpCert().GetRotation().Expiration)
+		duration, err := mesh_helper.ParseDuration(backend.GetDpCert().GetRotation().Expiration)
 		if err != nil {
 			return core_ca.KeyPair{}, err
 		}

--- a/pkg/plugins/ca/provided/manager.go
+++ b/pkg/plugins/ca/provided/manager.go
@@ -2,7 +2,6 @@ package provided
 
 import (
 	"context"
-	"time"
 
 	"github.com/pkg/errors"
 
@@ -10,6 +9,7 @@ import (
 	"github.com/Kong/kuma/pkg/core/ca"
 	ca_issuer "github.com/Kong/kuma/pkg/core/ca/issuer"
 	"github.com/Kong/kuma/pkg/core/datasource"
+	mesh_helper "github.com/Kong/kuma/pkg/core/resources/apis/mesh"
 	"github.com/Kong/kuma/pkg/core/validators"
 	"github.com/Kong/kuma/pkg/plugins/ca/provided/config"
 	util_proto "github.com/Kong/kuma/pkg/util/proto"
@@ -114,7 +114,7 @@ func (p *providedCaManager) GenerateDataplaneCert(ctx context.Context, mesh stri
 
 	var opts []ca_issuer.CertOptsFn
 	if backend.GetDpCert().GetRotation().GetExpiration() != "" {
-		duration, err := time.ParseDuration(backend.GetDpCert().GetRotation().Expiration)
+		duration, err := mesh_helper.ParseDuration(backend.GetDpCert().GetRotation().Expiration)
 		if err != nil {
 			return ca.KeyPair{}, err
 		}

--- a/pkg/sds/server/reconciler.go
+++ b/pkg/sds/server/reconciler.go
@@ -20,6 +20,7 @@ import (
 	"github.com/Kong/kuma/pkg/core"
 	"github.com/Kong/kuma/pkg/core/ca/issuer"
 	mesh_core "github.com/Kong/kuma/pkg/core/resources/apis/mesh"
+	mesh_helper "github.com/Kong/kuma/pkg/core/resources/apis/mesh"
 	core_manager "github.com/Kong/kuma/pkg/core/resources/manager"
 	core_model "github.com/Kong/kuma/pkg/core/resources/model"
 	core_store "github.com/Kong/kuma/pkg/core/resources/store"
@@ -110,7 +111,7 @@ func (d *DataplaneReconciler) shouldGenerateSnapshot(proxyID string, mesh *mesh_
 	}
 	expiration := issuer.DefaultWorkloadCertValidityPeriod
 	if mesh.GetEnabledCertificateAuthorityBackend().GetDpCert().GetRotation().GetExpiration() != "" {
-		expiration, err = time.ParseDuration(mesh.GetEnabledCertificateAuthorityBackend().GetDpCert().GetRotation().GetExpiration())
+		expiration, err = mesh_helper.ParseDuration(mesh.GetEnabledCertificateAuthorityBackend().GetDpCert().GetRotation().GetExpiration())
 		if err != nil {
 			return false, "", nil
 		}


### PR DESCRIPTION
### Summary

SUMMARY_GOES_HERE
Initially, #750 fixes this issue by using go's inbuilt `ParseDuration` fn. But missed that It won't support for `y`, `m` format. So, this PR contains the fix for that by adding a custom `ParseDuration` function.
### Full changelog

* Added a custom ParseDuration in mesh helper
* Updated tests

### Issues resolved

Fix #743 

Docs in https://github.com/Kong/kuma-website/pull/209
