### PR TITLE
feat(kuma-cp) Support many tags in Ingress

### DIFF
--- a/pkg/util/proto/marshal_any_test.go
+++ b/pkg/util/proto/marshal_any_test.go
@@ -17,7 +17,7 @@ var _ = Describe("MarshalAnyDeterministic", func() {
 			"version": "v1",
 			"cloud":   "aws",
 		}
-		metadata := envoy.Metadata(tags)
+		metadata := envoy.EndpointMetadata(tags)
 		for i := 0; i < 100; i++ {
 			any1, _ := util_proto.MarshalAnyDeterministic(metadata)
 			any2, _ := util_proto.MarshalAnyDeterministic(metadata)

--- a/pkg/xds/envoy/clusters/client_side_mtls_configurer.go
+++ b/pkg/xds/envoy/clusters/client_side_mtls_configurer.go
@@ -4,30 +4,34 @@ import (
 	envoy_api "github.com/envoyproxy/go-control-plane/envoy/api/v2"
 	envoy_core "github.com/envoyproxy/go-control-plane/envoy/api/v2/core"
 	envoy_wellknown "github.com/envoyproxy/go-control-plane/pkg/wellknown"
+	pstruct "github.com/golang/protobuf/ptypes/struct"
 
 	core_xds "github.com/Kong/kuma/pkg/core/xds"
 	"github.com/Kong/kuma/pkg/util/proto"
 	xds_context "github.com/Kong/kuma/pkg/xds/context"
 	"github.com/Kong/kuma/pkg/xds/envoy"
+	"github.com/Kong/kuma/pkg/xds/envoy/tls"
 )
 
-func ClientSideMTLS(ctx xds_context.Context, metadata *core_xds.DataplaneMetadata, clientService string) ClusterBuilderOpt {
+func ClientSideMTLS(ctx xds_context.Context, metadata *core_xds.DataplaneMetadata, clientService string, tags []envoy.Tags) ClusterBuilderOpt {
 	return ClusterBuilderOptFunc(func(config *ClusterBuilderConfig) {
 		config.Add(&clientSideMTLSConfigurer{
 			ctx:           ctx,
 			metadata:      metadata,
 			clientService: clientService,
+			tags:          tags,
 		})
 	})
 }
 
-func ClientSideMTLSWithSNI(ctx xds_context.Context, metadata *core_xds.DataplaneMetadata, clientService string, sni string) ClusterBuilderOpt {
+// UnknownDestinationClientSideMTLS configures cluster with mTLS for a mesh but without extensive destination verification (only Mesh is verified)
+func UnknownDestinationClientSideMTLS(ctx xds_context.Context, metadata *core_xds.DataplaneMetadata) ClusterBuilderOpt {
 	return ClusterBuilderOptFunc(func(config *ClusterBuilderConfig) {
 		config.Add(&clientSideMTLSConfigurer{
 			ctx:           ctx,
 			metadata:      metadata,
-			clientService: clientService,
-			sni:           sni,
+			clientService: "*",
+			tags:          nil,
 		})
 	})
 }
@@ -36,25 +40,64 @@ type clientSideMTLSConfigurer struct {
 	ctx           xds_context.Context
 	metadata      *core_xds.DataplaneMetadata
 	clientService string
-	sni           string
+	tags          []envoy.Tags
 }
 
 func (c *clientSideMTLSConfigurer) Configure(cluster *envoy_api.Cluster) error {
-	tlsContext, err := envoy.CreateUpstreamTlsContext(c.ctx, c.metadata, c.clientService, c.sni)
-	if err != nil {
-		return err
+	if !c.ctx.Mesh.Resource.MTLSEnabled() {
+		return nil
 	}
-	if tlsContext != nil {
-		pbst, err := proto.MarshalAnyDeterministic(tlsContext)
+	// there might be a situation when there are multiple sam tags passed here for example two outbound listeners with the same tags, therefore we need to distinct them.
+	distinctTags := envoy.DistinctTags(c.tags)
+	switch {
+	case len(distinctTags) == 0:
+		transportSocket, err := c.createTransportSocket("")
 		if err != nil {
 			return err
 		}
-		cluster.TransportSocket = &envoy_core.TransportSocket{
-			Name: envoy_wellknown.TransportSocketTls,
-			ConfigType: &envoy_core.TransportSocket_TypedConfig{
-				TypedConfig: pbst,
-			},
+		cluster.TransportSocket = transportSocket
+	case len(distinctTags) == 1:
+		transportSocket, err := c.createTransportSocket(tls.SNIFromTags(c.tags[0]))
+		if err != nil {
+			return err
+		}
+		cluster.TransportSocket = transportSocket
+	default:
+		for _, tags := range distinctTags {
+			sni := tls.SNIFromTags(tags)
+			transportSocket, err := c.createTransportSocket(sni)
+			if err != nil {
+				return err
+			}
+			cluster.TransportSocketMatches = append(cluster.TransportSocketMatches, &envoy_api.Cluster_TransportSocketMatch{
+				Name: sni,
+				Match: &pstruct.Struct{
+					Fields: envoy.MetadataFields(tags),
+				},
+				TransportSocket: transportSocket,
+			})
 		}
 	}
 	return nil
+}
+
+func (c *clientSideMTLSConfigurer) createTransportSocket(sni string) (*envoy_core.TransportSocket, error) {
+	tlsContext, err := envoy.CreateUpstreamTlsContext(c.ctx, c.metadata, c.clientService, sni)
+	if err != nil {
+		return nil, err
+	}
+	if tlsContext == nil {
+		return nil, nil
+	}
+	pbst, err := proto.MarshalAnyDeterministic(tlsContext)
+	if err != nil {
+		return nil, err
+	}
+	transportSocket := &envoy_core.TransportSocket{
+		Name: envoy_wellknown.TransportSocketTls,
+		ConfigType: &envoy_core.TransportSocket_TypedConfig{
+			TypedConfig: pbst,
+		},
+	}
+	return transportSocket, nil
 }

--- a/pkg/xds/envoy/clusters/client_side_mtls_configurer.go
+++ b/pkg/xds/envoy/clusters/client_side_mtls_configurer.go
@@ -47,7 +47,7 @@ func (c *clientSideMTLSConfigurer) Configure(cluster *envoy_api.Cluster) error {
 	if !c.ctx.Mesh.Resource.MTLSEnabled() {
 		return nil
 	}
-	// there might be a situation when there are multiple sam tags passed here for example two outbound listeners with the same tags, therefore we need to distinct them.
+	// there might be a situation when there are multiple sam tags passed here for example two outbound listeners with the same tags, therefore we need to distinguish between them.
 	distinctTags := envoy.DistinctTags(c.tags)
 	switch {
 	case len(distinctTags) == 0:

--- a/pkg/xds/envoy/clusters/lb_subset_configurer_test.go
+++ b/pkg/xds/envoy/clusters/lb_subset_configurer_test.go
@@ -2,7 +2,6 @@ package clusters_test
 
 import (
 	util_proto "github.com/Kong/kuma/pkg/util/proto"
-	"github.com/Kong/kuma/pkg/xds/envoy"
 	"github.com/Kong/kuma/pkg/xds/envoy/clusters"
 
 	. "github.com/onsi/ginkgo"
@@ -14,7 +13,7 @@ var _ = Describe("LbSubset", func() {
 
 	type testCase struct {
 		clusterName string
-		tags        []envoy.Tags
+		tags        [][]string
 		expected    string
 	}
 
@@ -33,13 +32,9 @@ var _ = Describe("LbSubset", func() {
 			Expect(err).ToNot(HaveOccurred())
 			Expect(actual).To(MatchYAML(given.expected))
 		},
-		Entry("LbSubset is empty if there is only a service tag", testCase{
+		Entry("LbSubset is empty if there are no tags", testCase{
 			clusterName: "backend",
-			tags: []envoy.Tags{
-				{
-					"service": "backend",
-				},
-			},
+			tags:        [][]string{},
 			expected: `
             connectTimeout: 5s
             edsClusterConfig:
@@ -50,20 +45,9 @@ var _ = Describe("LbSubset", func() {
 		}),
 		Entry("LbSubset is set when more than service tag is set", testCase{
 			clusterName: "backend",
-			tags: []envoy.Tags{
-				{
-					"service": "backend",
-					"version": "v1",
-				},
-				{
-					"service": "backend",
-					"version": "v2",
-				},
-				{
-					"service": "backend",
-					"version": "v3",
-					"cluster": "k8s-1",
-				},
+			tags: [][]string{
+				{"version"},
+				{"cluster", "version"},
 			},
 			expected: `
             connectTimeout: 5s

--- a/pkg/xds/envoy/endpoints/endpoints.go
+++ b/pkg/xds/envoy/endpoints/endpoints.go
@@ -38,7 +38,7 @@ func CreateClusterLoadAssignment(clusterName string, endpoints []core_xds.Endpoi
 	lbEndpoints := make([]*envoy_endpoint.LbEndpoint, 0, len(endpoints))
 	for _, ep := range endpoints {
 		lbEndpoints = append(lbEndpoints, &envoy_endpoint.LbEndpoint{
-			Metadata: envoy_common.Metadata(ep.Tags),
+			Metadata: envoy_common.EndpointMetadata(ep.Tags),
 			HostIdentifier: &envoy_endpoint.LbEndpoint_Endpoint{
 				Endpoint: &envoy_endpoint.Endpoint{
 					Address: &envoy_core.Address{

--- a/pkg/xds/envoy/endpoints/endpoints_test.go
+++ b/pkg/xds/envoy/endpoints/endpoints_test.go
@@ -96,6 +96,8 @@ var _ = Describe("Endpoints", func() {
                       filterMetadata:
                         envoy.lb:
                           region: us
+                        envoy.transport_socket_match:
+                          region: us
                   - endpoint:
                       address:
                         socketAddress:
@@ -105,7 +107,8 @@ var _ = Describe("Endpoints", func() {
                       filterMetadata:
                         envoy.lb:
                           region: eu
-`,
+                        envoy.transport_socket_match:
+                          region: eu`,
 			}),
 		)
 	})

--- a/pkg/xds/envoy/listeners/tcp_proxy_configurer.go
+++ b/pkg/xds/envoy/listeners/tcp_proxy_configurer.go
@@ -50,16 +50,14 @@ func (c *TcpProxyConfigurer) tcpProxy() *envoy_tcp.TcpProxy {
 		proxy.ClusterSpecifier = &envoy_tcp.TcpProxy_Cluster{
 			Cluster: c.clusters[0].ClusterName,
 		}
-		if envoy_common.Metadata(c.clusters[0].Tags) != nil {
-			proxy.MetadataMatch = envoy_common.Metadata(c.clusters[0].Tags)
-		}
+		proxy.MetadataMatch = envoy_common.LbMetadata(c.clusters[0].Tags)
 	} else {
 		var weightedClusters []*envoy_tcp.TcpProxy_WeightedCluster_ClusterWeight
 		for _, cluster := range c.clusters {
 			weightedClusters = append(weightedClusters, &envoy_tcp.TcpProxy_WeightedCluster_ClusterWeight{
 				Name:          cluster.ClusterName,
 				Weight:        cluster.Weight,
-				MetadataMatch: envoy_common.Metadata(cluster.Tags),
+				MetadataMatch: envoy_common.LbMetadata(cluster.Tags),
 			})
 		}
 		proxy.ClusterSpecifier = &envoy_tcp.TcpProxy_WeightedClusters{

--- a/pkg/xds/envoy/metadata_test.go
+++ b/pkg/xds/envoy/metadata_test.go
@@ -12,21 +12,21 @@ var _ = Describe("Metadata()", func() {
 
 	It("should handle `nil` map of tags", func() {
 		// when
-		metadata := Metadata(nil)
+		metadata := EndpointMetadata(nil)
 		// then
 		Expect(metadata).To(BeNil())
 	})
 
 	It("should handle empty map of tags", func() {
 		// when
-		metadata := Metadata(map[string]string{})
+		metadata := EndpointMetadata(map[string]string{})
 		// then
 		Expect(metadata).To(BeNil())
 	})
 
 	It("should skip service tag", func() {
 		// when
-		metadata := Metadata(map[string]string{
+		metadata := EndpointMetadata(map[string]string{
 			"service": "backend",
 		})
 		// then
@@ -40,7 +40,7 @@ var _ = Describe("Metadata()", func() {
 	DescribeTable("should generate Envoy metadata",
 		func(given testCase) {
 			// when
-			metadata := Metadata(given.tags)
+			metadata := EndpointMetadata(given.tags)
 			// and
 			actual, err := util_proto.ToYAML(metadata)
 			// then
@@ -54,11 +54,13 @@ var _ = Describe("Metadata()", func() {
 				"region":  "eu",
 			},
 			expected: `
-                filterMetadata:
-                  envoy.lb:
-                    version: v1
-                    region: eu
-`,
+            filterMetadata:
+              envoy.lb:
+                region: eu
+                version: v1
+              envoy.transport_socket_match:
+                region: eu
+                version: v1`,
 		}),
 	)
 })

--- a/pkg/xds/envoy/routes/default_route_configurer.go
+++ b/pkg/xds/envoy/routes/default_route_configurer.go
@@ -44,17 +44,18 @@ type RouteConfigurer struct {
 
 func (c RouteConfigurer) routeAction() *envoy_route.RouteAction {
 	routeAction := envoy_route.RouteAction{}
-	if len(c.subsets) == 1 && envoy_common.Metadata(c.subsets[0].Tags) == nil {
+	if len(c.subsets) == 1 {
 		routeAction.ClusterSpecifier = &envoy_route.RouteAction_Cluster{
 			Cluster: c.subsets[0].ClusterName,
 		}
+		routeAction.MetadataMatch = envoy_common.LbMetadata(c.subsets[0].Tags)
 	} else {
 		var weightedClusters []*envoy_route.WeightedCluster_ClusterWeight
 		for _, subset := range c.subsets {
 			weightedClusters = append(weightedClusters, &envoy_route.WeightedCluster_ClusterWeight{
 				Name:          subset.ClusterName,
 				Weight:        &wrappers.UInt32Value{Value: subset.Weight},
-				MetadataMatch: envoy_common.Metadata(subset.Tags),
+				MetadataMatch: envoy_common.LbMetadata(subset.Tags),
 			})
 		}
 		routeAction.ClusterSpecifier = &envoy_route.RouteAction_WeightedClusters{

--- a/pkg/xds/envoy/tls.go
+++ b/pkg/xds/envoy/tls.go
@@ -56,11 +56,6 @@ func CreateUpstreamTlsContext(ctx xds_context.Context, metadata *core_xds.Datapl
 	if err != nil {
 		return nil, err
 	}
-	if sni == "" {
-		return &envoy_auth.UpstreamTlsContext{
-			CommonTlsContext: commonTlsContext,
-		}, nil
-	}
 	return &envoy_auth.UpstreamTlsContext{
 		CommonTlsContext: commonTlsContext,
 		Sni:              sni,

--- a/pkg/xds/envoy/tls/sni.go
+++ b/pkg/xds/envoy/tls/sni.go
@@ -9,22 +9,19 @@ import (
 	"github.com/Kong/kuma/pkg/xds/envoy"
 )
 
+const sniRegexp = `(.*)\{(.*)\}`
+
 func SNIFromTags(tags envoy.Tags) string {
-	nonServiceTags := tags.WithoutTag(mesh_proto.ServiceTag)
-	var pairs []string
-	for _, key := range nonServiceTags.Keys() {
-		value := nonServiceTags[key]
-		pairs = append(pairs, fmt.Sprintf("%s=%s", key, value))
-	}
+	extraTags := tags.WithoutTag(mesh_proto.ServiceTag).String()
 	service := tags[mesh_proto.ServiceTag]
-	if len(pairs) == 0 {
+	if extraTags == "" {
 		return service
 	}
-	return fmt.Sprintf("%s{%s}", service, strings.Join(pairs, ","))
+	return fmt.Sprintf("%s{%s}", service, extraTags)
 }
 
 func TagsFromSNI(sni string) map[string]string {
-	r := regexp.MustCompile(`(.*)\{(.*)\}`)
+	r := regexp.MustCompile(sniRegexp)
 	matches := r.FindStringSubmatch(sni)
 	if len(matches) == 0 {
 		return map[string]string{

--- a/pkg/xds/envoy/tls/sni.go
+++ b/pkg/xds/envoy/tls/sni.go
@@ -1,0 +1,44 @@
+package tls
+
+import (
+	"fmt"
+	"regexp"
+	"strings"
+
+	mesh_proto "github.com/Kong/kuma/api/mesh/v1alpha1"
+	"github.com/Kong/kuma/pkg/xds/envoy"
+)
+
+func SNIFromTags(tags envoy.Tags) string {
+	nonServiceTags := tags.WithoutTag(mesh_proto.ServiceTag)
+	var pairs []string
+	for _, key := range nonServiceTags.Keys() {
+		value := nonServiceTags[key]
+		pairs = append(pairs, fmt.Sprintf("%s=%s", key, value))
+	}
+	service := tags[mesh_proto.ServiceTag]
+	if len(pairs) == 0 {
+		return service
+	}
+	return fmt.Sprintf("%s{%s}", service, strings.Join(pairs, ","))
+}
+
+func TagsFromSNI(sni string) map[string]string {
+	r := regexp.MustCompile(`(.*)\{(.*)\}`)
+	matches := r.FindStringSubmatch(sni)
+	if len(matches) == 0 {
+		return map[string]string{
+			mesh_proto.ServiceTag: sni,
+		}
+	}
+	service, tags := matches[1], matches[2]
+	pairs := strings.Split(tags, ",")
+	rv := map[string]string{
+		mesh_proto.ServiceTag: service,
+	}
+	for _, pair := range pairs {
+		kv := strings.Split(pair, "=")
+		rv[kv[0]] = kv[1]
+	}
+	return rv
+}

--- a/pkg/xds/envoy/tls/sni_test.go
+++ b/pkg/xds/envoy/tls/sni_test.go
@@ -1,0 +1,35 @@
+package tls_test
+
+import (
+	"github.com/Kong/kuma/pkg/xds/envoy/tls"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("SNI", func() {
+	It("should parse tags from SNI", func() {
+		actual := tls.TagsFromSNI("backend{app=backend-app,env=prod,region=eu,version=v1}")
+		expected := map[string]string{
+			"service": "backend",
+			"version": "v1",
+			"env":     "prod",
+			"region":  "eu",
+			"app":     "backend-app",
+		}
+		Expect(actual).To(Equal(expected))
+	})
+
+	It("should convert SNI to tags", func() {
+		tags := map[string]string{
+			"service": "backend",
+			"version": "v1",
+			"env":     "prod",
+			"region":  "eu",
+			"app":     "backend-app",
+		}
+		expected := "backend{app=backend-app,env=prod,region=eu,version=v1}"
+		actual := tls.SNIFromTags(tags)
+		Expect(actual).To(Equal(expected))
+	})
+})

--- a/pkg/xds/envoy/tls/sni_test.go
+++ b/pkg/xds/envoy/tls/sni_test.go
@@ -32,4 +32,13 @@ var _ = Describe("SNI", func() {
 		actual := tls.SNIFromTags(tags)
 		Expect(actual).To(Equal(expected))
 	})
+
+	It("should convert SNI to tags with only service name", func() {
+		tags := map[string]string{
+			"service": "backend",
+		}
+		expected := "backend"
+		actual := tls.SNIFromTags(tags)
+		Expect(actual).To(Equal(expected))
+	})
 })

--- a/pkg/xds/envoy/tls/tls_suite_test.go
+++ b/pkg/xds/envoy/tls/tls_suite_test.go
@@ -1,0 +1,18 @@
+package tls_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	util_test "github.com/Kong/kuma/pkg/util/test"
+)
+
+func TestTLS(t *testing.T) {
+	RegisterFailHandler(Fail)
+
+	RunSpecsWithDefaultAndCustomReporters(t,
+		"Envoy TLS Suite",
+		[]Reporter{util_test.NewlineReporter{}})
+}

--- a/pkg/xds/envoy/types.go
+++ b/pkg/xds/envoy/types.go
@@ -42,9 +42,6 @@ func (t Tags) String() string {
 }
 
 func DistinctTags(tags []Tags) []Tags {
-	if len(tags) == 0 {
-		return tags
-	}
 	used := map[string]bool{}
 	var result []Tags
 	for _, tag := range tags {

--- a/pkg/xds/envoy/types.go
+++ b/pkg/xds/envoy/types.go
@@ -1,6 +1,10 @@
 package envoy
 
-import "sort"
+import (
+	"fmt"
+	"sort"
+	"strings"
+)
 
 type ClusterSubset struct {
 	ClusterName string
@@ -27,6 +31,30 @@ func (t Tags) Keys() []string {
 	}
 	sort.Strings(keys)
 	return keys
+}
+
+func (t Tags) String() string {
+	var pairs []string
+	for _, key := range t.Keys() {
+		pairs = append(pairs, fmt.Sprintf("%s=%s", key, t[key]))
+	}
+	return strings.Join(pairs, ",")
+}
+
+func DistinctTags(tags []Tags) []Tags {
+	if len(tags) == 0 {
+		return tags
+	}
+	used := map[string]bool{}
+	var result []Tags
+	for _, tag := range tags {
+		str := tag.String()
+		if !used[str] {
+			result = append(result, tag)
+			used[str] = true
+		}
+	}
+	return result
 }
 
 type Clusters map[string][]ClusterSubset

--- a/pkg/xds/generator/direct_access_proxy_generator.go
+++ b/pkg/xds/generator/direct_access_proxy_generator.go
@@ -58,7 +58,7 @@ func (_ DirectAccessProxyGenerator) Generate(ctx xds_context.Context, proxy *cor
 
 	directAccessCluster, err := envoy_clusters.NewClusterBuilder().
 		Configure(envoy_clusters.PassThroughCluster("direct_access")).
-		Configure(envoy_clusters.ClientSideMTLS(ctx, proxy.Metadata, "*")).
+		Configure(envoy_clusters.UnknownDestinationClientSideMTLS(ctx, proxy.Metadata)).
 		Build()
 	if err != nil {
 		return nil, errors.Wrapf(err, "could not generate cluster: direct_access")

--- a/pkg/xds/generator/ingress_generator_test.go
+++ b/pkg/xds/generator/ingress_generator_test.go
@@ -113,16 +113,4 @@ var _ = Describe("IngressGenerator", func() {
 			outboundTargets: map[core_xds.ServiceName][]core_xds.Endpoint{},
 		}),
 	)
-
-	It("should parse tags from SNI", func() {
-		actual := generator.TagsBySNI("backend{version=v1,env=prod,region=eu,app=backend-app}")
-		expected := map[string]string{
-			"service": "backend",
-			"version": "v1",
-			"env":     "prod",
-			"region":  "eu",
-			"app":     "backend-app",
-		}
-		Expect(actual).To(Equal(expected))
-	})
 })

--- a/pkg/xds/generator/testdata/ingress/01.envoy.golden.yaml
+++ b/pkg/xds/generator/testdata/ingress/01.envoy.golden.yaml
@@ -110,6 +110,19 @@ resources:
       edsClusterConfig:
         edsConfig:
           ads: {}
+      lbSubsetConfig:
+        fallbackPolicy: ANY_ENDPOINT
+        subsetSelectors:
+          - fallbackPolicy: NO_FALLBACK
+            keys:
+              - region
+          - fallbackPolicy: NO_FALLBACK
+            keys:
+              - version
+          - fallbackPolicy: NO_FALLBACK
+            keys:
+              - region
+              - version
       name: backend
       type: EDS
   - name: backend
@@ -128,6 +141,9 @@ resources:
                   envoy.lb:
                     region: eu
                     version: v1
+                  envoy.transport_socket_match:
+                    region: eu
+                    version: v1
             - endpoint:
                 address:
                   socketAddress:
@@ -136,5 +152,8 @@ resources:
               metadata:
                 filterMetadata:
                   envoy.lb:
+                    region: us
+                    version: v2
+                  envoy.transport_socket_match:
                     region: us
                     version: v2

--- a/pkg/xds/generator/testdata/outbound-proxy/03.envoy.golden.yaml
+++ b/pkg/xds/generator/testdata/outbound-proxy/03.envoy.golden.yaml
@@ -180,6 +180,9 @@ resources:
                   envoy.lb:
                     protocol: http
                     region: us
+                  envoy.transport_socket_match:
+                    protocol: http
+                    region: us
             - endpoint:
                 address:
                   socketAddress:
@@ -188,6 +191,9 @@ resources:
               metadata:
                 filterMetadata:
                   envoy.lb:
+                    protocol: http
+                    region: eu
+                  envoy.transport_socket_match:
                     protocol: http
                     region: eu
   - name: api-tcp
@@ -206,6 +212,9 @@ resources:
                   envoy.lb:
                     protocol: http
                     region: us
+                  envoy.transport_socket_match:
+                    protocol: http
+                    region: us
             - endpoint:
                 address:
                   socketAddress:
@@ -214,6 +223,8 @@ resources:
               metadata:
                 filterMetadata:
                   envoy.lb:
+                    region: eu
+                  envoy.transport_socket_match:
                     region: eu
   - name: backend
     resource:
@@ -229,6 +240,8 @@ resources:
               metadata:
                 filterMetadata:
                   envoy.lb:
+                    region: us
+                  envoy.transport_socket_match:
                     region: us
             - endpoint:
                 address:
@@ -249,4 +262,6 @@ resources:
               metadata:
                 filterMetadata:
                   envoy.lb:
+                    role: master
+                  envoy.transport_socket_match:
                     role: master

--- a/pkg/xds/generator/testdata/outbound-proxy/04.envoy.golden.yaml
+++ b/pkg/xds/generator/testdata/outbound-proxy/04.envoy.golden.yaml
@@ -279,42 +279,85 @@ resources:
             keys:
               - role
       name: db
-      transportSocket:
-        name: envoy.transport_sockets.tls
-        typedConfig:
-          '@type': type.googleapis.com/envoy.api.v2.auth.UpstreamTlsContext
-          commonTlsContext:
-            combinedValidationContext:
-              defaultValidationContext:
-                matchSubjectAltNames:
-                  - exact: spiffe://mesh1/db
-              validationContextSdsSecretConfig:
-                name: mesh_ca
-                sdsConfig:
-                  apiConfigSource:
-                    apiType: GRPC
-                    grpcServices:
-                      - googleGrpc:
-                          channelCredentials:
-                            sslCredentials:
-                              rootCerts:
-                                inlineBytes: MTIzNDU=
-                          statPrefix: sds_mesh_ca
-                          targetUri: kuma-system:5677
-            tlsCertificateSdsSecretConfigs:
-              - name: identity_cert
-                sdsConfig:
-                  apiConfigSource:
-                    apiType: GRPC
-                    grpcServices:
-                      - googleGrpc:
-                          channelCredentials:
-                            sslCredentials:
-                              rootCerts:
-                                inlineBytes: MTIzNDU=
-                          statPrefix: sds_identity_cert
-                          targetUri: kuma-system:5677
-          sni: db
+      transportSocketMatches:
+        - match:
+            role: master
+          name: db{role=master}
+          transportSocket:
+            name: envoy.transport_sockets.tls
+            typedConfig:
+              '@type': type.googleapis.com/envoy.api.v2.auth.UpstreamTlsContext
+              commonTlsContext:
+                combinedValidationContext:
+                  defaultValidationContext:
+                    matchSubjectAltNames:
+                      - exact: spiffe://mesh1/db
+                  validationContextSdsSecretConfig:
+                    name: mesh_ca
+                    sdsConfig:
+                      apiConfigSource:
+                        apiType: GRPC
+                        grpcServices:
+                          - googleGrpc:
+                              channelCredentials:
+                                sslCredentials:
+                                  rootCerts:
+                                    inlineBytes: MTIzNDU=
+                              statPrefix: sds_mesh_ca
+                              targetUri: kuma-system:5677
+                tlsCertificateSdsSecretConfigs:
+                  - name: identity_cert
+                    sdsConfig:
+                      apiConfigSource:
+                        apiType: GRPC
+                        grpcServices:
+                          - googleGrpc:
+                              channelCredentials:
+                                sslCredentials:
+                                  rootCerts:
+                                    inlineBytes: MTIzNDU=
+                              statPrefix: sds_identity_cert
+                              targetUri: kuma-system:5677
+              sni: db{role=master}
+        - match:
+            role: replica
+          name: db{role=replica}
+          transportSocket:
+            name: envoy.transport_sockets.tls
+            typedConfig:
+              '@type': type.googleapis.com/envoy.api.v2.auth.UpstreamTlsContext
+              commonTlsContext:
+                combinedValidationContext:
+                  defaultValidationContext:
+                    matchSubjectAltNames:
+                      - exact: spiffe://mesh1/db
+                  validationContextSdsSecretConfig:
+                    name: mesh_ca
+                    sdsConfig:
+                      apiConfigSource:
+                        apiType: GRPC
+                        grpcServices:
+                          - googleGrpc:
+                              channelCredentials:
+                                sslCredentials:
+                                  rootCerts:
+                                    inlineBytes: MTIzNDU=
+                              statPrefix: sds_mesh_ca
+                              targetUri: kuma-system:5677
+                tlsCertificateSdsSecretConfigs:
+                  - name: identity_cert
+                    sdsConfig:
+                      apiConfigSource:
+                        apiType: GRPC
+                        grpcServices:
+                          - googleGrpc:
+                              channelCredentials:
+                                sslCredentials:
+                                  rootCerts:
+                                    inlineBytes: MTIzNDU=
+                              statPrefix: sds_identity_cert
+                              targetUri: kuma-system:5677
+              sni: db{role=replica}
       type: EDS
   - name: api-http
     resource:
@@ -332,6 +375,9 @@ resources:
                   envoy.lb:
                     protocol: http
                     region: us
+                  envoy.transport_socket_match:
+                    protocol: http
+                    region: us
             - endpoint:
                 address:
                   socketAddress:
@@ -340,6 +386,9 @@ resources:
               metadata:
                 filterMetadata:
                   envoy.lb:
+                    protocol: http
+                    region: eu
+                  envoy.transport_socket_match:
                     protocol: http
                     region: eu
   - name: api-tcp
@@ -358,6 +407,9 @@ resources:
                   envoy.lb:
                     protocol: http
                     region: us
+                  envoy.transport_socket_match:
+                    protocol: http
+                    region: us
             - endpoint:
                 address:
                   socketAddress:
@@ -366,6 +418,8 @@ resources:
               metadata:
                 filterMetadata:
                   envoy.lb:
+                    region: eu
+                  envoy.transport_socket_match:
                     region: eu
   - name: backend
     resource:
@@ -381,6 +435,8 @@ resources:
               metadata:
                 filterMetadata:
                   envoy.lb:
+                    region: us
+                  envoy.transport_socket_match:
                     region: us
             - endpoint:
                 address:
@@ -401,4 +457,6 @@ resources:
               metadata:
                 filterMetadata:
                   envoy.lb:
+                    role: master
+                  envoy.transport_socket_match:
                     role: master

--- a/pkg/xds/generator/testdata/profile-source/1-envoy-config.golden.yaml
+++ b/pkg/xds/generator/testdata/profile-source/1-envoy-config.golden.yaml
@@ -215,6 +215,8 @@ resources:
                 filterMetadata:
                   envoy.lb:
                     role: master
+                  envoy.transport_socket_match:
+                    role: master
   - name: elastic
     resource:
       '@type': type.googleapis.com/envoy.api.v2.ClusterLoadAssignment

--- a/pkg/xds/generator/testdata/profile-source/2-envoy-config.golden.yaml
+++ b/pkg/xds/generator/testdata/profile-source/2-envoy-config.golden.yaml
@@ -247,6 +247,8 @@ resources:
                 filterMetadata:
                   envoy.lb:
                     role: master
+                  envoy.transport_socket_match:
+                    role: master
   - name: elastic
     resource:
       '@type': type.googleapis.com/envoy.api.v2.ClusterLoadAssignment

--- a/pkg/xds/generator/testdata/profile-source/3-envoy-config.golden.yaml
+++ b/pkg/xds/generator/testdata/profile-source/3-envoy-config.golden.yaml
@@ -337,6 +337,8 @@ resources:
                 filterMetadata:
                   envoy.lb:
                     role: master
+                  envoy.transport_socket_match:
+                    role: master
   - name: elastic
     resource:
       '@type': type.googleapis.com/envoy.api.v2.ClusterLoadAssignment

--- a/pkg/xds/generator/testdata/profile-source/4-envoy-config.golden.yaml
+++ b/pkg/xds/generator/testdata/profile-source/4-envoy-config.golden.yaml
@@ -369,6 +369,8 @@ resources:
                 filterMetadata:
                   envoy.lb:
                     role: master
+                  envoy.transport_socket_match:
+                    role: master
   - name: elastic
     resource:
       '@type': type.googleapis.com/envoy.api.v2.ClusterLoadAssignment


### PR DESCRIPTION
### Summary

This PR introduces support for many tag in Ingress - meaning you can apply TrafficRoute like this
```
type: TrafficRoute
mesh: default
name: tr-1
sources:
  - match:
      service: gateway
destinations:
  - match:
      service: backend
conf:
  - weight: 80
    destination:
      service: backend
      cluster: "1"
  - weight: 20
    destination:
      service: backend
      cluster: "2"
```
or this (when version: 2 is in different cluster)
```
type: TrafficRoute
mesh: default
name: tr-1
sources:
  - match:
      service: gateway
destinations:
  - match:
      service: backend
conf:
  - weight: 100
    destination:
      service: backend
      version: "2"
```
### Documentation

Will be a part of Multi Cluster docs/demo. From user perspective is just a regular TrafficRoute
