### PR TITLE
chore(kuma-cp) prometheus overrides on Kubernetes

### DIFF
--- a/pkg/plugins/discovery/k8s/controllers/pod_converter_test.go
+++ b/pkg/plugins/discovery/k8s/controllers/pod_converter_test.go
@@ -196,6 +196,11 @@ var _ = Describe("PodToDataplane(..)", func() {
 			otherServices:   "06.other-services.yaml",
 			dataplane:       "06.dataplane.yaml",
 		}),
+		Entry("07.Pod with metrics override", testCase{
+			pod:            "07.pod.yaml",
+			servicesForPod: "07.services-for-pod.yaml",
+			dataplane:      "07.dataplane.yaml",
+		}),
 	)
 
 	Context("when Dataplane cannot be generated", func() {

--- a/pkg/plugins/discovery/k8s/controllers/testdata/07.dataplane.yaml
+++ b/pkg/plugins/discovery/k8s/controllers/testdata/07.dataplane.yaml
@@ -1,0 +1,18 @@
+mesh: default
+metadata:
+  creationTimestamp: null
+spec:
+  metrics:
+    conf:
+      path: /non-standard-path
+      port: 1234
+    type: prometheus
+  networking:
+    address: 192.168.0.1
+    inbound:
+      - port: 7070
+        tags:
+          app: example
+          protocol: tcp
+          service: sample.playground.svc:7071
+          version: "0.1"

--- a/pkg/plugins/discovery/k8s/controllers/testdata/07.pod.yaml
+++ b/pkg/plugins/discovery/k8s/controllers/testdata/07.pod.yaml
@@ -1,0 +1,15 @@
+metadata:
+  namespace: demo
+  name: example
+  labels:
+    app: example
+    version: "0.1"
+  annotations:
+    prometheus.metrics.kuma.io/port: "1234"
+    prometheus.metrics.kuma.io/path: "/non-standard-path"
+spec:
+  containers:
+    - ports:
+        - containerPort: 7070
+status:
+  podIP: 192.168.0.1

--- a/pkg/plugins/discovery/k8s/controllers/testdata/07.services-for-pod.yaml
+++ b/pkg/plugins/discovery/k8s/controllers/testdata/07.services-for-pod.yaml
@@ -1,0 +1,10 @@
+---
+metadata:
+  namespace: playground
+  name: sample
+spec:
+  clusterIP: 192.168.0.1
+  ports:
+    - protocol: TCP
+      port: 7071
+      targetPort: 7070


### PR DESCRIPTION
### Summary

Some time ago overrides for port and path was done using `prometheus.io` annotations (Kuma prometheus annotations were converted to prometheus) because Kuma DP discovery was based on `prometheus.io` annotations. Later we changed this so discovery of Kuma DP is based on `kuma-prometheus-sd` and we leave `prometheus.io` annotations for apps.

In the process of this change, we lost the ability to override port and path of Kuma DP metrics on Pod. This PR restores this functionality, so we convert Kuma Metrics annotations to DP config.

### Documentation

Already there
