### PR TITLE
chore(kuma-cp) Change default skipMTLS flag

### DIFF
--- a/api/mesh/v1alpha1/metrics.pb.go
+++ b/api/mesh/v1alpha1/metrics.pb.go
@@ -145,10 +145,7 @@ type PrometheusMetricsBackendConfig struct {
 	// `service` tag is mandatory.
 	Tags map[string]string `protobuf:"bytes,3,rep,name=tags,proto3" json:"tags,omitempty" protobuf_key:"bytes,1,opt,name=key,proto3" protobuf_val:"bytes,2,opt,name=value,proto3"`
 	// If true then endpoints for scraping metrics won't require mTLS even if mTLS
-	// is enabled in Mesh. If nil, then it is treated as set to true.
-	//
-	// todo(jakubdyszkiewicz) In next major version of Kuma, change BoolValue to
-	// bool, so the default is false
+	// is enabled in Mesh. If nil, then it is treated as false.
 	SkipMTLS             *wrappers.BoolValue `protobuf:"bytes,4,opt,name=skipMTLS,proto3" json:"skipMTLS,omitempty"`
 	XXX_NoUnkeyedLiteral struct{}            `json:"-"`
 	XXX_unrecognized     []byte              `json:"-"`

--- a/api/mesh/v1alpha1/metrics.proto
+++ b/api/mesh/v1alpha1/metrics.proto
@@ -46,9 +46,6 @@ message PrometheusMetricsBackendConfig {
   map<string, string> tags = 3;
 
   // If true then endpoints for scraping metrics won't require mTLS even if mTLS
-  // is enabled in Mesh. If nil, then it is treated as set to true.
-  //
-  // todo(jakubdyszkiewicz) In next major version of Kuma, change BoolValue to
-  // bool, so the default is false
+  // is enabled in Mesh. If nil, then it is treated as false.
   google.protobuf.BoolValue skipMTLS = 4;
 }

--- a/pkg/xds/generator/prometheus_endpoint_generator.go
+++ b/pkg/xds/generator/prometheus_endpoint_generator.go
@@ -108,6 +108,5 @@ func (g PrometheusEndpointGenerator) Generate(ctx xds_context.Context, proxy *co
 }
 
 func secureMetrics(cfg *mesh_proto.PrometheusMetricsBackendConfig, mesh *mesh_core.MeshResource) bool {
-	// We assume that skipMTLS = nil is the same as skipMTLS = false, so we don't break deployments between 0.5 and 0.5.1
-	return cfg.SkipMTLS != nil && !cfg.SkipMTLS.Value && mesh.MTLSEnabled()
+	return !cfg.SkipMTLS.GetValue() && mesh.MTLSEnabled()
 }


### PR DESCRIPTION
### Summary

We introduced mTLS Metrics in Kuma 0.5.1, but we wanted to skipMTLS by default to not break upgrades from 0.5.0 to 0.5.1.
With the upcoming 0.6.0 we are ready to make this change.

### Documentation

- [ ] https://github.com/Kong/kuma-website/pull/224
