### PR TITLE
fix(kuma-cp) dedup Ingresses, small fixes

### DIFF
--- a/pkg/config/clusters/clusters.go
+++ b/pkg/config/clusters/clusters.go
@@ -1,7 +1,9 @@
 package clusters
 
 import (
+	"net"
 	"net/url"
+	"strconv"
 
 	"github.com/pkg/errors"
 
@@ -39,8 +41,13 @@ func (g *ClustersConfig) Validate() error {
 			return errors.Wrapf(err, "Invalid remote url for cluster %s", cluster.Remote.Address)
 		}
 		_, err = url.ParseRequestURI(cluster.Ingress.Address)
+		_, port, err := net.SplitHostPort(cluster.Ingress.Address)
 		if err != nil {
-			return errors.Wrapf(err, "Invalid ingress url for cluster %s", cluster.Ingress.Address)
+			return errors.Wrapf(err, "Invalid ingress address for cluster %s", cluster.Ingress.Address)
+		}
+		_, err = strconv.ParseUint(port, 10, 32)
+		if err != nil {
+			return errors.Wrapf(err, "Invalid ingress's port %s", port)
 		}
 	}
 	return nil

--- a/pkg/config/clusters/clusters.go
+++ b/pkg/config/clusters/clusters.go
@@ -40,7 +40,6 @@ func (g *ClustersConfig) Validate() error {
 		if err != nil {
 			return errors.Wrapf(err, "Invalid remote url for cluster %s", cluster.Remote.Address)
 		}
-		_, err = url.ParseRequestURI(cluster.Ingress.Address)
 		_, port, err := net.SplitHostPort(cluster.Ingress.Address)
 		if err != nil {
 			return errors.Wrapf(err, "Invalid ingress address for cluster %s", cluster.Ingress.Address)

--- a/pkg/core/runtime/component/resilient.go
+++ b/pkg/core/runtime/component/resilient.go
@@ -45,7 +45,7 @@ func (r *resilientComponent) Start(stop <-chan struct{}) error {
 		select {
 		case <-stop:
 			r.log.Info("done")
-			break
+			return nil
 		case err := <-errCh:
 			if err != nil {
 				r.log.WithValues("generationID", generationID).Error(err, "component terminated with an error")

--- a/pkg/kds/client/client.go
+++ b/pkg/kds/client/client.go
@@ -32,9 +32,9 @@ func New(serverURL string) (KDSClient, error) {
 	}
 	var dialOpts []grpc.DialOption
 	switch u.Scheme {
-	case "http":
+	case "grpc":
 		dialOpts = append(dialOpts, grpc.WithInsecure())
-	case "https":
+	case "grpcs":
 		dialOpts = append(dialOpts, grpc.WithTransportCredentials(credentials.NewTLS(&tls.Config{
 			InsecureSkipVerify: true, // it's acceptable since we don't pass any secrets to the server
 		})))

--- a/pkg/kds/global/components.go
+++ b/pkg/kds/global/components.go
@@ -2,12 +2,13 @@ package global
 
 import (
 	"fmt"
-	"github.com/Kong/kuma/pkg/core/resources/registry"
-	kds_server "github.com/Kong/kuma/pkg/kds/server"
-	util_xds "github.com/Kong/kuma/pkg/util/xds"
 	"net"
 	"strconv"
 	"strings"
+
+	"github.com/Kong/kuma/pkg/core/resources/registry"
+	kds_server "github.com/Kong/kuma/pkg/kds/server"
+	util_xds "github.com/Kong/kuma/pkg/util/xds"
 
 	"github.com/Kong/kuma/pkg/core/resources/apis/system"
 

--- a/pkg/kds/remote/components.go
+++ b/pkg/kds/remote/components.go
@@ -43,7 +43,7 @@ var (
 
 func SetupServer(rt core_runtime.Runtime) error {
 	hasher, cache := kds_server.NewXdsContext(kdsRemoteLog)
-	generator := kds_server.NewSnapshotGenerator(rt, providedTypes, makeFilter(rt.Config().General.ClusterName))
+	generator := kds_server.NewSnapshotGenerator(rt, providedTypes, providedFilter(rt.Config().General.ClusterName))
 	versioner := kds_server.NewVersioner()
 	reconciler := kds_server.NewReconciler(hasher, cache, generator, versioner)
 	syncTracker := kds_server.NewSyncTracker(kdsRemoteLog, reconciler, rt.Config().KDSServer.RefreshInterval)
@@ -71,8 +71,8 @@ func SetupServer(rt core_runtime.Runtime) error {
 	return rt.Add(kds_server.NewKDSServer(srv, *rt.Config().KDSServer))
 }
 
-// makeFilter creates filter that exclude Ingresses from another cluster
-func makeFilter(clusterName string) reconcile.ResourceFilter {
+// providedFilter filter Resources provided by Remote, specifically Ingresses that belongs to another zones
+func providedFilter(clusterName string) reconcile.ResourceFilter {
 	return func(_ string, r model.Resource) bool {
 		if r.GetType() == mesh.DataplaneType {
 			return clusterName == util.ClusterTag(r)


### PR DESCRIPTION
### Summary

Deduplicate Ingress resources on the Global and small fixes.

### Full changelog

* Fix bug in a resilient component 
* Set Port for Ingress on the Global (could cause a problem with a NodePort)
* Rename schema to `grpc/grpcs`, get rid of schema in Ingress' address

### Issues resolved

Fix #XXX

### Documentation

- [ ] Link to the website [documentation PR](https://github.com/Kong/kuma-website/pull/XXX)
