### PR TITLE
feat(kuma-cp) sync dataplane insights

### DIFF
--- a/pkg/kds/client/stream.go
+++ b/pkg/kds/client/stream.go
@@ -15,7 +15,7 @@ import (
 
 type KDSStream interface {
 	DiscoveryRequest(resourceType model.ResourceType) error
-	Receive() (model.ResourceList, error)
+	Receive() (string, model.ResourceList, error)
 	ACK(typ string) error
 	NACK(typ string, err error) error
 	Close() error
@@ -51,17 +51,17 @@ func (s *stream) DiscoveryRequest(resourceType model.ResourceType) error {
 	})
 }
 
-func (s *stream) Receive() (model.ResourceList, error) {
+func (s *stream) Receive() (string, model.ResourceList, error) {
 	resp, err := s.streamClient.Recv()
 	if err != nil {
-		return nil, err
+		return "", nil, err
 	}
 	rs, err := util.ToCoreResourceList(resp)
 	if err != nil {
-		return nil, err
+		return "", nil, err
 	}
 	s.latestReceived[string(rs.GetItemType())] = resp
-	return rs, nil
+	return resp.GetControlPlane().GetIdentifier(), rs, nil
 }
 
 func (s *stream) ACK(typ string) error {

--- a/pkg/kds/global/components_test.go
+++ b/pkg/kds/global/components_test.go
@@ -23,7 +23,7 @@ import (
 	kds_setup "github.com/Kong/kuma/pkg/test/kds/setup"
 )
 
-var _ = Describe("Global Sync", func() {
+var _ = XDescribe("Global Sync", func() { // todo fix the test
 
 	var localStores []store.ResourceStore
 	var globalStore store.ResourceStore

--- a/pkg/kds/global/components_test.go
+++ b/pkg/kds/global/components_test.go
@@ -23,7 +23,7 @@ import (
 	kds_setup "github.com/Kong/kuma/pkg/test/kds/setup"
 )
 
-var _ = XDescribe("Global Sync", func() { // todo fix the test
+var _ = Describe("Global Sync", func() { // todo fix the test
 
 	var localStores []store.ResourceStore
 	var globalStore store.ResourceStore
@@ -37,7 +37,7 @@ var _ = XDescribe("Global Sync", func() { // todo fix the test
 		for i := 0; i < 2; i++ {
 			wg.Add(1)
 			localStore := memory.NewStore()
-			serverStream := kds_setup.StartServer(localStore, wg)
+			serverStream := kds_setup.StartServer(localStore, wg, fmt.Sprintf("cluster-%d", i))
 			serverStreams = append(serverStreams, serverStream)
 			localStores = append(localStores, localStore)
 		}

--- a/pkg/kds/server/server_test.go
+++ b/pkg/kds/server/server_test.go
@@ -44,7 +44,7 @@ var _ = Describe("KDS Server", func() {
 
 		wg := &sync.WaitGroup{}
 		wg.Add(1)
-		stream := kds_setup.StartServer(s, wg)
+		stream := kds_setup.StartServer(s, wg, "test-cluster")
 
 		tc = &kds_verifier.TestContextImpl{
 			ResourceStore:      s,

--- a/pkg/kds/server/server_test.go
+++ b/pkg/kds/server/server_test.go
@@ -59,11 +59,12 @@ var _ = Describe("KDS Server", func() {
 		ctx := context.Background()
 
 		// Just to don't forget to update this test after updating 'kds.SupportedTypes
-		Expect([]proto.Message{&kds_samples.Mesh1, &kds_samples.Ingress, &kds_samples.CircuitBreaker, &kds_samples.FaultInjection, &kds_samples.HealthCheck, &kds_samples.TrafficLog, &kds_samples.TrafficPermission, &kds_samples.TrafficRoute, &kds_samples.TrafficTrace, &kds_samples.ProxyTemplate, &kds_samples.Secret}).To(HaveLen(len(kds.SupportedTypes)))
+		Expect([]proto.Message{&kds_samples.Mesh1, &kds_samples.Ingress, &kds_samples.DataplaneInsight, &kds_samples.CircuitBreaker, &kds_samples.FaultInjection, &kds_samples.HealthCheck, &kds_samples.TrafficLog, &kds_samples.TrafficPermission, &kds_samples.TrafficRoute, &kds_samples.TrafficTrace, &kds_samples.ProxyTemplate, &kds_samples.Secret}).To(HaveLen(len(kds.SupportedTypes)))
 
 		vrf := kds_verifier.New().
 			Exec(kds_verifier.Create(ctx, &mesh.MeshResource{Spec: kds_samples.Mesh1}, store.CreateByKey("mesh-1", "mesh-1"))).
 			Exec(kds_verifier.Create(ctx, &mesh.DataplaneResource{Spec: kds_samples.Ingress}, store.CreateByKey("Ingress-1", "mesh-1"))).
+			Exec(kds_verifier.Create(ctx, &mesh.DataplaneInsightResource{Spec: kds_samples.DataplaneInsight}, store.CreateByKey("insight-1", "mesh-1"))).
 			Exec(kds_verifier.Create(ctx, &mesh.CircuitBreakerResource{Spec: kds_samples.CircuitBreaker}, store.CreateByKey("cb-1", "mesh-1"))).
 			Exec(kds_verifier.Create(ctx, &mesh.FaultInjectionResource{Spec: kds_samples.FaultInjection}, store.CreateByKey("fi-1", "mesh-1"))).
 			Exec(kds_verifier.Create(ctx, &mesh.HealthCheckResource{Spec: kds_samples.HealthCheck}, store.CreateByKey("hc-1", "mesh-1"))).
@@ -82,6 +83,11 @@ var _ = Describe("KDS Server", func() {
 			Exec(kds_verifier.WaitResponse(defaultTimeout, func(rs []model.Resource) {
 				Expect(rs).To(HaveLen(1))
 				Expect(rs[0].GetSpec()).To(Equal(&kds_samples.Ingress))
+			})).
+			Exec(kds_verifier.DiscoveryRequest(node, mesh.DataplaneInsightType)).
+			Exec(kds_verifier.WaitResponse(defaultTimeout, func(rs []model.Resource) {
+				Expect(rs).To(HaveLen(1))
+				Expect(rs[0].GetSpec()).To(Equal(&kds_samples.DataplaneInsight))
 			})).
 			Exec(kds_verifier.DiscoveryRequest(node, mesh.CircuitBreakerType)).
 			Exec(kds_verifier.WaitResponse(defaultTimeout, func(rs []model.Resource) {

--- a/pkg/kds/types.go
+++ b/pkg/kds/types.go
@@ -16,6 +16,7 @@ var (
 	SupportedTypes = []model.ResourceType{
 		mesh.MeshType,
 		mesh.DataplaneType,
+		mesh.DataplaneInsightType,
 		mesh.CircuitBreakerType,
 		mesh.FaultInjectionType,
 		mesh.HealthCheckType,

--- a/pkg/kds/util/resource.go
+++ b/pkg/kds/util/resource.go
@@ -69,7 +69,11 @@ func AddSuffixToNames(rs []model.Resource, suffix string) {
 }
 
 func ClusterTag(r model.Resource) string {
-	return r.GetSpec().(*mesh_proto.Dataplane).GetNetworking().GetInbound()[0].GetTags()[mesh_proto.ClusterTag]
+	dp := r.GetSpec().(*mesh_proto.Dataplane)
+	if dp.Networking.GetGateway() != nil {
+		return dp.Networking.GetGateway().GetTags()[mesh_proto.ClusterTag]
+	}
+	return dp.GetNetworking().GetInbound()[0].GetTags()[mesh_proto.ClusterTag]
 }
 
 func toResources(resourceType model.ResourceType, krs []*mesh_proto.KumaResource) (model.ResourceList, error) {

--- a/pkg/test/kds/samples/resources.go
+++ b/pkg/test/kds/samples/resources.go
@@ -79,6 +79,11 @@ var (
 			},
 		},
 	}
+	DataplaneInsight = mesh_proto.DataplaneInsight{
+		MTLS: &mesh_proto.DataplaneInsight_MTLS{
+			CertificateRegenerations: 3,
+		},
+	}
 	Ingress = mesh_proto.Dataplane{
 		Networking: &mesh_proto.Dataplane_Networking{
 			Ingress: &mesh_proto.Dataplane_Networking_Ingress{

--- a/pkg/test/kds/setup/server.go
+++ b/pkg/test/kds/setup/server.go
@@ -53,7 +53,7 @@ func StartServer(store store.ResourceStore, wg *sync.WaitGroup) *test_grpc.MockS
 			util_xds.LoggingCallbacks{Log: log},
 			syncTracker,
 		}
-		return kds_server.NewServer(cache, callbacks, log)
+		return kds_server.NewServer(cache, callbacks, log, "test-client")
 	}
 
 	srv := createServer(&testRuntimeContext{

--- a/pkg/test/kds/setup/server.go
+++ b/pkg/test/kds/setup/server.go
@@ -41,7 +41,7 @@ func (t *testRuntimeContext) Add(c ...component.Component) error {
 	return nil
 }
 
-func StartServer(store store.ResourceStore, wg *sync.WaitGroup) *test_grpc.MockServerStream {
+func StartServer(store store.ResourceStore, wg *sync.WaitGroup, clusterID string) *test_grpc.MockServerStream {
 	createServer := func(rt runtime.Runtime) kds_server.Server {
 		log := core.Log
 		hasher, cache := kds_server.NewXdsContext(log)
@@ -53,7 +53,7 @@ func StartServer(store store.ResourceStore, wg *sync.WaitGroup) *test_grpc.MockS
 			util_xds.LoggingCallbacks{Log: log},
 			syncTracker,
 		}
-		return kds_server.NewServer(cache, callbacks, log, "test-client")
+		return kds_server.NewServer(cache, callbacks, log, clusterID)
 	}
 
 	srv := createServer(&testRuntimeContext{


### PR DESCRIPTION
### Summary

Sync DP insights.
DP insights does not have tags so I needed to add cluster ID into ControlPlane#identifier in `DiscoveryResponse`

### Documentation

Internal
